### PR TITLE
Add batch to entries storage

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -52153,8 +52153,36 @@ module.exports = Component.exports
 
 "use strict";
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_axios__ = __webpack_require__(136);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_axios___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_axios__);
 
-/* harmony default export */ __webpack_exports__["default"] = ({});
+
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+    data: function data() {
+        return {
+            batch: null,
+            batchEntries: []
+        };
+    },
+
+
+    watch: {
+        batch: function batch(val) {
+            var _this = this;
+
+            __WEBPACK_IMPORTED_MODULE_0_axios___default.a.get('/telescope/telescope-api/entries?take=1000&batch=' + val).then(function (response) {
+                _this.batchEntries = response.data.entries;
+            });
+        }
+    },
+
+    methods: {
+        batchEntriesOfType: function batchEntriesOfType(type) {
+            return _.filter(this.batchEntries, { type: type });
+        }
+    }
+});
 
 /***/ }),
 /* 209 */
@@ -52272,6 +52300,380 @@ var render = function() {
                   _c("pre", { staticClass: "bg-dark p-4 mb-0 text-white" }, [
                     _vm._v(_vm._s(slotProps.entry.content.response))
                   ])
+                ])
+              : _vm._e(),
+            _vm._v(" "),
+            _vm.batchEntriesOfType(7).length
+              ? _c("div", { staticClass: "card mt-5" }, [
+                  _c("div", { staticClass: "card-header" }, [
+                    _c("h5", [_vm._v("Queries")])
+                  ]),
+                  _vm._v(" "),
+                  _c(
+                    "table",
+                    {
+                      staticClass:
+                        "table table-hover table-sm mb-0 penultimate-column-right"
+                    },
+                    [
+                      _c("thead", [
+                        _c("tr", [
+                          _c("th", [_vm._v("Query")]),
+                          _vm._v(" "),
+                          _c("th", [_vm._v("Connection")]),
+                          _vm._v(" "),
+                          _c("th")
+                        ])
+                      ]),
+                      _vm._v(" "),
+                      _c(
+                        "tbody",
+                        _vm._l(_vm.batchEntriesOfType(7), function(entry) {
+                          return _c("tr", [
+                            _c("td", [
+                              _vm._v(
+                                _vm._s(_vm.truncate(entry.content.sql, 90))
+                              )
+                            ]),
+                            _vm._v(" "),
+                            _c("td", { staticClass: "table-fit" }, [
+                              _vm._v(
+                                _vm._s(
+                                  _vm.truncate(entry.content.connection, 20)
+                                )
+                              )
+                            ]),
+                            _vm._v(" "),
+                            _c(
+                              "td",
+                              { staticClass: "table-fit" },
+                              [
+                                _c(
+                                  "router-link",
+                                  {
+                                    staticClass: "control-action",
+                                    attrs: {
+                                      to: {
+                                        name: "query-preview",
+                                        params: { id: entry.id }
+                                      }
+                                    }
+                                  },
+                                  [
+                                    _c(
+                                      "svg",
+                                      {
+                                        attrs: {
+                                          xmlns: "http://www.w3.org/2000/svg",
+                                          viewBox: "0 0 22 16"
+                                        }
+                                      },
+                                      [
+                                        _c("path", {
+                                          attrs: {
+                                            d:
+                                              "M16.56 13.66a8 8 0 0 1-11.32 0L.3 8.7a1 1 0 0 1 0-1.42l4.95-4.95a8 8 0 0 1 11.32 0l4.95 4.95a1 1 0 0 1 0 1.42l-4.95 4.95-.01.01zm-9.9-1.42a6 6 0 0 0 8.48 0L19.38 8l-4.24-4.24a6 6 0 0 0-8.48 0L2.4 8l4.25 4.24h.01zM10.9 12a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"
+                                          }
+                                        })
+                                      ]
+                                    )
+                                  ]
+                                )
+                              ],
+                              1
+                            )
+                          ])
+                        })
+                      )
+                    ]
+                  )
+                ])
+              : _vm._e(),
+            _vm._v(" "),
+            _vm.batchEntriesOfType(2).length
+              ? _c("div", { staticClass: "card mt-5" }, [
+                  _c("div", { staticClass: "card-header" }, [
+                    _c("h5", [_vm._v("Log Entries")])
+                  ]),
+                  _vm._v(" "),
+                  _c(
+                    "table",
+                    {
+                      staticClass:
+                        "table table-hover table-sm mb-0 penultimate-column-right"
+                    },
+                    [
+                      _c("thead", [
+                        _c("tr", [
+                          _c("th", [_vm._v("Message")]),
+                          _vm._v(" "),
+                          _c("th", [_vm._v("Level")]),
+                          _vm._v(" "),
+                          _c("th")
+                        ])
+                      ]),
+                      _vm._v(" "),
+                      _c(
+                        "tbody",
+                        _vm._l(_vm.batchEntriesOfType(2), function(entry) {
+                          return _c("tr", [
+                            _c("td", [
+                              _vm._v(
+                                _vm._s(_vm.truncate(entry.content.message, 80))
+                              )
+                            ]),
+                            _vm._v(" "),
+                            _c("td", { staticClass: "table-fit" }, [
+                              entry.content.level == "error"
+                                ? _c(
+                                    "svg",
+                                    {
+                                      staticClass: "icon fill-danger",
+                                      attrs: {
+                                        xmlns: "http://www.w3.org/2000/svg",
+                                        viewBox: "0 0 20 20"
+                                      }
+                                    },
+                                    [
+                                      _c("path", {
+                                        attrs: {
+                                          d:
+                                            "M15.3 14.89l2.77 2.77a1 1 0 0 1 0 1.41 1 1 0 0 1-1.41 0l-2.59-2.58A5.99 5.99 0 0 1 11 18V9.04a1 1 0 0 0-2 0V18a5.98 5.98 0 0 1-3.07-1.51l-2.59 2.58a1 1 0 0 1-1.41 0 1 1 0 0 1 0-1.41l2.77-2.77A5.95 5.95 0 0 1 4.07 13H1a1 1 0 1 1 0-2h3V8.41L.93 5.34a1 1 0 0 1 0-1.41 1 1 0 0 1 1.41 0l2.1 2.1h11.12l2.1-2.1a1 1 0 0 1 1.41 0 1 1 0 0 1 0 1.41L16 8.41V11h3a1 1 0 1 1 0 2h-3.07c-.1.67-.32 1.31-.63 1.89zM15 5H5a5 5 0 1 1 10 0z"
+                                        }
+                                      })
+                                    ]
+                                  )
+                                : _c(
+                                    "svg",
+                                    {
+                                      staticClass: "icon fill-info",
+                                      attrs: {
+                                        xmlns: "http://www.w3.org/2000/svg",
+                                        viewBox: "0 0 20 20"
+                                      }
+                                    },
+                                    [
+                                      _c("path", {
+                                        attrs: {
+                                          d:
+                                            "M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zM9 11v4h2V9H9v2zm0-6v2h2V5H9z"
+                                        }
+                                      })
+                                    ]
+                                  )
+                            ]),
+                            _vm._v(" "),
+                            _c(
+                              "td",
+                              { staticClass: "table-fit" },
+                              [
+                                _c(
+                                  "router-link",
+                                  {
+                                    staticClass: "control-action",
+                                    attrs: {
+                                      to: {
+                                        name: "log-preview",
+                                        params: { id: entry.id }
+                                      }
+                                    }
+                                  },
+                                  [
+                                    _c(
+                                      "svg",
+                                      {
+                                        attrs: {
+                                          xmlns: "http://www.w3.org/2000/svg",
+                                          viewBox: "0 0 22 16"
+                                        }
+                                      },
+                                      [
+                                        _c("path", {
+                                          attrs: {
+                                            d:
+                                              "M16.56 13.66a8 8 0 0 1-11.32 0L.3 8.7a1 1 0 0 1 0-1.42l4.95-4.95a8 8 0 0 1 11.32 0l4.95 4.95a1 1 0 0 1 0 1.42l-4.95 4.95-.01.01zm-9.9-1.42a6 6 0 0 0 8.48 0L19.38 8l-4.24-4.24a6 6 0 0 0-8.48 0L2.4 8l4.25 4.24h.01zM10.9 12a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"
+                                          }
+                                        })
+                                      ]
+                                    )
+                                  ]
+                                )
+                              ],
+                              1
+                            )
+                          ])
+                        })
+                      )
+                    ]
+                  )
+                ])
+              : _vm._e(),
+            _vm._v(" "),
+            _vm.batchEntriesOfType(6).length
+              ? _c("div", { staticClass: "card mt-5" }, [
+                  _c("div", { staticClass: "card-header" }, [
+                    _c("h5", [_vm._v("Cache")])
+                  ]),
+                  _vm._v(" "),
+                  _c(
+                    "table",
+                    {
+                      staticClass:
+                        "table table-hover table-sm mb-0 penultimate-column-right"
+                    },
+                    [
+                      _c("thead", [
+                        _c("tr", [
+                          _c("th", [_vm._v("Key")]),
+                          _vm._v(" "),
+                          _c("th", [_vm._v("Action")]),
+                          _vm._v(" "),
+                          _c("th")
+                        ])
+                      ]),
+                      _vm._v(" "),
+                      _c(
+                        "tbody",
+                        _vm._l(_vm.batchEntriesOfType(6), function(entry) {
+                          return _c("tr", [
+                            _c("td", [
+                              _vm._v(
+                                _vm._s(_vm.truncate(entry.content.key, 80))
+                              )
+                            ]),
+                            _vm._v(" "),
+                            _c("td", { staticClass: "table-fit" }, [
+                              _vm._v(_vm._s(entry.content.type))
+                            ]),
+                            _vm._v(" "),
+                            _c(
+                              "td",
+                              { staticClass: "table-fit" },
+                              [
+                                _c(
+                                  "router-link",
+                                  {
+                                    staticClass: "control-action",
+                                    attrs: {
+                                      to: {
+                                        name: "cache-preview",
+                                        params: { id: entry.id }
+                                      }
+                                    }
+                                  },
+                                  [
+                                    _c(
+                                      "svg",
+                                      {
+                                        attrs: {
+                                          xmlns: "http://www.w3.org/2000/svg",
+                                          viewBox: "0 0 22 16"
+                                        }
+                                      },
+                                      [
+                                        _c("path", {
+                                          attrs: {
+                                            d:
+                                              "M16.56 13.66a8 8 0 0 1-11.32 0L.3 8.7a1 1 0 0 1 0-1.42l4.95-4.95a8 8 0 0 1 11.32 0l4.95 4.95a1 1 0 0 1 0 1.42l-4.95 4.95-.01.01zm-9.9-1.42a6 6 0 0 0 8.48 0L19.38 8l-4.24-4.24a6 6 0 0 0-8.48 0L2.4 8l4.25 4.24h.01zM10.9 12a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"
+                                          }
+                                        })
+                                      ]
+                                    )
+                                  ]
+                                )
+                              ],
+                              1
+                            )
+                          ])
+                        })
+                      )
+                    ]
+                  )
+                ])
+              : _vm._e(),
+            _vm._v(" "),
+            _vm.batchEntriesOfType(5).length
+              ? _c("div", { staticClass: "card mt-5" }, [
+                  _c("div", { staticClass: "card-header" }, [
+                    _c("h5", [_vm._v("Events")])
+                  ]),
+                  _vm._v(" "),
+                  _c(
+                    "table",
+                    {
+                      staticClass:
+                        "table table-hover table-sm mb-0 penultimate-column-right"
+                    },
+                    [
+                      _c("thead", [
+                        _c("tr", [
+                          _c("th", [_vm._v("Name")]),
+                          _vm._v(" "),
+                          _c("th", [_vm._v("Listeners")]),
+                          _vm._v(" "),
+                          _c("th")
+                        ])
+                      ]),
+                      _vm._v(" "),
+                      _c(
+                        "tbody",
+                        _vm._l(_vm.batchEntriesOfType(5), function(entry) {
+                          return _c("tr", [
+                            _c("td", [
+                              _vm._v(
+                                _vm._s(
+                                  _vm.truncate(entry.content.event_name, 80)
+                                )
+                              )
+                            ]),
+                            _vm._v(" "),
+                            _c("td", { staticClass: "table-fit" }, [
+                              _vm._v(_vm._s(entry.content.listeners.length))
+                            ]),
+                            _vm._v(" "),
+                            _c(
+                              "td",
+                              { staticClass: "table-fit" },
+                              [
+                                _c(
+                                  "router-link",
+                                  {
+                                    staticClass: "control-action",
+                                    attrs: {
+                                      to: {
+                                        name: "event-preview",
+                                        params: { id: entry.id }
+                                      }
+                                    }
+                                  },
+                                  [
+                                    _c(
+                                      "svg",
+                                      {
+                                        attrs: {
+                                          xmlns: "http://www.w3.org/2000/svg",
+                                          viewBox: "0 0 22 16"
+                                        }
+                                      },
+                                      [
+                                        _c("path", {
+                                          attrs: {
+                                            d:
+                                              "M16.56 13.66a8 8 0 0 1-11.32 0L.3 8.7a1 1 0 0 1 0-1.42l4.95-4.95a8 8 0 0 1 11.32 0l4.95 4.95a1 1 0 0 1 0 1.42l-4.95 4.95-.01.01zm-9.9-1.42a6 6 0 0 0 8.48 0L19.38 8l-4.24-4.24a6 6 0 0 0-8.48 0L2.4 8l4.25 4.24h.01zM10.9 12a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"
+                                          }
+                                        })
+                                      ]
+                                    )
+                                  ]
+                                )
+                              ],
+                              1
+                            )
+                          ])
+                        })
+                      )
+                    ]
+                  )
                 ])
               : _vm._e()
           ])
@@ -71022,6 +71424,8 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 
         this.loadEntry(function (response) {
             _this.entry = response.data.entry;
+
+            _this.$parent.batch = _this.entry.batch;
 
             _this.ready = true;
         });

--- a/resources/js/components/PreviewScreen.vue
+++ b/resources/js/components/PreviewScreen.vue
@@ -28,6 +28,8 @@
             this.loadEntry((response) => {
                 this.entry = response.data.entry;
 
+                this.$parent.batch = this.entry.batch;
+
                 this.ready = true;
             });
         },

--- a/resources/js/screens/requests/preview.vue
+++ b/resources/js/screens/requests/preview.vue
@@ -1,5 +1,28 @@
 <script type="text/ecmascript-6">
-    export default {}
+    import axios from 'axios';
+
+    export default {
+        data(){
+            return {
+                batch: null,
+                batchEntries: []
+            };
+        },
+
+        watch: {
+            batch(val){
+                axios.get('/telescope/telescope-api/entries?take=1000&batch=' + val).then(response => {
+                    this.batchEntries = response.data.entries;
+                });
+            }
+        },
+
+        methods: {
+            batchEntriesOfType(type){
+                return _.filter(this.batchEntries, {type: type})
+            }
+        }
+    }
 </script>
 
 <template>
@@ -52,6 +75,123 @@
 
                 <pre class="bg-dark p-4 mb-0 text-white">{{slotProps.entry.content.response}}</pre>
             </div>
+
+            <div class="card mt-5" v-if="batchEntriesOfType(7).length">
+                <div class="card-header"><h5>Queries</h5></div>
+
+                <table class="table table-hover table-sm mb-0 penultimate-column-right">
+                    <thead>
+                    <tr>
+                        <th>Query</th>
+                        <th>Connection</th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr v-for="entry in batchEntriesOfType(7)">
+                        <td>{{truncate(entry.content.sql, 90)}}</td>
+                        <td class="table-fit">{{truncate(entry.content.connection, 20)}}</td>
+                        <td class="table-fit">
+                            <router-link :to="{name:'query-preview', params:{id: entry.id}}" class="control-action">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 16">
+                                    <path d="M16.56 13.66a8 8 0 0 1-11.32 0L.3 8.7a1 1 0 0 1 0-1.42l4.95-4.95a8 8 0 0 1 11.32 0l4.95 4.95a1 1 0 0 1 0 1.42l-4.95 4.95-.01.01zm-9.9-1.42a6 6 0 0 0 8.48 0L19.38 8l-4.24-4.24a6 6 0 0 0-8.48 0L2.4 8l4.25 4.24h.01zM10.9 12a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"></path>
+                                </svg>
+                            </router-link>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="card mt-5" v-if="batchEntriesOfType(2).length">
+                <div class="card-header"><h5>Log Entries</h5></div>
+
+                <table class="table table-hover table-sm mb-0 penultimate-column-right">
+                    <thead>
+                    <tr>
+                        <th>Message</th>
+                        <th>Level</th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr v-for="entry in batchEntriesOfType(2)">
+                        <td>{{truncate(entry.content.message, 80)}}</td>
+                        <td class="table-fit">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="icon fill-danger" v-if="entry.content.level == 'error'">
+                                <path d="M15.3 14.89l2.77 2.77a1 1 0 0 1 0 1.41 1 1 0 0 1-1.41 0l-2.59-2.58A5.99 5.99 0 0 1 11 18V9.04a1 1 0 0 0-2 0V18a5.98 5.98 0 0 1-3.07-1.51l-2.59 2.58a1 1 0 0 1-1.41 0 1 1 0 0 1 0-1.41l2.77-2.77A5.95 5.95 0 0 1 4.07 13H1a1 1 0 1 1 0-2h3V8.41L.93 5.34a1 1 0 0 1 0-1.41 1 1 0 0 1 1.41 0l2.1 2.1h11.12l2.1-2.1a1 1 0 0 1 1.41 0 1 1 0 0 1 0 1.41L16 8.41V11h3a1 1 0 1 1 0 2h-3.07c-.1.67-.32 1.31-.63 1.89zM15 5H5a5 5 0 1 1 10 0z"/>
+                            </svg>
+
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="icon fill-info" v-else>
+                                <path d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zM9 11v4h2V9H9v2zm0-6v2h2V5H9z"/>
+                            </svg>
+                        </td>
+                        <td class="table-fit">
+                            <router-link :to="{name:'log-preview', params:{id: entry.id}}" class="control-action">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 16">
+                                    <path d="M16.56 13.66a8 8 0 0 1-11.32 0L.3 8.7a1 1 0 0 1 0-1.42l4.95-4.95a8 8 0 0 1 11.32 0l4.95 4.95a1 1 0 0 1 0 1.42l-4.95 4.95-.01.01zm-9.9-1.42a6 6 0 0 0 8.48 0L19.38 8l-4.24-4.24a6 6 0 0 0-8.48 0L2.4 8l4.25 4.24h.01zM10.9 12a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"></path>
+                                </svg>
+                            </router-link>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="card mt-5" v-if="batchEntriesOfType(6).length">
+                <div class="card-header"><h5>Cache</h5></div>
+
+                <table class="table table-hover table-sm mb-0 penultimate-column-right">
+                    <thead>
+                    <tr>
+                        <th>Key</th>
+                        <th>Action</th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr v-for="entry in batchEntriesOfType(6)">
+                        <td>{{truncate(entry.content.key, 80)}}</td>
+                        <td class="table-fit">{{entry.content.type}}</td>
+                        <td class="table-fit">
+                            <router-link :to="{name:'cache-preview', params:{id: entry.id}}" class="control-action">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 16">
+                                    <path d="M16.56 13.66a8 8 0 0 1-11.32 0L.3 8.7a1 1 0 0 1 0-1.42l4.95-4.95a8 8 0 0 1 11.32 0l4.95 4.95a1 1 0 0 1 0 1.42l-4.95 4.95-.01.01zm-9.9-1.42a6 6 0 0 0 8.48 0L19.38 8l-4.24-4.24a6 6 0 0 0-8.48 0L2.4 8l4.25 4.24h.01zM10.9 12a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"></path>
+                                </svg>
+                            </router-link>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="card mt-5" v-if="batchEntriesOfType(5).length">
+                <div class="card-header"><h5>Events</h5></div>
+
+                <table class="table table-hover table-sm mb-0 penultimate-column-right">
+                    <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Listeners</th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr v-for="entry in batchEntriesOfType(5)">
+                        <td>{{truncate(entry.content.event_name, 80)}}</td>
+                        <td class="table-fit">{{entry.content.listeners.length}}</td>
+                        <td class="table-fit">
+                            <router-link :to="{name:'event-preview', params:{id: entry.id}}" class="control-action">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 16">
+                                    <path d="M16.56 13.66a8 8 0 0 1-11.32 0L.3 8.7a1 1 0 0 1 0-1.42l4.95-4.95a8 8 0 0 1 11.32 0l4.95 4.95a1 1 0 0 1 0 1.42l-4.95 4.95-.01.01zm-9.9-1.42a6 6 0 0 0 8.48 0L19.38 8l-4.24-4.24a6 6 0 0 0-8.48 0L2.4 8l4.25 4.24h.01zM10.9 12a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"></path>
+                                </svg>
+                            </router-link>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+
         </div>
     </preview-screen>
 </template>

--- a/src/Contracts/EntriesRepository.php
+++ b/src/Contracts/EntriesRepository.php
@@ -7,7 +7,7 @@ interface EntriesRepository
     /**
      * Return an entry with the given ID.
      *
-     * @param  integer $id
+     * @param  integer  $id
      * @return mixed
      */
     public function find($id);
@@ -24,8 +24,9 @@ interface EntriesRepository
     /**
      * Store the given entries.
      *
-     * @param  array $data
+     * @param  array  $data
+     * @param  string  $batch
      * @return mixed
      */
-    public function store($data);
+    public function store($data, $batch);
 }

--- a/src/Http/Controllers/EntriesController.php
+++ b/src/Http/Controllers/EntriesController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Laravel\Telescope\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Laravel\Telescope\Contracts\EntriesRepository;
+
+class EntriesController extends Controller
+{
+    /**
+     * List the entries of the given type.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Laravel\Telescope\Contracts\EntriesRepository $storage
+     * @return \Illuminate\Http\Response
+     */
+    public function index(Request $request, EntriesRepository $storage)
+    {
+        return response()->json([
+            'entries' => $storage->get(null, $request->all())
+        ]);
+    }
+}

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -1,5 +1,8 @@
 <?php
 
+// All entries...
+Route::get('/telescope-api/entries', 'EntriesController@index');
+
 // Mail entries...
 Route::get('/telescope-api/mail', 'MailController@index');
 Route::get('/telescope-api/mail/{id}', 'MailController@show');

--- a/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -16,6 +16,7 @@ class CreateTelescopeEntriesTable extends Migration
         Schema::create('telescope_entries', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->tinyInteger('type');
+            $table->uuid('batch');
             $table->json('content');
             $table->timestamp('created_at');
 

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -3,6 +3,7 @@
 namespace Laravel\Telescope;
 
 use Closure;
+use Illuminate\Support\Str;
 use Laravel\Telescope\Contracts\EntriesRepository;
 
 class Telescope
@@ -193,7 +194,7 @@ class Telescope
      */
     public static function store(EntriesRepository $storage)
     {
-        $storage->store(static::$entriesQueue);
+        $storage->store(static::$entriesQueue, Str::uuid());
 
         static::$entriesQueue = [];
     }

--- a/src/Watchers/QueueWatcher.php
+++ b/src/Watchers/QueueWatcher.php
@@ -34,7 +34,7 @@ class QueueWatcher extends Watcher
     {
         list($payload, $tags) = $this->extractPayloadAndTags($event->job);
 
-        $tags[] = ['processed'];
+        $tags[] = 'processed';
 
         Telescope::recordJob([
             'id' => $event->job->getJobId(),
@@ -58,7 +58,7 @@ class QueueWatcher extends Watcher
     {
         list($payload, $tags) = $this->extractPayloadAndTags($event->job);
 
-        $tags[] = ['failed'];
+        $tags[] = 'failed';
 
         Telescope::recordJob([
             'id' => $event->job->getJobId(),


### PR DESCRIPTION
This allows us to show events that happened during a request like queries, events, cache keys called, and also any log entries. So if you see a 500 response for example you know what exception was thrown and you can go to the exception view and see full details.

<img width="530" alt="screen shot 2018-09-05 at 1 30 32 pm" src="https://user-images.githubusercontent.com/4332182/45090090-9e66dd00-b10e-11e8-9b93-d49a77b34d41.png">
