### PR TITLE
[1.0] Resubmitting #199 with explanation (Add telescopeApiPath to the root component)

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -49,7 +49,9 @@ new Vue({
                 confirmationCancel: null,
             },
 
-            autoLoadsNewEntries: localStorage.autoLoadsNewEntries === '1'
+            autoLoadsNewEntries: localStorage.autoLoadsNewEntries === '1',
+
+            telescopeApiPath : '/' + window.Telescope.path + '/telescope-api'
         }
     },
 

--- a/resources/js/components/IndexScreen.vue
+++ b/resources/js/components/IndexScreen.vue
@@ -104,7 +104,7 @@
 
         methods: {
             loadEntries(after){
-                axios.post('/' + Telescope.path + '/telescope-api/' + this.resource +
+                axios.post(`${this.$root.telescopeApiPath}/${this.resource}` +
                         '?tag=' + this.tag +
                         '&before=' + this.lastEntryIndex +
                         '&take=' + this.entriesPerRequest +
@@ -128,7 +128,7 @@
              */
             checkForNewEntries(){
                 this.newEntriesTimeout = setTimeout(() => {
-                    axios.post('/' + Telescope.path + '/telescope-api/' + this.resource +
+                    axios.post(`${this.$root.telescopeApiPath}/${this.resource}` +
                             '?tag=' + this.tag +
                             '&take=1' +
                             '&family_hash=' + this.familyHash
@@ -223,7 +223,7 @@
                     let uuids = _.chain(this.entries).filter(entry => entry.content.status === 'pending').map('id').value();
 
                     if (uuids.length) {
-                        axios.post('/' + Telescope.path + '/telescope-api/' + this.resource, {
+                        axios.post(`${this.$root.telescopeApiPath}/${this.resource}`, {
                             uuids: uuids
                         }).then(response => {
                             this.entries = _.map(this.entries, entry => {

--- a/resources/js/components/PreviewScreen.vue
+++ b/resources/js/components/PreviewScreen.vue
@@ -92,7 +92,7 @@
 
 
             loadEntry(after){
-                axios.get('/' + Telescope.path + '/telescope-api/' + this.resource + '/' + this.id).then(response => {
+                axios.get(`${this.$root.telescopeApiPath}/${this.resource}` + '/' + this.id).then(response => {
                     if (_.isFunction(after)) {
                         after(response);
                     }

--- a/resources/js/screens/dumps/index.vue
+++ b/resources/js/screens/dumps/index.vue
@@ -36,7 +36,7 @@
 
         methods: {
             loadEntries(){
-                axios.post('/' + Telescope.path + '/telescope-api/dumps').then(response => {
+                axios.post(this.$root.telescopeApiPath + '/dumps').then(response => {
                     this.entries = response.data.entries;
 
                     this.ready = true;

--- a/resources/js/screens/mail/preview.vue
+++ b/resources/js/screens/mail/preview.vue
@@ -79,13 +79,13 @@
             <tr>
                 <td class="table-fit font-weight-bold">Download</td>
                 <td>
-                    <a :href="'/' + Telescope.path + '/telescope-api/mail/'+$route.params.id+'/download'">Download .eml file</a>
+                    <a :href="$root.telescopeApiPath + '/mail/'+$route.params.id+'/download'">Download .eml file</a>
                 </td>
             </tr>
         </template>
 
         <div slot="after-attributes-card" slot-scope="slotProps" class="mt-5">
-            <iframe :src="'/' + Telescope.path + '/telescope-api/mail/'+$route.params.id+'/preview'" width="100%" height="400"></iframe>
+            <iframe :src="$root.telescopeApiPath + '/mail/'+$route.params.id+'/preview'" width="100%" height="400"></iframe>
         </div>
     </preview-screen>
 </template>

--- a/resources/js/screens/monitoring/index.vue
+++ b/resources/js/screens/monitoring/index.vue
@@ -21,7 +21,7 @@
             document.title = "Monitoring - Telescope";
 
 
-            axios.get('/' + Telescope.path + '/telescope-api/monitored-tags').then(response => {
+            axios.get(this.$root.telescopeApiPath + '/monitored-tags').then(response => {
                 this.tags = response.data.tags;
 
                 this.ready = true;
@@ -34,7 +34,7 @@
                 this.alertConfirm('Are you sure you want to remove this tag?', ()=> {
                     this.tags = _.reject(this.tags, t => t === tag);
 
-                    axios.post('/' + Telescope.path + '/telescope-api/monitored-tags/delete', {tag: tag});
+                    axios.post(this.$root.telescopeApiPath + '/monitored-tags/delete', {tag: tag});
                 });
             },
 
@@ -56,7 +56,7 @@
              */
             monitorNewTag(){
                 if (this.newTag.length) {
-                    axios.post('/' + Telescope.path + '/telescope-api/monitored-tags', {tag: this.newTag});
+                    axios.post(this.$root.telescopeApiPath + '/monitored-tags', {tag: this.newTag});
 
                     this.tags.push(this.newTag);
                 }


### PR DESCRIPTION
this **PR** , extracts the repeated ```'/' + Telescope.path + '/telescope-api/' ``` across axios requests & href values to a **data property** in the **root Vue instance** called ```telescopeApiPath```

 i thought in case the **Telescope window object** changed the **path** property name or in case the ```/telescope-api``` changed , so there will be only one abstracted place called **telescopeApiPath** where our changes can be reflected to different axios calls or href values  from single place