### PR TITLE
[1.0] Added `laravel/framework` to dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     "require": {
         "php": "^7.1.3",
         "ext-json": "*",
+        "laravel/framework" : "~5.7.7",
         "moontoast/math": "^1.1",
         "symfony/var-dumper": "^4.1"
     },


### PR DESCRIPTION
 - added "laravel/framework" : "^5.7.7", to `required`, since laravel should be with minimum version v5.7.7.

 So after this commit composer will update automaticly laravel to 5.7.7 or package will not be installed;

 Similar to https://github.com/laravel/telescope/pull/45