### PR TITLE
[1.0] update `CommandWatcher`

### DIFF
--- a/src/Watchers/CommandWatcher.php
+++ b/src/Watchers/CommandWatcher.php
@@ -33,7 +33,7 @@ class CommandWatcher extends Watcher
         }
 
         Telescope::recordCommand(IncomingEntry::make([
-            'command' => $event->command,
+            'command' => $event->command ?? $event->input->getArguments()['command'] ?? 'default',
             'exit_code' => $event->exitCode,
             'arguments' => $event->input->getArguments(),
             'options' => $event->input->getOptions(),


### PR DESCRIPTION
currently if you run `php artisan` with no arguments, the default `list` command is run. however, the watcher gets sent an empty string. this change gets the command name from the `getArguments()` method, and falls back to 'default', just in case for some reason that doesn't exist.

maybe this should be fixed upstream at some point, but thought I'd get this fix pushed out first before digging into the framework.