### PR TITLE
Add "telescope.enabled" option

### DIFF
--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -22,8 +22,10 @@ class TelescopeServiceProvider extends ServiceProvider
         $this->registerMigrations();
         $this->registerPublishing();
 
-        Telescope::start($this->app);
-        Telescope::listenForStorageOpportunities($this->app);
+        if (config('telescope.enabled', true)) {
+            Telescope::start($this->app);
+            Telescope::listenForStorageOpportunities($this->app);
+        }
 
         $this->loadViewsFrom(
             __DIR__.'/../resources/views', 'telescope'


### PR DESCRIPTION
Disabling Telescope in production is quite annoying. This hidden config option that defaults to `true` would allow everything to be loaded (migrations, commands, views), but tracking can be disabled easily.

We might be able to use this in other places as well.