### PR TITLE
Show backtrace for queries

### DIFF
--- a/resources/js/components/PreviewScreen.vue
+++ b/resources/js/components/PreviewScreen.vue
@@ -76,6 +76,14 @@
         methods: {
             prepareEntry() {
                 document.title = this.title + " - Telescope";
+                this.ready = false;
+
+                let unwatch = this.$watch('ready', (newVal, oldVal) => {
+                    if (newVal) {
+                        this.$emit('ready');
+                        unwatch();
+                    }
+                });
 
                 this.loadEntry((response) => {
                     this.entry = response.data.entry;

--- a/resources/js/screens/queries/preview.vue
+++ b/resources/js/screens/queries/preview.vue
@@ -83,9 +83,7 @@
                 </ul>
 
                 <div>
-                    <pre class="code-bg p-4 mb-0 text-white" ref="sqlcode" v-show="currentTab=='query'">
-                        {{formatSQL(slotProps.entry.content.sql, slotProps.entry.content.bindings)}}
-                    </pre>
+                    <pre class="code-bg p-4 mb-0 text-white" ref="sqlcode" v-show="currentTab=='query'">{{formatSQL(slotProps.entry.content.sql, slotProps.entry.content.bindings)}}</pre>
 
                     <stack-trace
                             v-if="showSource"

--- a/resources/js/screens/queries/preview.vue
+++ b/resources/js/screens/queries/preview.vue
@@ -5,25 +5,35 @@
     import sql from 'highlight.js/lib/languages/sql';
 
     export default {
-        data(){
+        components: {
+            'stack-trace': require('./../../components/Stacktrace')
+        },
+
+        data() {
             return {
                 entry: null,
                 batch: [],
+                currentTab: 'query',
             };
         },
 
-        mounted(){
-           setTimeout(() => {
-               hljs.registerLanguage('sql', sql);
-
-               hljs.highlightBlock(this.$refs.sqlcode);
-           }, 500);
+        computed: {
+            showSource() {
+                return this.entry.content.source && this.entry.content.source.length;
+            }
         },
 
-        methods:{
+        methods: {
             formatSQL(sql, params) {
                 return sqlFormatter.format(sql, {
                     params: _.map(params, param => _.isString(param) ? '"'+param+'"' : param)
+                });
+            },
+
+            highlightSQL() {
+                this.$nextTick(() => {
+                    hljs.registerLanguage('sql', sql);
+                    hljs.highlightBlock(this.$refs.sqlcode);
                 });
             }
         }
@@ -31,7 +41,7 @@
 </script>
 
 <template>
-    <preview-screen title="Query Details" resource="queries" :id="$route.params.id">
+    <preview-screen title="Query Details" resource="queries" :id="$route.params.id" v-on:ready="highlightSQL()">
         <template slot="table-parameters" slot-scope="slotProps">
             <tr>
                 <td class="table-fit font-weight-bold">Connection</td>
@@ -52,13 +62,37 @@
                     </span>
                 </td>
             </tr>
+
+            <tr v-if="showSource">
+                <td class="table-fit font-weight-bold">Location</td>
+                <td>
+                    {{slotProps.entry.content.source[0].file}}:{{slotProps.entry.content.source[0].line}}
+                </td>
+            </tr>
         </template>
 
         <div slot="after-attributes-card" slot-scope="slotProps">
             <div class="card mt-5">
-                <div class="card-header"><h5>Query</h5></div>
+                <ul class="nav nav-pills">
+                    <li class="nav-item">
+                        <a class="nav-link" :class="{active: currentTab=='query'}" href="#" v-on:click.prevent="currentTab='query'">Query</a>
+                    </li>
+                    <li class="nav-item" v-if="showSource">
+                        <a class="nav-link" :class="{active: currentTab=='source'}" href="#" v-on:click.prevent="currentTab='source'">Source</a>
+                    </li>
+                </ul>
 
-                <pre class="code-bg p-4 mb-0 text-white" ref="sqlcode">{{formatSQL(slotProps.entry.content.sql, slotProps.entry.content.bindings)}}</pre>
+                <div>
+                    <pre class="code-bg p-4 mb-0 text-white" ref="sqlcode" v-show="currentTab=='query'">
+                        {{formatSQL(slotProps.entry.content.sql, slotProps.entry.content.bindings)}}
+                    </pre>
+
+                    <stack-trace
+                            v-if="showSource"
+                            v-show="currentTab=='source'"
+                            :trace="slotProps.entry.content.source">
+                    </stack-trace>
+                </div>
             </div>
         </div>
     </preview-screen>

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -2,12 +2,20 @@
 
 namespace Laravel\Telescope\Watchers;
 
+use ReflectionClass;
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\IncomingEntry;
 use Illuminate\Database\Events\QueryExecuted;
 
 class QueryWatcher extends Watcher
 {
+    /**
+     * The views that have been located by the view finder.
+     *
+     * @var \ReflectionProperty
+     */
+    protected $views;
+
     /**
      * Register the watcher.
      *
@@ -28,6 +36,7 @@ class QueryWatcher extends Watcher
     public function recordQuery(QueryExecuted $event)
     {
         $time = $event->time;
+        $source = $this->getSource();
 
         Telescope::recordQuery(IncomingEntry::make([
             'connection' => $event->connectionName,
@@ -35,6 +44,7 @@ class QueryWatcher extends Watcher
             'sql' => $event->sql,
             'time' => number_format($time, 2),
             'slow' => isset($this->options['slow']) && $time >= $this->options['slow'],
+            'source' => $source,
         ])->tags($this->tags($event)));
     }
 
@@ -58,5 +68,90 @@ class QueryWatcher extends Watcher
     protected function formatBindings($event)
     {
         return $event->connection->prepareBindings($event->bindings);
+    }
+
+    /**
+     * Get the query source from the backtrace.
+     *
+     * @return array
+     */
+    protected function getSource()
+    {
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 50);
+
+        return array_values(array_filter(array_map([$this, 'parseTrace'], $trace)));
+    }
+
+    /**
+     * Parse the backtrace.
+     *
+     * @param  array  $trace
+     * @return array|null
+     */
+    protected function parseTrace(array $trace)
+    {
+        if (! isset($trace['class']) || ! isset($trace['file']) || $this->fileIsInExcludedPath($trace['file'])) {
+            return null;
+        }
+
+        if (strpos($trace['file'], storage_path()) !== false) {
+            $hash = pathinfo($trace['file'], PATHINFO_FILENAME);
+            $file = $this->findViewFromHash($hash) ?: $hash;
+        } else {
+            $file = file_exists($trace['file']) ? realpath($trace['file']) : $trace['file'];
+        }
+
+        return [
+            'file' => $file,
+            'line' => $trace['line'] ?? '?',
+        ];
+    }
+
+    /**
+     * Check if the given file is to be excluded from analysis
+     *
+     * @param string $file
+     * @return bool
+     */
+    protected function fileIsInExcludedPath($file)
+    {
+        $excludedPaths = [
+            '/vendor/laravel/framework/src/Illuminate/Database',
+            '/vendor/laravel/framework/src/Illuminate/Events',
+            '/vendor/laravel/telescope',
+        ];
+
+        $normalizedPath = str_replace('\\', '/', $file);
+        foreach ($excludedPaths as $excludedPath) {
+            if (strpos($normalizedPath, $excludedPath) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Find the view template name from the hash.
+     *
+     * @param  string $hash
+     * @return null|string
+     */
+    protected function findViewFromHash($hash)
+    {
+        $finder = app('view')->getFinder();
+
+        if (! isset($this->views)) {
+            $this->views = (new ReflectionClass($finder))->getProperty('views');
+            $this->views->setAccessible(true);
+        }
+
+        foreach ($this->views->getValue($finder) as $name => $path) {
+            if (sha1($path) === $hash || md5($path) === $hash) {
+                return $name;
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
This change shows the backtrace for queries as requested in #116.

<img width="946" alt="screen shot 2018-10-25 at 1 12 53 am" src="https://user-images.githubusercontent.com/5883755/47479745-ab8d7780-d7f3-11e8-80e5-e28efffe13fd.png">

<img width="945" alt="screen shot 2018-10-25 at 1 13 02 am" src="https://user-images.githubusercontent.com/5883755/47479747-ae886800-d7f3-11e8-8931-420d33917b6e.png">

Some of the PHP code is loosely derived from https://github.com/barryvdh/laravel-debugbar/blob/v3.2.0/src/DataCollector/QueryCollector.php
I can add an MIT notice if you believe it would be required.