### PR TITLE
[1.0] Adds Larastan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,9 @@
         "moontoast/math": "^1.1",
         "symfony/var-dumper": "^4.1"
     },
-    "require-dev": {},
+    "require-dev": {
+        "nunomaduro/larastan": "^0.3.4"
+    },
     "autoload": {
         "psr-4": {
             "Laravel\\Telescope\\": "src/"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,6 @@
+includes:
+    - ./vendor/nunomaduro/larastan/extension.neon
+parameters:
+    level: 1
+    paths:
+        - src

--- a/src/ListensForStorageOpportunities.php
+++ b/src/ListensForStorageOpportunities.php
@@ -67,7 +67,7 @@ trait ListensForStorageOpportunities
             static::storeIfDoneProcessingJob($app);
         });
 
-        $app['events']->listen(JobExceptionOccurred::class, function () use ($app) {
+        $app['events']->listen(JobExceptionOccurred::class, function () {
             array_pop(static::$processingJobs);
         });
     }

--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -106,9 +106,7 @@ class DatabaseEntriesRepository implements Contract, PrunableRepository, Termina
 
         $this->storeExceptions($exceptions);
 
-        $createdAt = now();
-
-        $this->table('telescope_entries')->insert($entries->map(function ($entry) use ($createdAt) {
+        $this->table('telescope_entries')->insert($entries->map(function ($entry) {
             $entry->content = json_encode($entry->content);
 
             return $entry->toArray();

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -228,7 +228,7 @@ class Telescope
      */
     public static function recordCache(IncomingEntry $entry)
     {
-        return static::record(EntryType::CACHE, $entry);
+        static::record(EntryType::CACHE, $entry);
     }
 
     /**
@@ -239,7 +239,7 @@ class Telescope
      */
     public static function recordCommand(IncomingEntry $entry)
     {
-        return static::record(EntryType::COMMAND, $entry);
+        static::record(EntryType::COMMAND, $entry);
     }
 
     /**
@@ -250,7 +250,7 @@ class Telescope
      */
     public static function recordDump(IncomingEntry $entry)
     {
-        return static::record(EntryType::DUMP, $entry);
+        static::record(EntryType::DUMP, $entry);
     }
 
     /**
@@ -261,7 +261,7 @@ class Telescope
      */
     public static function recordEvent(IncomingEntry $entry)
     {
-        return static::record(EntryType::EVENT, $entry);
+        static::record(EntryType::EVENT, $entry);
     }
 
     /**
@@ -272,7 +272,7 @@ class Telescope
      */
     public static function recordException(IncomingEntry $entry)
     {
-        return static::record(EntryType::EXCEPTION, $entry);
+        static::record(EntryType::EXCEPTION, $entry);
     }
 
     /**
@@ -283,7 +283,7 @@ class Telescope
      */
     public static function recordJob($entry)
     {
-        return static::record(EntryType::JOB, $entry);
+        static::record(EntryType::JOB, $entry);
     }
 
     /**
@@ -294,7 +294,7 @@ class Telescope
      */
     public static function recordLog(IncomingEntry $entry)
     {
-        return static::record(EntryType::LOG, $entry);
+        static::record(EntryType::LOG, $entry);
     }
 
     /**
@@ -305,7 +305,7 @@ class Telescope
      */
     public static function recordMail(IncomingEntry $entry)
     {
-        return static::record(EntryType::MAIL, $entry);
+        static::record(EntryType::MAIL, $entry);
     }
 
     /**
@@ -316,7 +316,7 @@ class Telescope
      */
     public static function recordNotification($entry)
     {
-        return static::record(EntryType::NOTIFICATION, $entry);
+        static::record(EntryType::NOTIFICATION, $entry);
     }
 
     /**
@@ -327,7 +327,7 @@ class Telescope
      */
     public static function recordQuery(IncomingEntry $entry)
     {
-        return static::record(EntryType::QUERY, $entry);
+        static::record(EntryType::QUERY, $entry);
     }
 
     /**
@@ -338,7 +338,7 @@ class Telescope
      */
     public static function recordModelEvent(IncomingEntry $entry)
     {
-        return static::record(EntryType::MODEL, $entry);
+        static::record(EntryType::MODEL, $entry);
     }
 
     /**
@@ -349,7 +349,7 @@ class Telescope
      */
     public static function recordRedis(IncomingEntry $entry)
     {
-        return static::record(EntryType::REDIS, $entry);
+        static::record(EntryType::REDIS, $entry);
     }
 
     /**
@@ -361,7 +361,7 @@ class Telescope
 
     public static function recordRequest(IncomingEntry $entry)
     {
-        return static::record(EntryType::REQUEST, $entry);
+        static::record(EntryType::REQUEST, $entry);
     }
 
     /**
@@ -373,7 +373,7 @@ class Telescope
 
     public static function recordScheduledCommand(IncomingEntry $entry)
     {
-        return static::record(EntryType::SCHEDULED_TASK, $entry);
+        static::record(EntryType::SCHEDULED_TASK, $entry);
     }
 
     /**


### PR DESCRIPTION
This Pull Request adds [nunomaduro/larastan](http://github.com/nunomaduro/larastan) as `require-dev` dependency of Telescope. Larastan is a wrapper of PHPStan, and is a **static analysis** tool for PHP.

About Phpstan: "_PHPStan is a static analysis tool for PHP code. It parses your code and tries to find flaws in the program logic (like a variable being used before being declared, or a function being called that does not exist...). It is not the ultimate tool for catching bugs but it has one huge advantage: it does not need a lot work to set up! No need to write unit tests, simply run the tool and it will output a list of potential errors!_".

You can read more in this article: [medium.com/@ondrejmirtes/phpstan-2939cd0ad0e3](https://medium.com/@ondrejmirtes/phpstan-2939cd0ad0e3)

This **Pull Request also fixes the errors detected until level `1`**, later I will submit pull requests until we get level `>= 5`.

Usage:
```bash
./vendor/bin/phpstan analyse
```
<img width="100%" alt="example" src="https://user-images.githubusercontent.com/5457236/47382339-5faed580-d702-11e8-9c46-9c3158f20ccf.png">

Notes:
- You can choose from currently 8 levels: (0 is the loosest and 7 is the strictest) by passing `--level` option: `./vendor/bin/phpstan analyse --level=5`.
- **Larastan is not stable yet**. But I am using it in all my projects and packages.
- The line `./vendor/bin/phpstan analyse` should be added to `.travis.yml` in order to auto-analyse pull requests.
