### PR TITLE
[1.0] use fully qualified class names in docblocks

### DIFF
--- a/src/Http/Controllers/MonitoredTagController.php
+++ b/src/Http/Controllers/MonitoredTagController.php
@@ -29,7 +29,7 @@ class MonitoredTagController extends Controller
     /**
      * Get all of the tags being monitored.
      *
-     * @return Response
+     * @return \Illuminate\Http\JsonResponse
      */
     public function index()
     {

--- a/src/IncomingDumpEntry.php
+++ b/src/IncomingDumpEntry.php
@@ -40,7 +40,7 @@ class IncomingDumpEntry extends IncomingEntry
     /**
      * Description for the entry point.
      *
-     * @param  IncomingDumpEntry  $entryPoint
+     * @param  \Laravel\Telescope\IncomingDumpEntry  $entryPoint
      * @return string
      */
     private function entryPointDescription($entryPoint)

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -379,7 +379,7 @@ class Telescope
     /**
      * Record the given exception.
      *
-     * @param  Throwable|Exception  $e
+     * @param  \Throwable|\Exception  $e
      * @param  array  $tags
      * @return void
      */
@@ -513,7 +513,7 @@ class Telescope
     /**
      * Hide the given request parameters;
      *
-     * @param  $attributes  array
+     * @param  array  $attributes
      * @return static
      */
     public static function hideRequestParameters(array $attributes)


### PR DESCRIPTION
consistent with everywhere else

also fix the order of one docblock @param