### PR TITLE
General cleanup/improvements

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,11 +52,12 @@ Telescope exposes a dashboard at `/telescope`. By default, you will only be able
  *
  * This gate determines who can access Telescope in non-local environments.
  *
+ * @param  \Illuminate\Contracts\Auth\Access\Gate  $gate
  * @return void
  */
-protected function gate()
+protected function gate(Gate $gate)
 {
-    Gate::define('viewTelescope', function ($user) {
+    $gate->define('viewTelescope', function ($user) {
         return in_array($user->email, [
             'taylor@laravel.com',
         ]);

--- a/src/AuthorizesRequests.php
+++ b/src/AuthorizesRequests.php
@@ -2,6 +2,9 @@
 
 namespace Laravel\Telescope;
 
+use Closure;
+use Illuminate\Http\Request;
+
 trait AuthorizesRequests
 {
     /**
@@ -17,7 +20,7 @@ trait AuthorizesRequests
      * @param  \Closure  $callback
      * @return static
      */
-    public static function auth($callback)
+    public static function auth(Closure $callback)
     {
         static::$authUsing = $callback;
 
@@ -30,7 +33,7 @@ trait AuthorizesRequests
      * @param  \Illuminate\Http\Request  $request
      * @return bool
      */
-    public static function check($request)
+    public static function check(Request $request)
     {
         return (static::$authUsing ?: function () {
             return app()->environment('local');

--- a/src/Http/Controllers/DumpController.php
+++ b/src/Http/Controllers/DumpController.php
@@ -4,6 +4,7 @@ namespace Laravel\Telescope\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Laravel\Telescope\EntryType;
+use Illuminate\Contracts\Routing\ResponseFactory;
 use Laravel\Telescope\Contracts\EntriesRepository;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 
@@ -26,18 +27,20 @@ class DumpController extends EntryController
     {
         $this->cache = $cache;
     }
+
     /**
      * List the entries of the given type.
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
+     * @param  \Illuminate\Contracts\Routing\ResponseFactory  $responseFactory
      * @return \Illuminate\Http\JsonResponse
      */
-    public function index(Request $request, EntriesRepository $storage)
+    public function index(Request $request, EntriesRepository $storage, ResponseFactory $responseFactory)
     {
         $this->cache->put('telescope:dump-watcher', true, now()->addSecond(4));
 
-        return parent::index($request, $storage);
+        return parent::index($request, $storage, $responseFactory);
     }
 
     /**

--- a/src/Http/Controllers/EntryController.php
+++ b/src/Http/Controllers/EntryController.php
@@ -5,6 +5,7 @@ namespace Laravel\Telescope\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Telescope\Storage\EntryQueryOptions;
+use Illuminate\Contracts\Routing\ResponseFactory;
 use Laravel\Telescope\Contracts\EntriesRepository;
 
 abstract class EntryController extends Controller
@@ -21,11 +22,12 @@ abstract class EntryController extends Controller
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
+     * @param  \Illuminate\Contracts\Routing\ResponseFactory  $responseFactory
      * @return \Illuminate\Http\JsonResponse
      */
-    public function index(Request $request, EntriesRepository $storage)
+    public function index(Request $request, EntriesRepository $storage, ResponseFactory $responseFactory)
     {
-        return response()->json([
+        return $responseFactory->json([
             'entries' => $storage->get(
                 $this->entryType(),
                 EntryQueryOptions::fromRequest($request)
@@ -37,14 +39,15 @@ abstract class EntryController extends Controller
      * Get an entry with the given ID.
      *
      * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
+     * @param  \Illuminate\Contracts\Routing\ResponseFactory  $responseFactory
      * @param  int  $id
      * @return \Illuminate\Http\JsonResponse
      */
-    public function show(EntriesRepository $storage, $id)
+    public function show(EntriesRepository $storage, ResponseFactory $responseFactory, $id)
     {
         $entry = $storage->find($id);
 
-        return response()->json([
+        return $responseFactory->json([
             'entry' => $entry,
             'batch' => $storage->get(null, EntryQueryOptions::forBatchId($entry->batchId)),
         ]);

--- a/src/Http/Controllers/HomeController.php
+++ b/src/Http/Controllers/HomeController.php
@@ -3,16 +3,18 @@
 namespace Laravel\Telescope\Http\Controllers;
 
 use Illuminate\Routing\Controller;
+use Illuminate\Contracts\Routing\ResponseFactory;
 
 class HomeController extends Controller
 {
     /**
      * Display the Telescope view.
      *
+     * @param  \Illuminate\Contracts\Routing\ResponseFactory  $responseFactory
      * @return \Illuminate\Http\Response
      */
-    public function index()
+    public function index(ResponseFactory $responseFactory)
     {
-        return view('telescope::layout');
+        return $responseFactory->view('telescope::layout');
     }
 }

--- a/src/Http/Controllers/MailEmlController.php
+++ b/src/Http/Controllers/MailEmlController.php
@@ -3,6 +3,7 @@
 namespace Laravel\Telescope\Http\Controllers;
 
 use Illuminate\Routing\Controller;
+use Illuminate\Contracts\Routing\ResponseFactory;
 use Laravel\Telescope\Contracts\EntriesRepository;
 
 class MailEmlController extends Controller
@@ -11,12 +12,13 @@ class MailEmlController extends Controller
      * Download the Eml content of the email.
      *
      * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
+     * @param  \Illuminate\Contracts\Routing\ResponseFactory  $responseFactory
      * @param  int  $id
-     * @return mixed
+     * @return \Illuminate\Http\Response
      */
-    public function show(EntriesRepository $storage, $id)
+    public function show(EntriesRepository $storage, ResponseFactory $responseFactory, $id)
     {
-        return response($storage->find($id)->content['raw'], 200, [
+        return $responseFactory->make($storage->find($id)->content['raw'], 200, [
             'Content-Type' => 'message/rfc822',
             'Content-Disposition' => 'attachment; filename="mail-'.$id.'.eml"',
         ]);

--- a/src/Http/Controllers/MailHtmlController.php
+++ b/src/Http/Controllers/MailHtmlController.php
@@ -3,6 +3,7 @@
 namespace Laravel\Telescope\Http\Controllers;
 
 use Illuminate\Routing\Controller;
+use Illuminate\Contracts\Routing\ResponseFactory;
 use Laravel\Telescope\Contracts\EntriesRepository;
 
 class MailHtmlController extends Controller
@@ -11,11 +12,12 @@ class MailHtmlController extends Controller
      * Get the HTML content of the given email.
      *
      * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
+     * @param  \Illuminate\Contracts\Routing\ResponseFactory  $responseFactory
      * @param  int  $id
-     * @return mixed
+     * @return \Illuminate\Http\Response
      */
-    public function show(EntriesRepository $storage, $id)
+    public function show(EntriesRepository $storage, ResponseFactory $responseFactory, $id)
     {
-        return $storage->find($id)->content['html'];
+        return $responseFactory->make($storage->find($id)->content['html']);
     }
 }

--- a/src/Http/Controllers/MonitoredTagController.php
+++ b/src/Http/Controllers/MonitoredTagController.php
@@ -4,6 +4,7 @@ namespace Laravel\Telescope\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Contracts\Routing\ResponseFactory;
 use Laravel\Telescope\Contracts\EntriesRepository;
 
 class MonitoredTagController extends Controller
@@ -29,11 +30,12 @@ class MonitoredTagController extends Controller
     /**
      * Get all of the tags being monitored.
      *
+     * @param  \Illuminate\Contracts\Routing\ResponseFactory  $responseFactory
      * @return \Illuminate\Http\JsonResponse
      */
-    public function index()
+    public function index(ResponseFactory $responseFactory)
     {
-        return response()->json([
+        return $responseFactory->json([
             'tags' => $this->entries->monitoring()
         ]);
     }

--- a/src/Http/Controllers/QueueController.php
+++ b/src/Http/Controllers/QueueController.php
@@ -4,6 +4,7 @@ namespace Laravel\Telescope\Http\Controllers;
 
 use Laravel\Telescope\EntryType;
 use Laravel\Telescope\Storage\EntryQueryOptions;
+use Illuminate\Contracts\Routing\ResponseFactory;
 use Laravel\Telescope\Contracts\EntriesRepository;
 
 class QueueController extends EntryController
@@ -22,14 +23,15 @@ class QueueController extends EntryController
      * Get an entry with the given ID.
      *
      * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
+     * @param  \Illuminate\Contracts\Routing\ResponseFactory  $responseFactory
      * @param  int  $id
      * @return \Illuminate\Http\JsonResponse
      */
-    public function show(EntriesRepository $storage, $id)
+    public function show(EntriesRepository $storage, ResponseFactory $responseFactory, $id)
     {
         $entry = $storage->find($id);
 
-        return response()->json([
+        return $responseFactory->json([
             'entry' => $entry,
             'batch' => isset($entry->content['updated_batch_id'])
                             ? $storage->get(null, EntryQueryOptions::forBatchId($entry->content['updated_batch_id']))

--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -3,6 +3,7 @@
 namespace Laravel\Telescope;
 
 use Illuminate\Support\Str;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Laravel\Telescope\Contracts\EntriesRepository;
 
 class IncomingEntry
@@ -38,7 +39,7 @@ class IncomingEntry
     /**
      * The currently authenticated user, if applicable.
      *
-     * @var mixed
+     * @var \Illuminate\Contracts\Auth\Authenticatable|null
      */
     public $user;
 
@@ -123,7 +124,7 @@ class IncomingEntry
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return $this
      */
-    public function user($user)
+    public function user(Authenticatable $user)
     {
         $this->user = $user;
 
@@ -135,7 +136,7 @@ class IncomingEntry
             ],
         ]);
 
-        $this->tags(['Auth:'.$user->getKey()]);
+        $this->tags(['Auth:'.$user->getAuthIdentifier()]);
 
         return $this;
     }

--- a/src/RegistersWatchers.php
+++ b/src/RegistersWatchers.php
@@ -2,6 +2,10 @@
 
 namespace Laravel\Telescope;
 
+use Laravel\Telescope\Watchers\Watcher;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Foundation\Application;
+
 trait RegistersWatchers
 {
     /**
@@ -25,12 +29,12 @@ trait RegistersWatchers
     /**
      * Register the configured Telescope watchers.
      *
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    protected static function registerWatchers($app)
+    protected static function registerWatchers(Application $app)
     {
-        foreach (config('telescope.watchers') as $key => $watcher) {
+        foreach ($app->make(Repository::class)->get('telescope.watchers') as $key => $watcher) {
             if (is_string($key) && $watcher === false) {
                 continue;
             }
@@ -39,7 +43,8 @@ trait RegistersWatchers
                 continue;
             }
 
-            $watcher = $app->makeWith(is_string($key) ? $key : $watcher, [
+            /** @var \Laravel\Telescope\Watchers\Watcher $watcher */
+            $watcher = $app->make(is_string($key) ? $key : $watcher, [
                 'options' => is_array($watcher) ? $watcher : []
             ]);
 

--- a/src/Storage/EntryModel.php
+++ b/src/Storage/EntryModel.php
@@ -3,6 +3,7 @@
 namespace Laravel\Telescope\Storage;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 
 class EntryModel extends Model
 {
@@ -51,7 +52,7 @@ class EntryModel extends Model
      * @param  \Laravel\Telescope\Storage\EntryQueryOptions  $options
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeWithTelescopeOptions($query, $type, EntryQueryOptions $options)
+    public function scopeWithTelescopeOptions(Builder $query, $type, EntryQueryOptions $options)
     {
         $this->whereType($query, $type)
                 ->whereBatchId($query, $options)
@@ -70,9 +71,9 @@ class EntryModel extends Model
      * @param  string  $type
      * @return $this
      */
-    protected function whereType($query, $type)
+    protected function whereType(Builder $query, $type)
     {
-        $query->when($type, function ($query, $type) {
+        $query->when($type, function (Builder $query, $type) {
             return $query->where('type', $type);
         });
 
@@ -86,9 +87,9 @@ class EntryModel extends Model
      * @param  \Laravel\Telescope\Storage\EntryQueryOptions  $options
      * @return $this
      */
-    protected function whereBatchId($query, EntryQueryOptions $options)
+    protected function whereBatchId(Builder $query, EntryQueryOptions $options)
     {
-        $query->when($options->batchId, function ($query, $batchId) {
+        $query->when($options->batchId, function (Builder $query, $batchId) {
             return $query->where('batch_id', $batchId);
         });
 
@@ -102,10 +103,10 @@ class EntryModel extends Model
      * @param  \Laravel\Telescope\Storage\EntryQueryOptions  $options
      * @return $this
      */
-    protected function whereTag($query, EntryQueryOptions $options)
+    protected function whereTag(Builder $query, EntryQueryOptions $options)
     {
-        $query->when($options->tag, function ($query, $tag) {
-            return $query->whereIn('uuid', function ($query) use ($tag) {
+        $query->when($options->tag, function (Builder $query, $tag) {
+            return $query->whereIn('uuid', function (Builder $query) use ($tag) {
                 $query->select('entry_uuid')->from('telescope_entries_tags')->whereTag($tag);
             });
         });
@@ -120,9 +121,9 @@ class EntryModel extends Model
      * @param  \Laravel\Telescope\Storage\EntryQueryOptions  $options
      * @return $this
      */
-    protected function whereFamilyHash($query, EntryQueryOptions $options)
+    protected function whereFamilyHash(Builder $query, EntryQueryOptions $options)
     {
-        $query->when($options->familyHash, function ($query, $hash) {
+        $query->when($options->familyHash, function (Builder $query, $hash) {
             return $query->where('family_hash', $hash);
         });
 
@@ -136,9 +137,9 @@ class EntryModel extends Model
      * @param  \Laravel\Telescope\Storage\EntryQueryOptions  $options
      * @return $this
      */
-    protected function whereBeforeSequence($query, EntryQueryOptions $options)
+    protected function whereBeforeSequence(Builder $query, EntryQueryOptions $options)
     {
-        $query->when($options->beforeSequence, function ($query, $beforeSequence) {
+        $query->when($options->beforeSequence, function (Builder $query, $beforeSequence) {
             return $query->where('sequence', '<', $beforeSequence);
         });
 
@@ -152,7 +153,7 @@ class EntryModel extends Model
      * @param  \Laravel\Telescope\Storage\EntryQueryOptions  $options
      * @return $this
      */
-    protected function filter($query, EntryQueryOptions $options)
+    protected function filter(Builder $query, EntryQueryOptions $options)
     {
         if ($options->familyHash || $options->tag || $options->batchId) {
             return $this;

--- a/src/TelescopeApplicationServiceProvider.php
+++ b/src/TelescopeApplicationServiceProvider.php
@@ -2,33 +2,36 @@
 
 namespace Laravel\Telescope;
 
-use Illuminate\Support\Facades\Gate;
+use Illuminate\Http\Request;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Auth\Access\Gate;
 
 class TelescopeApplicationServiceProvider extends ServiceProvider
 {
     /**
      * Bootstrap any application services.
      *
+     * @param  \Illuminate\Contracts\Auth\Access\Gate  $gate
      * @return void
      */
-    public function boot()
+    public function boot(Gate $gate)
     {
-        $this->authorization();
+        $this->authorization($gate);
     }
 
     /**
      * Configure the Telescope authorization services.
      *
+     * @param  \Illuminate\Contracts\Auth\Access\Gate  $gate
      * @return void
      */
-    protected function authorization()
+    protected function authorization(Gate $gate)
     {
-        $this->gate();
+        $this->gate($gate);
 
-        Telescope::auth(function ($request) {
-            return app()->environment('local') ||
-                   Gate::check('viewTelescope', [$request->user()]);
+        Telescope::auth(function (Request $request) use ($gate) {
+            return $this->app->environment('local') ||
+                $gate->check('viewTelescope', [$request->user()]);
         });
     }
 
@@ -37,11 +40,12 @@ class TelescopeApplicationServiceProvider extends ServiceProvider
      *
      * This gate determines who can access Telescope in non-local environments.
      *
+     * @param  \Illuminate\Contracts\Auth\Access\Gate  $gate
      * @return void
      */
-    protected function gate()
+    protected function gate(Gate $gate)
     {
-        Gate::define('viewTelescope', function ($user) {
+        $gate->define('viewTelescope', function ($user) {
             return in_array($user->email, [
                 //
             ]);

--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -2,8 +2,9 @@
 
 namespace Laravel\Telescope;
 
-use Illuminate\Support\Facades\Route;
+use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Config\Repository;
 use Laravel\Telescope\Contracts\EntriesRepository;
 use Laravel\Telescope\Storage\DatabaseEntriesRepository;
 
@@ -12,13 +13,15 @@ class TelescopeServiceProvider extends ServiceProvider
     /**
      * Bootstrap any package services.
      *
+     * @param  \Illuminate\Routing\Router  $router
+     * @param  \Illuminate\Contracts\Config\Repository  $config
      * @return void
      */
-    public function boot()
+    public function boot(Router $router, Repository $config)
     {
-        Route::middlewareGroup('telescope', config('telescope.middleware', []));
+        $router->middlewareGroup('telescope', $config->get('telescope.middleware', []));
 
-        $this->registerRoutes();
+        $this->registerRoutes($router);
         $this->registerMigrations();
         $this->registerPublishing();
 
@@ -33,11 +36,12 @@ class TelescopeServiceProvider extends ServiceProvider
     /**
      * Register the package routes.
      *
+     * @param  \Illuminate\Routing\Router  $router
      * @return void
      */
-    private function registerRoutes()
+    private function registerRoutes(Router $router)
     {
-        Route::group($this->routeConfiguration(), function () {
+        $router->group($this->routeConfiguration(), function () {
             $this->loadRoutesFrom(__DIR__.'/Http/routes.php');
         });
     }

--- a/src/Watchers/CacheWatcher.php
+++ b/src/Watchers/CacheWatcher.php
@@ -9,6 +9,8 @@ use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Cache\Events\KeyWritten;
 use Illuminate\Cache\Events\CacheMissed;
 use Illuminate\Cache\Events\KeyForgotten;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Foundation\Application;
 
 class CacheWatcher extends Watcher
 {
@@ -18,13 +20,15 @@ class CacheWatcher extends Watcher
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function register($app)
+    public function register(Application $app)
     {
-        $app['events']->listen(CacheHit::class, [$this, 'recordCacheHit']);
-        $app['events']->listen(CacheMissed::class, [$this, 'recordCacheMissed']);
+        /** @var \Illuminate\Contracts\Events\Dispatcher $dispatcher */
+        $dispatcher = $app->make(Dispatcher::class);
+        $dispatcher->listen(CacheHit::class, [$this, 'recordCacheHit']);
+        $dispatcher->listen(CacheMissed::class, [$this, 'recordCacheMissed']);
 
-        $app['events']->listen(KeyWritten::class, [$this, 'recordKeyWritten']);
-        $app['events']->listen(KeyForgotten::class, [$this, 'recordKeyForgotten']);
+        $dispatcher->listen(KeyWritten::class, [$this, 'recordKeyWritten']);
+        $dispatcher->listen(KeyForgotten::class, [$this, 'recordKeyForgotten']);
     }
 
     /**

--- a/src/Watchers/CommandWatcher.php
+++ b/src/Watchers/CommandWatcher.php
@@ -5,7 +5,9 @@ namespace Laravel\Telescope\Watchers;
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\IncomingEntry;
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Console\Events\CommandFinished;
+use Illuminate\Contracts\Foundation\Application;
 
 class CommandWatcher extends Watcher
 {
@@ -15,9 +17,9 @@ class CommandWatcher extends Watcher
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function register($app)
+    public function register(Application $app)
     {
-        $app['events']->listen(CommandFinished::class, [$this, 'recordCommand']);
+        $app->make(Dispatcher::class)->listen(CommandFinished::class, [$this, 'recordCommand']);
     }
 
     /**

--- a/src/Watchers/DumpWatcher.php
+++ b/src/Watchers/DumpWatcher.php
@@ -4,28 +4,29 @@ namespace Laravel\Telescope\Watchers;
 
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\IncomingDumpEntry;
+use Illuminate\Contracts\Cache\Repository;
 use Symfony\Component\VarDumper\VarDumper;
+use Illuminate\Contracts\Foundation\Application;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
-use Illuminate\Contracts\Cache\Factory as CacheFactory;
 
 class DumpWatcher extends Watcher
 {
     /**
      * The cache factory implementation.
      *
-     * @var \Illuminate\Contracts\Cache\Factory
+     * @var \Illuminate\Contracts\Cache\Repository
      */
     protected $cache;
 
     /**
      * Create a new watcher instance.
      *
-     * @param  \Illuminate\Contracts\Cache\Factory  $cache
+     * @param  \Illuminate\Contracts\Cache\Repository  $cache
      * @param  array  $options
      * @return void
      */
-    public function __construct(CacheFactory $cache, array $options = [])
+    public function __construct(Repository $cache, array $options = [])
     {
         parent::__construct($options);
 
@@ -38,7 +39,7 @@ class DumpWatcher extends Watcher
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function register($app)
+    public function register(Application $app)
     {
         if (! $this->cache->get('telescope:dump-watcher')) {
             return;

--- a/src/Watchers/EventWatcher.php
+++ b/src/Watchers/EventWatcher.php
@@ -9,7 +9,9 @@ use Laravel\Telescope\Telescope;
 use Laravel\Telescope\ExtractTags;
 use Laravel\Telescope\IncomingEntry;
 use Laravel\Telescope\ExtractProperties;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 
 class EventWatcher extends Watcher
@@ -20,9 +22,9 @@ class EventWatcher extends Watcher
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function register($app)
+    public function register(Application $app)
     {
-        $app['events']->listen('*', [$this, 'recordEvent']);
+        $app->make(Dispatcher::class)->listen('*', [$this, 'recordEvent']);
     }
 
     /**

--- a/src/Watchers/ExceptionWatcher.php
+++ b/src/Watchers/ExceptionWatcher.php
@@ -6,7 +6,9 @@ use Laravel\Telescope\Telescope;
 use Laravel\Telescope\ExtractTags;
 use Laravel\Telescope\ExceptionContext;
 use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Telescope\IncomingExceptionEntry;
+use Illuminate\Contracts\Foundation\Application;
 
 class ExceptionWatcher extends Watcher
 {
@@ -16,9 +18,9 @@ class ExceptionWatcher extends Watcher
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function register($app)
+    public function register(Application $app)
     {
-        $app['events']->listen(MessageLogged::class, [$this, 'recordException']);
+        $app->make(Dispatcher::class)->listen(MessageLogged::class, [$this, 'recordException']);
     }
 
     /**
@@ -53,7 +55,7 @@ class ExceptionWatcher extends Watcher
      * @param  \Illuminate\Log\Events\MessageLogged  $event
      * @return array
      */
-    protected function tags($event)
+    protected function tags(MessageLogged $event)
     {
         return array_merge(ExtractTags::from($event->context['exception']),
             $event->context['telescope'] ?? []

--- a/src/Watchers/LogWatcher.php
+++ b/src/Watchers/LogWatcher.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Arr;
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\IncomingEntry;
 use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Foundation\Application;
 
 class LogWatcher extends Watcher
 {
@@ -15,9 +17,9 @@ class LogWatcher extends Watcher
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function register($app)
+    public function register(Application $app)
     {
-        $app['events']->listen(MessageLogged::class, [$this, 'recordLog']);
+        $app->make(Dispatcher::class)->listen(MessageLogged::class, [$this, 'recordLog']);
     }
 
     /**
@@ -47,7 +49,7 @@ class LogWatcher extends Watcher
      * @param  \Illuminate\Log\Events\MessageLogged  $event
      * @return array
      */
-    private function tags($event)
+    private function tags(MessageLogged $event)
     {
         return $event->context['telescope'] ?? [];
     }

--- a/src/Watchers/MailWatcher.php
+++ b/src/Watchers/MailWatcher.php
@@ -2,9 +2,12 @@
 
 namespace Laravel\Telescope\Watchers;
 
+use Swift_Message;
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\IncomingEntry;
 use Illuminate\Mail\Events\MessageSent;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Foundation\Application;
 
 class MailWatcher extends Watcher
 {
@@ -14,9 +17,9 @@ class MailWatcher extends Watcher
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function register($app)
+    public function register(Application $app)
     {
-        $app['events']->listen(MessageSent::class, [$this, 'recordMail']);
+        $app->make(Dispatcher::class)->listen(MessageSent::class, [$this, 'recordMail']);
     }
 
     /**
@@ -47,7 +50,7 @@ class MailWatcher extends Watcher
      * @param  \Illuminate\Mail\Events\MessageSent  $event
      * @return string
      */
-    protected function getMailable($event)
+    protected function getMailable(MessageSent $event)
     {
         if (isset($event->data['__laravel_notification'])) {
             return $event->data['__laravel_notification'];
@@ -62,7 +65,7 @@ class MailWatcher extends Watcher
      * @param  \Illuminate\Mail\Events\MessageSent  $event
      * @return bool
      */
-    protected function getQueuedStatus($event)
+    protected function getQueuedStatus(MessageSent $event)
     {
         if (isset($event->data['__laravel_notification_queued'])) {
             return $event->data['__laravel_notification_queued'];
@@ -78,7 +81,7 @@ class MailWatcher extends Watcher
      * @param  array  $data
      * @return array
      */
-    private function tags($message, $data)
+    private function tags(Swift_Message $message, $data)
     {
         return array_merge(
             array_keys($message->getTo() ?: []),

--- a/src/Watchers/ModelWatcher.php
+++ b/src/Watchers/ModelWatcher.php
@@ -5,6 +5,8 @@ namespace Laravel\Telescope\Watchers;
 use Illuminate\Support\Str;
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\IncomingEntry;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Foundation\Application;
 
 class ModelWatcher extends Watcher
 {
@@ -14,9 +16,9 @@ class ModelWatcher extends Watcher
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function register($app)
+    public function register(Application $app)
     {
-        $app['events']->listen('eloquent.*', [$this, 'recordAction']);
+        $app->make(Dispatcher::class)->listen('eloquent.*', [$this, 'recordAction']);
     }
 
     /**

--- a/src/Watchers/NotificationWatcher.php
+++ b/src/Watchers/NotificationWatcher.php
@@ -6,7 +6,9 @@ use Laravel\Telescope\Telescope;
 use Laravel\Telescope\ExtractTags;
 use Laravel\Telescope\IncomingEntry;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\Events\NotificationSent;
 
@@ -18,9 +20,9 @@ class NotificationWatcher extends Watcher
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function register($app)
+    public function register(Application $app)
     {
-        $app['events']->listen(NotificationSent::class, [$this, 'recordNotification']);
+        $app->make(Dispatcher::class)->listen(NotificationSent::class, [$this, 'recordNotification']);
     }
 
     /**
@@ -46,7 +48,7 @@ class NotificationWatcher extends Watcher
      * @param  \Illuminate\Notifications\Events\NotificationSent  $event
      * @return array
      */
-    private function tags($event)
+    private function tags(NotificationSent $event)
     {
         return array_merge([
             $this->formatNotifiable($event->notifiable),

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -4,7 +4,9 @@ namespace Laravel\Telescope\Watchers;
 
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\IncomingEntry;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Contracts\Foundation\Application;
 
 class QueryWatcher extends Watcher
 {
@@ -14,9 +16,9 @@ class QueryWatcher extends Watcher
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function register($app)
+    public function register(Application $app)
     {
-        $app['events']->listen(QueryExecuted::class, [$this, 'recordQuery']);
+        $app->make(Dispatcher::class)->listen(QueryExecuted::class, [$this, 'recordQuery']);
     }
 
     /**
@@ -44,7 +46,7 @@ class QueryWatcher extends Watcher
      * @param  \Illuminate\Database\Events\QueryExecuted  $event
      * @return array
      */
-    protected function tags($event)
+    protected function tags(QueryExecuted $event)
     {
         return isset($this->options['slow']) && $event->time >= $this->options['slow'] ? ['slow'] : [];
     }
@@ -55,7 +57,7 @@ class QueryWatcher extends Watcher
      * @param  \Illuminate\Database\Events\QueryExecuted  $event
      * @return array
      */
-    protected function formatBindings($event)
+    protected function formatBindings(QueryExecuted $event)
     {
         return $event->connection->prepareBindings($event->bindings);
     }

--- a/src/Watchers/RedisWatcher.php
+++ b/src/Watchers/RedisWatcher.php
@@ -4,7 +4,9 @@ namespace Laravel\Telescope\Watchers;
 
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\IncomingEntry;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Redis\Events\CommandExecuted;
+use Illuminate\Contracts\Foundation\Application;
 
 class RedisWatcher extends Watcher
 {
@@ -14,9 +16,9 @@ class RedisWatcher extends Watcher
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function register($app)
+    public function register(Application $app)
     {
-        $app['events']->listen(CommandExecuted::class, [$this, 'recordCommand']);
+        $app->make(Dispatcher::class)->listen(CommandExecuted::class, [$this, 'recordCommand']);
     }
 
     /**

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -6,7 +6,9 @@ use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\IncomingEntry;
+use Illuminate\Contracts\Events\Dispatcher;
 use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Http\Events\RequestHandled;
 
 class RequestWatcher extends Watcher
@@ -17,9 +19,9 @@ class RequestWatcher extends Watcher
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function register($app)
+    public function register(Application $app)
     {
-        $app['events']->listen(RequestHandled::class, [$this, 'recordRequest']);
+        $app->make(Dispatcher::class)->listen(RequestHandled::class, [$this, 'recordRequest']);
     }
 
     /**

--- a/src/Watchers/ScheduleWatcher.php
+++ b/src/Watchers/ScheduleWatcher.php
@@ -5,9 +5,11 @@ namespace Laravel\Telescope\Watchers;
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\IncomingEntry;
 use Illuminate\Console\Scheduling\Event;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Console\Scheduling\CallbackEvent;
+use Illuminate\Contracts\Foundation\Application;
 
 class ScheduleWatcher extends Watcher
 {
@@ -17,9 +19,9 @@ class ScheduleWatcher extends Watcher
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function register($app)
+    public function register(Application $app)
     {
-        $app['events']->listen(CommandStarting::class, [$this, 'recordCommand']);
+        $app->make(Dispatcher::class)->listen(CommandStarting::class, [$this, 'recordCommand']);
     }
 
     /**
@@ -35,7 +37,7 @@ class ScheduleWatcher extends Watcher
             return;
         }
 
-        collect(app(Schedule::class)->events())->each(function ($event) {
+        collect(app(Schedule::class)->events())->each(function (Event $event) {
             $event->then(function () use ($event) {
                 Telescope::recordScheduledCommand(IncomingEntry::make([
                     'command' => $event instanceof CallbackEvent ? 'Closure' : $event->command,
@@ -52,7 +54,7 @@ class ScheduleWatcher extends Watcher
     /**
      * Get the output for the scheduled event.
      *
-     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @param  Event $event
      * @return string|null
      */
     protected function getEventOutput(Event $event)

--- a/src/Watchers/Watcher.php
+++ b/src/Watchers/Watcher.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Telescope\Watchers;
 
+use Illuminate\Contracts\Foundation\Application;
+
 abstract class Watcher
 {
     /**
@@ -28,5 +30,5 @@ abstract class Watcher
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    abstract public function register($app);
+    abstract public function register(Application $app);
 }


### PR DESCRIPTION
Some general cleanup and improvements:

- the concrete `Container` contract implementation also implements `ArrayAccess` to resolve dependencies, but that isn't on the `Container` contract and as such stuff like `$app['events']` would break on any other implementation
- I type-hinted stuff as much as possible to avoid issues like https://github.com/laravel/telescope/commit/fa6919367e9d0af7bbac05c0b3fa89707239010d#diff-deecd2e5f86cd9955088f4026ca3d452 (and to enable better IDE auto-completion) and in doing so I found some instances of calls being made to a contract implementation which doesn't have that method (`getKey` was called on an `\Illuminate\Contracts\Auth\Authenticatable` implementation and `makeWith` was called on an `\Illuminate\Contracts\Container\Container` implementation)
- some controller docblocks said they were returning a `Response` instance or just "mixed", but they actually returned a `View` instance - I switched them all to actually return a proper `Response` object