### PR TITLE
Record user while storing each entity

### DIFF
--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -67,9 +67,7 @@ class IncomingEntry
      */
     public static function make(array $content)
     {
-        $user = app()->runningInConsole() ? null : request()->user();
-
-        return (new static($content))->user($user);
+        return (new static($content));
     }
 
     /**
@@ -107,6 +105,10 @@ class IncomingEntry
     public function user($user)
     {
         $this->user = $user;
+
+        $this->content = array_merge($this->content, ['user' => $user]);
+
+        $this->tags(['user:'.$user]);
 
         return $this;
     }

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -196,6 +196,10 @@ class Telescope
         }
 
         $storage->store($entries->each(function ($entry) use ($batchId) {
+            if (auth()->user()) {
+                $entry->user(auth()->user()->id);
+            }
+
             $entry->batchId($batchId);
         }));
 

--- a/src/Watchers/CacheWatcher.php
+++ b/src/Watchers/CacheWatcher.php
@@ -59,7 +59,7 @@ class CacheWatcher extends Watcher
         Telescope::recordCacheEntry(IncomingEntry::make([
             'type' => 'missed',
             'key' => $event->key,
-        ])->tagss([$event->key]));
+        ])->tags([$event->key]));
     }
 
     /**


### PR DESCRIPTION
Instead of adding the user object to the entry while recording it, we add the user id while storing to prevent the query watcher from watching the query run by `request()->user()` to retrieve the user and try adding a new record recursively.

Now on each record a `user:ID` tag is added to it and also a `user` attribute added to the entry content that we can use to show in the UI.