### PR TITLE
Emit ready event from PreviewScreen

### DIFF
--- a/resources/js/components/PreviewScreen.vue
+++ b/resources/js/components/PreviewScreen.vue
@@ -76,6 +76,14 @@
         methods: {
             prepareEntry() {
                 document.title = this.title + " - Telescope";
+                this.ready = false;
+
+                let unwatch = this.$watch('ready', newVal => {
+                    if (newVal) {
+                        this.$emit('ready');
+                        unwatch();
+                    }
+                });
 
                 this.loadEntry((response) => {
                     this.entry = response.data.entry;

--- a/resources/js/screens/queries/preview.vue
+++ b/resources/js/screens/queries/preview.vue
@@ -12,18 +12,17 @@
             };
         },
 
-        mounted(){
-           setTimeout(() => {
-               hljs.registerLanguage('sql', sql);
-
-               hljs.highlightBlock(this.$refs.sqlcode);
-           }, 500);
-        },
-
         methods:{
             formatSQL(sql, params) {
                 return sqlFormatter.format(sql, {
                     params: _.map(params, param => _.isString(param) ? '"'+param+'"' : param)
+                });
+            },
+
+            highlightSQL() {
+                this.$nextTick(() => {
+                    hljs.registerLanguage('sql', sql);
+                    hljs.highlightBlock(this.$refs.sqlcode);
                 });
             }
         }
@@ -31,7 +30,7 @@
 </script>
 
 <template>
-    <preview-screen title="Query Details" resource="queries" :id="$route.params.id">
+    <preview-screen title="Query Details" resource="queries" :id="$route.params.id" v-on:ready="highlightSQL()">
         <template slot="table-parameters" slot-scope="slotProps">
             <tr>
                 <td class="table-fit font-weight-bold">Connection</td>


### PR DESCRIPTION
This makes it so the PreviewScreen component emits a ready event when it is ready. Other components (currently the query preview screen) can listen for it to know when the child component is ready. This is more reliable and better for the user experience than waiting an arbitrary amount of time, after which the child component might not be ready.