### PR TITLE
Authenticatable interface does not have getKey()

### DIFF
--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -135,7 +135,7 @@ class IncomingEntry
             ],
         ]);
 
-        $this->tags(['Auth:'.$user->getKey()]);
+        $this->tags(['Auth:'.$user->getAuthIdentifier()]);
 
         return $this;
     }


### PR DESCRIPTION
As a continuation of https://github.com/laravel/telescope/issues/138 @themsaid fixed one of the calls on https://github.com/laravel/telescope/commit/2bf5b122e364a57f3da1cba3809b178d7f798f38 but this one was left behind.