### PR TITLE
[Test Coverage] Add test for DatabaseEntriesRepository::find

### DIFF
--- a/src/Storage/EntryModel.php
+++ b/src/Storage/EntryModel.php
@@ -44,6 +44,13 @@ class EntryModel extends Model
     protected $keyType = 'string';
 
     /**
+     * Prevent Eloquent from overriding uuid with `lastInsertId`
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
      * Scope the query for the given query options.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query

--- a/src/Storage/factories/EntryModelFactory.php
+++ b/src/Storage/factories/EntryModelFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+use Laravel\Telescope\EntryType;
+use Laravel\Telescope\Storage\EntryModel;
+
+/**
+ * @var \Illuminate\Database\Eloquent\Factory $factory
+ */
+
+$factory->define(EntryModel::class, function (Faker\Generator $faker) {
+    return [
+        'sequence' => random_int(1, 10000),
+        'uuid' => $faker->uuid,
+        'batch_id' => $faker->uuid,
+        'type' => $faker->randomElement([
+            EntryType::CACHE, EntryType::COMMAND, EntryType::DUMP, EntryType::EVENT, EntryType::EXCEPTION,
+            EntryType::JOB, EntryType::LOG, EntryType::MAIL, EntryType::MODEL, EntryType::NOTIFICATION,
+            EntryType::QUERY, EntryType::REDIS, EntryType::REQUEST, EntryType::SCHEDULED_TASK,
+        ]),
+        'content' => [$faker->word => $faker->word],
+    ];
+});

--- a/tests/Storage/DatabaseEntriesRepositoryTest.php
+++ b/tests/Storage/DatabaseEntriesRepositoryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Laravel\Telescope\Tests\Storage;
+
+use Laravel\Telescope\Storage\DatabaseEntriesRepository;
+use Laravel\Telescope\Storage\EntryModel;
+use Laravel\Telescope\Tests\FeatureTestCase;
+
+class DatabaseEntriesRepositoryTest extends FeatureTestCase
+{
+    public function test_find_entry_by_uuid()
+    {
+        $this->loadFactoriesUsing($this->app, __DIR__ . '/../../src/Storage/factories');
+
+        $entry = factory(EntryModel::class)->create();
+
+        $repository = new DatabaseEntriesRepository('testbench');
+
+        $result = $repository->find($entry->uuid)->jsonSerialize();
+
+        self::assertSame($entry->uuid, $result['id']);
+        self::assertSame($entry->batch_id, $result['batch_id']);
+        self::assertSame($entry->type, $result['type']);
+        self::assertSame($entry->content, $result['content']);
+
+        // Why is sequence always null? DatabaseEntriesRepository::class#L60
+        self::assertNull($result['sequence']);
+    }
+}


### PR DESCRIPTION
While working on a test for the `DatabaseEntriesRepository::find` method, I wrote the `EntryModelFactory` and noticed that the field `uuid` was not working. It turns out that when performing an insert with Eloquent, if the model has `incrementing` set to `true` it will automatically use the `LAST_INSERTED_ID()` to set into the `keyName()` field. I fixed that by setting the `incrementing` to `false` so the correct `uuid` would stay in place.