### PR TITLE
[1.0] fix return type

### DIFF
--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -75,7 +75,7 @@ class RequestWatcher extends Watcher
      * Format the given response object.
      *
      * @param  \Symfony\Component\HttpFoundation\Response  $response
-     * @return array
+     * @return array|string
      */
     protected function response(Response $response)
     {


### PR DESCRIPTION
method can return either an array or a string