### PR TITLE
[1.0] Set Telescope Request ID

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -2,6 +2,7 @@
 
 use Laravel\Telescope\Watchers;
 use Laravel\Telescope\Http\Middleware\Authorize;
+use Laravel\Telescope\Http\Middleware\SetTelescopeRequestId;
 
 return [
 
@@ -55,6 +56,7 @@ return [
     'middleware' => [
         'web',
         Authorize::class,
+        SetTelescopeRequestId::class,
     ],
 
     /*

--- a/src/Http/Middleware/SetTelescopeRequestId.php
+++ b/src/Http/Middleware/SetTelescopeRequestId.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Laravel\Telescope\Http\Middleware;
+
+use Illuminate\Support\Str;
+
+class SetTelescopeRequestId
+{
+    /**
+     * Handle the incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return \Illuminate\Http\Response
+     */
+    public function handle($request, $next)
+    {
+        $response = $next($request);
+        $response->headers->set('X-Telescope-Request-Id', Str::uuid());
+
+        return $response;
+    }
+}


### PR DESCRIPTION
Set Telescope Request ID.
This PR is for https://github.com/laravel/telescope/issues/129 by @dennisoderwald

---

The header name is called `X-Telescope-Request-Id` as other popular debugging/logging SAAS already use `X-Request-Id` and we want to avoid conflicts.