### PR TITLE
Removing Horizon Routes by default

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -128,7 +128,7 @@ class Telescope
     }
 
     /**
-     * Determine if the application is handling a request not originating from Telescope.
+     * Determine if the application is handling a request not originating from Telescope, or Horizon.
      *
      * @param  \Illuminate\Foundation\Application  $app
      * @return bool
@@ -138,7 +138,9 @@ class Telescope
         return ! $app->runningInConsole() && ! $app['request']->is(
             config('telescope.path').'*',
             'telescope-api*',
-            'vendor/telescope*'
+            'vendor/telescope*',
+            'horizon*',
+            'vendor/horizon*'
         );
     }
 


### PR DESCRIPTION
Fixes issue #101, as no one should ever need to inspect horizon requests (can't comment on Laravel Horizon Contribs)
Having it open query's the API every couple of seconds or so

The other option is that this can be placed in the Service Provider stub file, can re-submit if need be

