### PR TITLE
Clean up migrations

### DIFF
--- a/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -15,25 +15,18 @@ class CreateTelescopeEntriesTable extends Migration
     {
         Schema::create('telescope_entries', function (Blueprint $table) {
             $table->bigIncrements('sequence');
-            $table->uuid('uuid');
-            $table->uuid('batch_id');
+            $table->uuid('uuid')->unique();
+            $table->uuid('batch_id')->index();
             $table->string('family_hash')->nullable()->index();
-            $table->boolean('should_display_on_index')->default(true);
-            $table->string('type', 20);
+            $table->boolean('should_display_on_index')->index()->default(true);
+            $table->string('type', 20)->unique()->index();
             $table->json('content');
             $table->dateTime('created_at')->nullable();
-
-            $table->unique(['uuid', 'type']);
-            $table->index('batch_id');
-            $table->index(['type', 'should_display_on_index']);
         });
 
         Schema::create('telescope_entries_tags', function (Blueprint $table) {
-            $table->uuid('entry_uuid');
-            $table->string('tag');
-
-            $table->index(['entry_uuid', 'tag']);
-            $table->index('tag');
+            $table->uuid('entry_uuid')->index();
+            $table->string('tag')->index();
 
             $table->foreign('entry_uuid')
                   ->references('uuid')


### PR DESCRIPTION
This PR just cleans up the migration. When running it (Postgres) I received the following errors.

```
 1   Doctrine\DBAL\Driver\PDOException::("SQLSTATE[42830]: Invalid foreign key: 7 ERROR:  there is no unique constraint matching given keys for referenced table "telescope_entries"")

  2   PDOException::("SQLSTATE[42830]: Invalid foreign key: 7 ERROR:  there is no unique constraint matching given keys for referenced table "telescope_entries"")
```

I resolved it by inlining the `unique()` constraint.
I also got rid of a couple duplications for indexing columns.

