### PR TITLE
[1.0] Fix ClearCommand contract

### DIFF
--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -3,7 +3,7 @@
 namespace Laravel\Telescope\Console;
 
 use Illuminate\Console\Command;
-use Laravel\Telescope\Contracts\EntriesRepository;
+use Laravel\Telescope\Contracts\ClearableRepository;
 
 class ClearCommand extends Command
 {
@@ -24,10 +24,10 @@ class ClearCommand extends Command
     /**
      * Execute the console command.
      *
-     * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
+     * @param  \Laravel\Telescope\Contracts\ClearableRepository  $storage
      * @return void
      */
-    public function handle(EntriesRepository $storage)
+    public function handle(ClearableRepository $storage)
     {
         $storage->clear();
 

--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -4,6 +4,7 @@ namespace Laravel\Telescope;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Telescope\Contracts\ClearableRepository;
 use Laravel\Telescope\Contracts\EntriesRepository;
 use Laravel\Telescope\Storage\DatabaseEntriesRepository;
 
@@ -133,6 +134,10 @@ class TelescopeServiceProvider extends ServiceProvider
     {
         $this->app->singleton(
             EntriesRepository::class, DatabaseEntriesRepository::class
+        );
+
+        $this->app->singleton(
+            ClearableRepository::class, DatabaseEntriesRepository::class
         );
 
         $this->app->when(DatabaseEntriesRepository::class)


### PR DESCRIPTION
The ClearCommand relies on the `EntriesRepository` contract, which does not offer the method `clear()`. Moreover, if the developer tries to swap the `ClearableRepository` on the container, it will not take effect on the ClearCommand.

This pull request fixes the contract that ClearCommand uses so it can be correctly swapped.