### PR TITLE
[Coverage] Test Case for Clear Command

### DIFF
--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -3,7 +3,7 @@
 namespace Laravel\Telescope\Console;
 
 use Illuminate\Console\Command;
-use Laravel\Telescope\Contracts\EntriesRepository;
+use Laravel\Telescope\Contracts\ClearableRepository;
 
 class ClearCommand extends Command
 {
@@ -24,10 +24,10 @@ class ClearCommand extends Command
     /**
      * Execute the console command.
      *
-     * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
+     * @param  \Laravel\Telescope\Contracts\ClearableRepository  $storage
      * @return void
      */
-    public function handle(EntriesRepository $storage)
+    public function handle(ClearableRepository $storage)
     {
         $storage->clear();
 

--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -4,6 +4,7 @@ namespace Laravel\Telescope;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Telescope\Contracts\ClearableRepository;
 use Laravel\Telescope\Contracts\EntriesRepository;
 use Laravel\Telescope\Storage\DatabaseEntriesRepository;
 
@@ -133,6 +134,10 @@ class TelescopeServiceProvider extends ServiceProvider
     {
         $this->app->singleton(
             EntriesRepository::class, DatabaseEntriesRepository::class
+        );
+
+        $this->app->singleton(
+            ClearableRepository::class, DatabaseEntriesRepository::class
         );
 
         $this->app->when(DatabaseEntriesRepository::class)

--- a/tests/Console/ClearCommandTest.php
+++ b/tests/Console/ClearCommandTest.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace Laravel\Telescope\Tests\Console;
+
+use Illuminate\Support\Facades\DB;
+use Laravel\Telescope\Storage\EntryModel;
+use Laravel\Telescope\Tests\FeatureTestCase;
+
+class ClearCommandTest extends FeatureTestCase
+{
+    public function test_clear_command_will_delete_all_entries()
+    {
+        $this->loadFactoriesUsing($this->app, __DIR__ . '/../../src/Storage/factories');
+
+        factory(EntryModel::class)->create();
+
+        DB::table('telescope_monitoring')->insert([
+            ['tag' => 'one'],
+            ['tag' => 'two'],
+        ]);
+
+        $this->artisan('telescope:clear');
+
+        self::assertSame(0, EntryModel::query()->count());
+        self::assertSame(0, DB::table('telescope_monitoring')->count());
+    }
+}


### PR DESCRIPTION
While writing the Test Case for ClearCommand I noticed that the type-hint interface does not have the `clear()` method. 