### PR TITLE
Update 2018_08_08_100000_create_telescope_entries_table.php

### DIFF
--- a/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -32,6 +32,10 @@ class CreateTelescopeEntriesTable extends Migration
      */
     public function up()
     {
+        $this->schema->create('telescope_monitoring', function (Blueprint $table) {
+            $table->string('tag');
+        });
+        
         $this->schema->create('telescope_entries', function (Blueprint $table) {
             $table->bigIncrements('sequence');
             $table->uuid('uuid');
@@ -58,10 +62,6 @@ class CreateTelescopeEntriesTable extends Migration
                   ->references('uuid')
                   ->on('telescope_entries')
                   ->onDelete('cascade');
-        });
-
-        $this->schema->create('telescope_monitoring', function (Blueprint $table) {
-            $table->string('tag');
         });
     }
 


### PR DESCRIPTION
env:
Mysql:8.x
laravel:5.7.11

```
Migrating: 2018_08_02_123029_create_card_discounts_table

   Illuminate\Database\QueryException  : SQLSTATE[42S02]: Base table or view not found: 1146 Table 'hk8591.h8_telescope_monitoring' doesn't exist (SQL: select `tag` from `h8_telescope_monitoring`)

  at /Users/linji/gitroot/hk8591/api/vendor/laravel/framework/src/Illuminate/Database/Connection.php:664
    660|         // If an exception occurs when attempting to run a query, we'll format the error
    661|         // message to include the bindings with SQL, which will make this exception a
    662|         // lot more helpful to the developer instead of just the database's errors.
    663|         catch (Exception $e) {
  > 664|             throw new QueryException(
    665|                 $query, $this->prepareBindings($bindings), $e
    666|             );
    667|         }
    668| 

  Exception trace:

  1   Doctrine\DBAL\Driver\PDOException::("SQLSTATE[42S02]: Base table or view not found: 1146 Table 'hk8591.h8_telescope_monitoring' doesn't exist")
      /Users/linji/gitroot/hk8591/api/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php:82

  2   PDOException::("SQLSTATE[42S02]: Base table or view not found: 1146 Table 'hk8591.h8_telescope_monitoring' doesn't exist")
      /Users/linji/gitroot/hk8591/api/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php:80

  Please use the argument -v to see more details.
```
