### PR TITLE
[1.0] Fix PruneCommand contract

### DIFF
--- a/src/Console/PruneCommand.php
+++ b/src/Console/PruneCommand.php
@@ -3,7 +3,7 @@
 namespace Laravel\Telescope\Console;
 
 use Illuminate\Console\Command;
-use Laravel\Telescope\Contracts\EntriesRepository;
+use Laravel\Telescope\Contracts\PrunableRepository;
 
 class PruneCommand extends Command
 {
@@ -24,10 +24,10 @@ class PruneCommand extends Command
     /**
      * Execute the console command.
      *
-     * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
+     * @param  \Laravel\Telescope\Contracts\PrunableRepository  $storage
      * @return void
      */
-    public function handle(EntriesRepository $storage)
+    public function handle(PrunableRepository $storage)
     {
         $this->info($storage->prune(now()->subHours(24)).' entries pruned.');
     }

--- a/src/Console/PruneCommand.php
+++ b/src/Console/PruneCommand.php
@@ -24,11 +24,11 @@ class PruneCommand extends Command
     /**
      * Execute the console command.
      *
-     * @param  \Laravel\Telescope\Contracts\PrunableRepository  $storage
+     * @param  \Laravel\Telescope\Contracts\PrunableRepository  $repository
      * @return void
      */
-    public function handle(PrunableRepository $storage)
+    public function handle(PrunableRepository $repository)
     {
-        $this->info($storage->prune(now()->subHours(24)).' entries pruned.');
+        $this->info($repository->prune(now()->subHours(24)).' entries pruned.');
     }
 }

--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -5,6 +5,7 @@ namespace Laravel\Telescope;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Telescope\Contracts\EntriesRepository;
+use Laravel\Telescope\Contracts\PrunableRepository;
 use Laravel\Telescope\Storage\DatabaseEntriesRepository;
 
 class TelescopeServiceProvider extends ServiceProvider
@@ -133,6 +134,10 @@ class TelescopeServiceProvider extends ServiceProvider
     {
         $this->app->singleton(
             EntriesRepository::class, DatabaseEntriesRepository::class
+        );
+
+        $this->app->singleton(
+            PrunableRepository::class, DatabaseEntriesRepository::class
         );
 
         $this->app->when(DatabaseEntriesRepository::class)


### PR DESCRIPTION
The PruneCommand relies on the `EntriesRepository`, which does not have the `prune` method. Moreover, if the developer tries to swap the `PrunableRepository` in the container, it wouldn't work because of the wrong type-hint.

This Pull Request changes the contract being used by the PruneCommand to rely on the correct contract.