### PR TITLE
Return array only from Telescope::tag()

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -191,8 +191,10 @@ class Telescope
             $entries = $entries->filter(static::$filterUsing);
         }
 
-        if (static::$tagUsing) {
-            $entries = $entries->each(static::$tagUsing);
+        if ($tagger = static::$tagUsing) {
+            $entries = $entries->each(function ($entry) use ($tagger) {
+                return $entry->tags($tagger($entry));
+            });
         }
 
         $storage->store($entries->each(function ($entry) use ($batchId) {


### PR DESCRIPTION
This PR allows using the tag function like this:

```
Telescope::tag(function(IncomingEntry $entry){
    return ['userPlan:'.auth()->user()->plan];
});
```

Currently you have to do this

```
Telescope::tag(function(IncomingEntry $entry){
    $entry->tags(['userPlan:'.auth()->user()->plan]);
});
```