### PR TITLE
Added ClearCommand to clear all Telescope entries

### DIFF
--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Laravel\Telescope\Console;
+
+use Illuminate\Console\Command;
+use Laravel\Telescope\Contracts\EntriesRepository;
+
+class ClearCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'telescope:clear';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clear all entries from Telescope';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
+     * @return void
+     */
+    public function handle(EntriesRepository $storage)
+    {
+        $storage->clear();
+        $this->info('Telescope entries cleared!');
+    }
+}

--- a/src/Contracts/EntriesRepository.php
+++ b/src/Contracts/EntriesRepository.php
@@ -51,6 +51,13 @@ interface EntriesRepository
     public function pruneEntries($type, $limit);
 
     /**
+     * Clear all the entries.
+     *
+     * @return void
+     */
+    public function clear();
+
+    /**
      * Determine if any of the given tags are currently being monitored.
      *
      * @param  array  $tags

--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -296,6 +296,17 @@ class DatabaseEntriesRepository implements Contract, PrunableRepository, Termina
     }
 
     /**
+     * Clear all the entries.
+     *
+     * @return void
+     */
+    public function clear()
+    {
+        $this->table('telescope_entries')
+            ->delete();
+    }
+
+    /**
      * Perform any clean-up tasks needed after storing Telescope entries.
      *
      * @return void

--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -303,7 +303,7 @@ class DatabaseEntriesRepository implements Contract, PrunableRepository, Termina
     public function clear()
     {
         $this->table('telescope_entries')
-            ->delete();
+            ->truncate();
     }
 
     /**

--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -106,6 +106,7 @@ class TelescopeServiceProvider extends ServiceProvider
         $this->commands([
             Console\InstallCommand::class,
             Console\PruneCommand::class,
+            Console\ClearCommand::class,
         ]);
     }
 


### PR DESCRIPTION
This PR adds a `ClearCommand` console command class to clear all Telescope entries. It's useful to clear all Telescope entries, perform an action and then view fresh entries to debug applications. This command will enable clearing all entries.

Fixes #20. Although the issue also mentions disabling logs for some time / pausing logs, this PR only addresses clearing logs.