### PR TITLE
[1.0] Added `export-ignore` flag;

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,7 @@
 
 .gitattributes export-ignore
 .gitignore export-ignore
+/tests export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore
+phpstan.neon.dist export-ignore


### PR DESCRIPTION
 - added `export-ignore` to `/tests` / `.travis.yml` / `phpunit.xml.dist` / `phpstan.neon.dist`.

Since no reason for export this 