### PR TITLE
Add env for TELESCOPE_DB_CONNECTION.

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -22,7 +22,7 @@ return [
 
     'storage' => [
         'database' => [
-            'connection' => env('DB_CONNECTION', 'mysql'),
+            'connection' => env('TELESCOPE_DB_CONNECTION', env('DB_CONNECTION', 'mysql')),
         ],
     ],
 


### PR DESCRIPTION
- This will allow telescope to use a separate DB connection aside from the main.
- This will also allow support for third party DB drivers that is not officially supported by Laravel. For my case, Oracle DB using my package [Laravel-OCI8](https://github.com/yajra/laravel-oci8).

Thanks!