### PR TITLE
[1.0] Fix route caching

### DIFF
--- a/src/Http/Controllers/RouterController.php
+++ b/src/Http/Controllers/RouterController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Telescope\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+
+class RouterController extends Controller
+{
+    /**
+     * Display the Telescope Vue router.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function show()
+    {
+        return view('telescope::layout');
+    }
+}

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -62,6 +62,4 @@ Route::get('/telescope-api/monitored-tags', 'MonitoredTagController@index');
 Route::post('/telescope-api/monitored-tags/', 'MonitoredTagController@store');
 Route::post('/telescope-api/monitored-tags/delete', 'MonitoredTagController@destroy');
 
-Route::get('/{view?}', function () {
-    return view('telescope::layout');
-})->where('view', '(.*)');
+Route::get('/{view?}', 'RouterController@show')->where('view', '(.*)');


### PR DESCRIPTION
Right now you can't run `route:cache` because of closure.