### PR TITLE
[1.0] update docblocks

### DIFF
--- a/src/Http/Controllers/MonitoredTagController.php
+++ b/src/Http/Controllers/MonitoredTagController.php
@@ -42,7 +42,7 @@ class MonitoredTagController extends Controller
      * Begin monitoring the given tag.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return Response
+     * @return void
      */
     public function store(Request $request)
     {
@@ -53,7 +53,7 @@ class MonitoredTagController extends Controller
      * Stop monitoring the given tag.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return Response
+     * @return void
      */
     public function destroy(Request $request)
     {

--- a/src/IncomingDumpEntry.php
+++ b/src/IncomingDumpEntry.php
@@ -18,7 +18,7 @@ class IncomingDumpEntry extends IncomingEntry
      * Assign entry point parameters from the given batch entries.
      *
      * @param  array  $batch
-     * @return $this
+     * @return void
      */
     public function assignEntryPointFromBatch(array $batch)
     {


### PR DESCRIPTION
- `assignEntryPointFromBatch()` does not return anything
- `store()` and `destroy()` do not return anything