### PR TITLE
Use uuid for uuid

### DIFF
--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -2,60 +2,60 @@
 
 // Mail entries...
 Route::post('/telescope-api/mail', 'MailController@index');
-Route::get('/telescope-api/mail/{id}', 'MailController@show');
-Route::get('/telescope-api/mail/{id}/preview', 'MailHtmlController@show');
-Route::get('/telescope-api/mail/{id}/download', 'MailEmlController@show');
+Route::get('/telescope-api/mail/{uuid}', 'MailController@show');
+Route::get('/telescope-api/mail/{uuid}/preview', 'MailHtmlController@show');
+Route::get('/telescope-api/mail/{uuid}/download', 'MailEmlController@show');
 
 // Exception entries...
 Route::post('/telescope-api/exceptions', 'ExceptionController@index');
-Route::get('/telescope-api/exceptions/{id}', 'ExceptionController@show');
+Route::get('/telescope-api/exceptions/{uuid}', 'ExceptionController@show');
 
 // Dump entries...
 Route::post('/telescope-api/dumps', 'DumpController@index');
 
 // Log entries...
 Route::post('/telescope-api/logs', 'LogController@index');
-Route::get('/telescope-api/logs/{id}', 'LogController@show');
+Route::get('/telescope-api/logs/{uuid}', 'LogController@show');
 
 // Notifications entries...
 Route::post('/telescope-api/notifications', 'NotificationsController@index');
-Route::get('/telescope-api/notifications/{id}', 'NotificationsController@show');
+Route::get('/telescope-api/notifications/{uuid}', 'NotificationsController@show');
 
 // Queue entries...
 Route::post('/telescope-api/jobs', 'QueueController@index');
-Route::get('/telescope-api/jobs/{id}', 'QueueController@show');
+Route::get('/telescope-api/jobs/{uuid}', 'QueueController@show');
 
 // Events entries...
 Route::post('/telescope-api/events', 'EventsController@index');
-Route::get('/telescope-api/events/{id}', 'EventsController@show');
+Route::get('/telescope-api/events/{uuid}', 'EventsController@show');
 
 // Cache entries...
 Route::post('/telescope-api/cache', 'CacheController@index');
-Route::get('/telescope-api/cache/{id}', 'CacheController@show');
+Route::get('/telescope-api/cache/{uuid}', 'CacheController@show');
 
 // Queries entries...
 Route::post('/telescope-api/queries', 'QueriesController@index');
-Route::get('/telescope-api/queries/{id}', 'QueriesController@show');
+Route::get('/telescope-api/queries/{uuid}', 'QueriesController@show');
 
 // Eloquent entries...
 Route::post('/telescope-api/models', 'ModelsController@index');
-Route::get('/telescope-api/models/{id}', 'ModelsController@show');
+Route::get('/telescope-api/models/{uuid}', 'ModelsController@show');
 
 // Requests entries...
 Route::post('/telescope-api/requests', 'RequestsController@index');
-Route::get('/telescope-api/requests/{id}', 'RequestsController@show');
+Route::get('/telescope-api/requests/{uuid}', 'RequestsController@show');
 
 // Artisan Commands entries...
 Route::post('/telescope-api/commands', 'CommandsController@index');
-Route::get('/telescope-api/commands/{id}', 'CommandsController@show');
+Route::get('/telescope-api/commands/{uuid}', 'CommandsController@show');
 
 // Scheduled Commands entries...
 Route::post('/telescope-api/schedule', 'ScheduleController@index');
-Route::get('/telescope-api/schedule/{id}', 'ScheduleController@show');
+Route::get('/telescope-api/schedule/{uuid}', 'ScheduleController@show');
 
 // Redis Commands entries...
 Route::post('/telescope-api/redis', 'RedisController@index');
-Route::get('/telescope-api/redis/{id}', 'RedisController@show');
+Route::get('/telescope-api/redis/{uuid}', 'RedisController@show');
 
 // Monitored Tags...
 Route::get('/telescope-api/monitored-tags', 'MonitoredTagController@index');


### PR DESCRIPTION
Hi,

I'm using this pattern on my apps and it broke telescope : 
`Route::pattern('id', '\d+');`

Since telescope use uuid wich should be matched by : 
`Route::pattern('uuid', '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}');`