### PR TITLE
[1.0] Fix model watcher exception for models with composite keys

### DIFF
--- a/src/Watchers/ModelWatcher.php
+++ b/src/Watchers/ModelWatcher.php
@@ -32,7 +32,7 @@ class ModelWatcher extends Watcher
             return;
         }
 
-        $model = get_class($data[0]).':'.$data[0]->getKey();
+        $model = get_class($data[0]) . ':' . implode('_', (array) $data[0]->getKey());
 
         $changes = $data[0]->getChanges();
 


### PR DESCRIPTION
Was throwing `Array to string conversion`.