### PR TITLE
disable debugbar in mail preview if exists

### DIFF
--- a/src/Http/Controllers/MailHtmlController.php
+++ b/src/Http/Controllers/MailHtmlController.php
@@ -16,6 +16,10 @@ class MailHtmlController extends Controller
      */
     public function show(EntriesRepository $storage, $id)
     {
+        if (class_exists('Debugbar')) {
+            \Debugbar::disable();
+        }
+
         return $storage->find($id)->content['html'];
     }
 }


### PR DESCRIPTION
The debug bar is displayed in the mail preview if it is installed. This doesn't make much sense in my opinion.

This PR will disable the Debugbar if it does exist for the mail preview request.