### PR TITLE
[1.0] Version assets

### DIFF
--- a/mix-manifest.json
+++ b/mix-manifest.json
@@ -1,5 +1,0 @@
-{
-    "/public/app.js": "/public/app.js",
-    "/public/app.css": "/public/app.css",
-    "/public/app-dark.css": "/public/app-dark.css"
-}

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -10,9 +10,9 @@
     <!-- Style sheets-->
     <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet">
     @if(\Laravel\Telescope\Telescope::$useDarkTheme)
-        <link href='{{asset('vendor/telescope/app-dark.css')}}' rel='stylesheet' type='text/css'>
+        <link href='{{mix('app-dark.css', 'vendor/telescope')}}' rel='stylesheet' type='text/css'>
     @else
-        <link href='{{asset('vendor/telescope/app.css')}}' rel='stylesheet' type='text/css'>
+        <link href='{{mix('app.css', 'vendor/telescope')}}' rel='stylesheet' type='text/css'>
     @endif
 </head>
 <body>
@@ -180,6 +180,6 @@
     )); ?>;
 </script>
 
-<script src="{{asset('vendor/telescope/app.js')}}"></script>
+<script src="{{mix('app.js', 'vendor/telescope')}}"></script>
 </body>
 </html>

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -22,6 +22,7 @@ mix
             }
         }
     })
+    .setPublicPath('public')
     .js('resources/js/app.js', 'public')
     .sass('resources/sass/app.scss', 'public')
     .sass('resources/sass/app-dark.scss', 'public')

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -26,6 +26,7 @@ mix
     .sass('resources/sass/app.scss', 'public')
     .sass('resources/sass/app-dark.scss', 'public')
     .copy('public', '../telescopetest/public/vendor/telescope')
+    .version()
     .webpackConfig({
         resolve: {
             symlinks: false,


### PR DESCRIPTION
Hi,

Lets version the assets same as horizon

https://github.com/laravel/horizon/blob/4b4822fa7dc8ec69842a339b44fe73d0a63f1cc7/resources/views/app.blade.php#L6

I have removed the `mix-manifest.json` from root. It will be generated inside `public` folder from now.
I have not complied the assets, they should be complied before new release.
