### PR TITLE
Remove no-dev option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ Laravel Telescope is an elegant debug assistant for the Laravel framework. Teles
 
 You may use Composer to install Telescope into your Laravel project:
 
-    composer require laravel/telescope --dev
+    composer require laravel/telescope 
 
 > **Note:** Telescope requires Laravel 5.7+.
 


### PR DESCRIPTION
Because it is used in production and many people will use following command I think it is better to remove however warning can be made.


$ composer install --no-dev