### PR TITLE
Get file and line number for database queries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,8 @@ You may use Composer to install Telescope into your Laravel project:
 
     composer require laravel/telescope
 
+> **Note:** Telescope requires Laravel 5.7+.
+
 After installing Horizon, publish its assets using the `telescope:install` Artisan command. After installing Telescope, you should also run the `migrate` command:
 
     php artisan telescope:install

--- a/resources/js/screens/queries/preview.vue
+++ b/resources/js/screens/queries/preview.vue
@@ -41,6 +41,13 @@
             </tr>
 
             <tr>
+                <td class="table-fit font-weight-bold">Location</td>
+                <td>
+                    {{slotProps.entry.content.file}}:{{slotProps.entry.content.line}}
+                </td>
+            </tr>
+
+            <tr>
                 <td class="table-fit font-weight-bold">Duration</td>
                 <td>
                     <span class="badge badge-danger font-weight-light" v-if="slotProps.entry.content.slow">


### PR DESCRIPTION
Inspired by Laravel Clockwork (https://github.com/itsgoingd/clockwork), this uses the backtrace to find the calling file & line number for the first frame in the trace outside of Telescope/Laravel.