### PR TITLE
[1.0] fix docblock

### DIFF
--- a/src/Watchers/RedisWatcher.php
+++ b/src/Watchers/RedisWatcher.php
@@ -38,7 +38,7 @@ class RedisWatcher extends Watcher
      * Format the given Redis command.
      *
      * @param  string  $command
-     * @param  string  $parameters
+     * @param  array  $parameters
      * @return string
      */
     private function formatCommand($command, $parameters)


### PR DESCRIPTION
`implode()` requires an array passed as the second parameter.