### PR TITLE
Fix public asset path

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -10,9 +10,9 @@
     <!-- Style sheets-->
     <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet">
     @if(\Laravel\Telescope\Telescope::$useDarkTheme)
-        <link href='{{asset('vendors/telescope/app-dark.css')}}' rel='stylesheet' type='text/css'>
+        <link href='{{asset('vendor/telescope/app-dark.css')}}' rel='stylesheet' type='text/css'>
     @else
-        <link href='{{asset('vendors/telescope/app.css')}}' rel='stylesheet' type='text/css'>
+        <link href='{{asset('vendor/telescope/app.css')}}' rel='stylesheet' type='text/css'>
     @endif
 </head>
 <body>
@@ -180,6 +180,6 @@
     )); ?>;
 </script>
 
-<script src="{{asset('vendors/telescope/app.js')}}"></script>
+<script src="{{asset('vendor/telescope/app.js')}}"></script>
 </body>
 </html>

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -138,7 +138,7 @@ class Telescope
         return ! $app->runningInConsole() && ! $app['request']->is(
             config('telescope.path').'*',
             'telescope-api*',
-            'vendors/telescope*'
+            'vendor/telescope*'
         );
     }
 

--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -77,7 +77,7 @@ class TelescopeServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__.'/../public' => public_path('vendors/telescope'),
+                __DIR__.'/../public' => public_path('vendor/telescope'),
             ], 'telescope-assets');
 
             $this->publishes([

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -15,7 +15,7 @@ mix
     .js('resources/js/app.js', 'public')
     .sass('resources/sass/app.scss', 'public')
     .sass('resources/sass/app-dark.scss', 'public')
-    .copy('public', '../telescopetest/public/vendors/telescope')
+    .copy('public', '../telescopetest/public/vendor/telescope')
     .webpackConfig({
         resolve: {
             symlinks: false,


### PR DESCRIPTION
Most applications, including Horizon, will publish assets to a `vendor` subdirectory (and not `vendors`).