### PR TITLE
Add notice about env

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,8 @@ After installing Telescope, publish its assets using the `telescope:install` Art
 
 After publishing Telescope's assets, its primary configuration file will be located at `config/telescope.php`. This configuration file allows you to configure your watcher options and each configuration option includes a description of its purpose, so be sure to thoroughly explore this file.
 
+> **Note:** Using APP_ENV=testing will disable Telescope. Make sure to use a different value.
+
 <a name="dashboard-authorization"></a>
 ### Dashboard Authorization
 


### PR DESCRIPTION
I spent a while trying to figure out why Telescope wouldn't work on my projects. My company make use of `APP_ENV=testing` for local development and tests as we orchestrate the entire container suite through Docker compose and it's easier to track env vars through `.env.testing`