### PR TITLE
[Coverage] Add EventWatcherTest and CommandWatcherTest

### DIFF
--- a/.travis.yaml
+++ b/.travis.yaml
@@ -1,0 +1,31 @@
+language: php
+
+env:
+  global:
+    - setup=stable
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.1
+    - php: 7.1
+      env: setup=lowest
+    - php: 7.2
+    - php: 7.2
+      env: setup=lowest
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+before_install:
+  - phpenv config-rm xdebug.ini || true
+  - travis_retry composer self-update
+
+install:
+  - if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-stable --no-suggest; fi
+  - if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-lowest --prefer-stable --no-suggest; fi
+
+script: vendor/bin/phpunit

--- a/tests/FeatureTestCase.php
+++ b/tests/FeatureTestCase.php
@@ -74,6 +74,13 @@ class FeatureTestCase extends TestCase
             ->give('testbench');
     }
 
+    protected function loadTelescopeEntries()
+    {
+        $this->terminateTelescope();
+
+        return EntryModel::all();
+    }
+
     public function terminateTelescope()
     {
         Telescope::store(app(EntriesRepository::class));

--- a/tests/FeatureTestCase.php
+++ b/tests/FeatureTestCase.php
@@ -22,6 +22,8 @@ class FeatureTestCase extends TestCase
         parent::setUp();
 
         TestResponse::macro('terminateTelescope', [$this, 'terminateTelescope']);
+
+        Telescope::flushEntries();
     }
 
     protected function tearDown()
@@ -75,14 +77,5 @@ class FeatureTestCase extends TestCase
     public function terminateTelescope()
     {
         Telescope::store(app(EntriesRepository::class));
-    }
-
-    protected function prepareDatabase()
-    {
-        Telescope::withoutRecording(function () {
-            $this->terminateTelescope();
-
-            EntryModel::query()->delete();
-        });
     }
 }

--- a/tests/Watchers/CommandWatcherTest.php
+++ b/tests/Watchers/CommandWatcherTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Laravel\Telescope\Tests\Watchers;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\Kernel;
+use Laravel\Telescope\Storage\EntryModel;
+use Laravel\Telescope\Tests\FeatureTestCase;
+use Laravel\Telescope\Watchers\CommandWatcher;
+
+class CommandWatcherTest extends FeatureTestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app->get('config')->set('telescope.watchers', [
+            CommandWatcher::class => true,
+        ]);
+    }
+
+    public function test_command_watcher_register_entry()
+    {
+        $this->app->get(Kernel::class)->registerCommand(new MyCommand);
+
+        $this->artisan('telescope:test-command');
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        self::assertSame('command', $entry->type);
+        self::assertSame('telescope:test-command', $entry->content['command']);
+        self::assertSame(0, $entry->content['exit_code']);
+    }
+}
+
+class MyCommand extends Command
+{
+    protected $signature = 'telescope:test-command';
+
+    public function handle()
+    {
+
+    }
+}

--- a/tests/Watchers/EventWatcherTest.php
+++ b/tests/Watchers/EventWatcherTest.php
@@ -32,10 +32,35 @@ class EventWatcherTest extends FeatureTestCase
         self::assertSame('event', $entry->type);
         self::assertSame(DummyEvent::class, $entry->content['name']);
     }
+
+    public function test_event_watcher_stores_payloads()
+    {
+        Event::listen(DummyEvent::class, function ($payload) {
+        });
+
+        event(new DummyEvent('Telescope', 'Laravel', 'PHP'));
+
+        $this->terminateTelescope();
+
+        $entry = EntryModel::query()->first();
+
+        self::assertSame('event', $entry->type);
+        self::assertSame(DummyEvent::class, $entry->content['name']);
+        self::assertArrayHasKey('data', $entry->content['payload']);
+        self::assertArraySubset(['Telescope', 'Laravel', 'PHP'], $entry->content['payload']['data']);
+
+    }
 }
 
 class DummyEvent
 {
+    public $data;
+
+    public function __construct(...$payload)
+    {
+        $this->data = $payload;
+    }
+
     public function handle()
     {
 

--- a/tests/Watchers/EventWatcherTest.php
+++ b/tests/Watchers/EventWatcherTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Laravel\Telescope\Tests\Watchers;
+
+use Illuminate\Support\Facades\Event;
+use Laravel\Telescope\Storage\EntryModel;
+use Laravel\Telescope\Tests\FeatureTestCase;
+use Laravel\Telescope\Watchers\EventWatcher;
+
+class EventWatcherTest extends FeatureTestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app->get('config')->set('telescope.watchers', [
+            EventWatcher::class => true,
+        ]);
+    }
+
+    public function test_event_watcher_registers_any_events()
+    {
+        Event::listen(DummyEvent::class, function ($payload) {
+        });
+
+        event(new DummyEvent);
+
+        $this->terminateTelescope();
+
+        $entry = EntryModel::query()->first();
+
+        self::assertSame('event', $entry->type);
+        self::assertSame(DummyEvent::class, $entry->content['name']);
+    }
+}
+
+class DummyEvent
+{
+    public function handle()
+    {
+
+    }
+}

--- a/tests/Watchers/QueryWatcherTest.php
+++ b/tests/Watchers/QueryWatcherTest.php
@@ -23,8 +23,6 @@ class QueryWatcherTest extends FeatureTestCase
 
     public function test_query_watcher_registers_database_queries()
     {
-        $this->prepareDatabase();
-
         $this->app->get('db')->table('telescope_entries')->count();
 
         $this->terminateTelescope();
@@ -39,8 +37,6 @@ class QueryWatcherTest extends FeatureTestCase
 
     public function test_query_watcher_can_tag_slow_queries()
     {
-        $this->prepareDatabase();
-
         $records = Collection::times(300, function () {
             return [
                 'tag' => str_random(),


### PR DESCRIPTION
- Added Travis CI basic file
- Added Event Watcher simple test
- Removed `prepareDatabase` in favor of flushing Telescope entries for each test.
- Added Command Watcher test

Somebody with write access to the repository would need to setup Travis integration.