### PR TITLE
Fixes Custom Namespacing Issues (#186)

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -2,11 +2,14 @@
 
 namespace Laravel\Telescope\Console;
 
-use Illuminate\Support\Str;
+use Illuminate\Console\DetectsApplicationNamespace;
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
 
 class InstallCommand extends Command
 {
+    use DetectsApplicationNamespace;
+
     /**
      * The name and signature of the console command.
      *
@@ -49,16 +52,24 @@ class InstallCommand extends Command
      */
     protected function registerTelescopeServiceProvider()
     {
+        $appNamespace = $this->getAppNamespace();
         $appConfig = file_get_contents(config_path('app.php'));
+        $serviceProvider = file_get_contents(app_path('Providers/TelescopeServiceProvider.php'));
 
-        if (Str::contains($appConfig, "App\Providers\TelescopeServiceProvider::class")) {
+        if (Str::contains($appConfig, $appNamespace . "Providers\TelescopeServiceProvider::class")) {
             return;
         }
 
         file_put_contents(config_path('app.php'), str_replace(
-            "App\\Providers\EventServiceProvider::class,".PHP_EOL,
-            "App\\Providers\EventServiceProvider::class,".PHP_EOL."        App\Providers\TelescopeServiceProvider::class,".PHP_EOL,
+            $appNamespace . "Providers\EventServiceProvider::class,".PHP_EOL,
+            $appNamespace . "Providers\EventServiceProvider::class,".PHP_EOL."        " . $appNamespace . "Providers\TelescopeServiceProvider::class,".PHP_EOL,
             $appConfig
+        ));
+
+        file_put_contents(app_path('Providers/TelescopeServiceProvider.php'), str_replace(
+            "namespace App\Providers;",
+            "namespace " . $appNamespace . "Providers;",
+            $serviceProvider
         ));
     }
 }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -56,19 +56,19 @@ class InstallCommand extends Command
         $appConfig = file_get_contents(config_path('app.php'));
         $serviceProvider = file_get_contents(app_path('Providers/TelescopeServiceProvider.php'));
 
-        if (Str::contains($appConfig, $appNamespace . "Providers\TelescopeServiceProvider::class")) {
+        if (Str::contains($appConfig, $appNamespace."Providers\TelescopeServiceProvider::class")) {
             return;
         }
 
         file_put_contents(config_path('app.php'), str_replace(
-            $appNamespace . "Providers\EventServiceProvider::class,".PHP_EOL,
-            $appNamespace . "Providers\EventServiceProvider::class,".PHP_EOL."        " . $appNamespace . "Providers\TelescopeServiceProvider::class,".PHP_EOL,
+            $appNamespace."Providers\EventServiceProvider::class,".PHP_EOL,
+            $appNamespace."Providers\EventServiceProvider::class,".PHP_EOL."        ".$appNamespace."Providers\TelescopeServiceProvider::class,".PHP_EOL,
             $appConfig
         ));
 
         file_put_contents(app_path('Providers/TelescopeServiceProvider.php'), str_replace(
             "namespace App\Providers;",
-            "namespace " . $appNamespace . "Providers;",
+            "namespace ".$appNamespace."Providers;",
             $serviceProvider
         ));
     }


### PR DESCRIPTION
Tested against a new Laravel Installation, all works fine

* Essentially carries over the `file_put_contents` method to the Service Provider as well.
* Replaces the namespace using the DetectsApplicationNamespace trait

