### PR TITLE
[1.0] No need to call resolve that call app

### DIFF
--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -161,7 +161,7 @@ class IncomingEntry
     public function hasMonitoredTag()
     {
         if (! empty($this->tags)) {
-            return resolve(EntriesRepository::class)->isMonitoring($this->tags);
+            return app(EntriesRepository::class)->isMonitoring($this->tags);
         }
 
         return false;

--- a/src/IncomingExceptionEntry.php
+++ b/src/IncomingExceptionEntry.php
@@ -34,7 +34,7 @@ class IncomingExceptionEntry extends IncomingEntry
      */
     public function isReportableException()
     {
-        return resolve(ExceptionHandler::class)
+        return app(ExceptionHandler::class)
             ->shouldReport($this->exception);
     }
 

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -447,7 +447,7 @@ class Telescope
                 static::pruneEntries($storage, config('telescope.limit'));
             }
         } catch (Exception $e) {
-            resolve(ExceptionHandler::class)->report($e);
+            app(ExceptionHandler::class)->report($e);
         }
 
         static::$entriesQueue = [];


### PR DESCRIPTION
No need to call `resolve` that call `app`.
Wen can directly `app`.