### PR TITLE
TestCase to cover Prune command

### DIFF
--- a/src/Console/PruneCommand.php
+++ b/src/Console/PruneCommand.php
@@ -3,7 +3,7 @@
 namespace Laravel\Telescope\Console;
 
 use Illuminate\Console\Command;
-use Laravel\Telescope\Contracts\EntriesRepository;
+use Laravel\Telescope\Contracts\PrunableRepository;
 
 class PruneCommand extends Command
 {
@@ -27,10 +27,8 @@ class PruneCommand extends Command
      * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
      * @return void
      */
-    public function handle(EntriesRepository $storage)
+    public function handle(PrunableRepository $storage)
     {
-        if (method_exists($storage, 'prune')) {
-            $this->info($storage->prune(now()->subHours(24)).' entries pruned.');
-        }
+        $this->info($storage->prune(now()->subHours(24)).' entries pruned.');
     }
 }

--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -5,6 +5,7 @@ namespace Laravel\Telescope;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Telescope\Contracts\EntriesRepository;
+use Laravel\Telescope\Contracts\PrunableRepository;
 use Laravel\Telescope\Storage\DatabaseEntriesRepository;
 
 class TelescopeServiceProvider extends ServiceProvider
@@ -133,6 +134,10 @@ class TelescopeServiceProvider extends ServiceProvider
     {
         $this->app->singleton(
             EntriesRepository::class, DatabaseEntriesRepository::class
+        );
+
+        $this->app->singleton(
+            PrunableRepository::class, DatabaseEntriesRepository::class
         );
 
         $this->app->when(DatabaseEntriesRepository::class)

--- a/tests/Console/PruneCommandTest.php
+++ b/tests/Console/PruneCommandTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Laravel\Telescope\Tests\Console;
+
+use Laravel\Telescope\Storage\EntryModel;
+use Laravel\Telescope\Tests\FeatureTestCase;
+
+class PruneCommandTest extends FeatureTestCase
+{
+    public function test_prune_command_will_clear_old_records()
+    {
+        $this->loadFactoriesUsing($this->app, __DIR__ . '/../../src/Storage/factories');
+
+        $recent = factory(EntryModel::class)->create(['created_at' => now()]);
+
+        $old = factory(EntryModel::class)->create(['created_at' => now()->subDays(2)]);
+
+        $this->artisan('telescope:prune')->expectsOutput('1 entries pruned.');
+
+        $this->assertDatabaseHas('telescope_entries', ['uuid' => $recent->uuid]);
+
+        $this->assertDatabaseMissing('telescope_entries', ['uuid' => $old->uuid]);
+    }
+}


### PR DESCRIPTION
Similar to #255, instead of relying on the wrong interface and checking for method existence, we can just bind the interface into the container and rely on the correct interface. 