### PR TITLE
Fix bug

### DIFF
--- a/resources/js/components/IndexScreen.vue
+++ b/resources/js/components/IndexScreen.vue
@@ -104,7 +104,7 @@
 
         methods: {
             loadEntries(after){
-                axios.post('/' + Telescope.path + '/telescope-api/' + this.resource +
+                axios.post(Telescope.path + '/telescope-api/' + this.resource +
                         '?tag=' + this.tag +
                         '&before=' + this.lastEntryIndex +
                         '&take=' + this.entriesPerRequest +
@@ -128,7 +128,7 @@
              */
             checkForNewEntries(){
                 this.newEntriesTimeout = setTimeout(() => {
-                    axios.post('/' + Telescope.path + '/telescope-api/' + this.resource +
+                    axios.post(Telescope.path + '/telescope-api/' + this.resource +
                             '?tag=' + this.tag +
                             '&take=1' +
                             '&family_hash=' + this.familyHash


### PR DESCRIPTION
The url used in axios request is a relative url to the base url, so we don't need the "'/' +".
This caused an issue of receiving always the Http code 302. After diagnost the issue i found that the Route::post to "queries" for example never reached (I did a test using dd()). But when i removed the '/' from this file all works fine. (At this point you should disable the CSRF middleware to get thing working waiting for fixing the 419 HTTP code received if the Csrf middleware is enabled in Kernel.php).