### PR TITLE
[1.0] Use PHP ^7.1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": "^7.1.3",
         "moontoast/math": "^1.1",
         "symfony/var-dumper": "^4.1"
     },


### PR DESCRIPTION
Use PHP `^7.1.3`, as it's sufficient to get any Laravel 5.7 app running.

See https://github.com/laravel/laravel/blob/master/composer.json#L8