### PR TITLE
[1.0] Increase Query Watcher slow query settings

### DIFF
--- a/tests/Watchers/QueryWatcherTest.php
+++ b/tests/Watchers/QueryWatcherTest.php
@@ -16,7 +16,7 @@ class QueryWatcherTest extends FeatureTestCase
         $app->get('config')->set('telescope.watchers', [
             QueryWatcher::class => [
                 'enabled' => true,
-                'slow' => 0.1,
+                'slow' => 0.2,
             ],
         ]);
     }


### PR DESCRIPTION
The test on https://travis-ci.org/laravel/telescope/jobs/448360991 failed because it took longer than 0.1 second to run a database query. That was not an actual failure but rather a lack of speed on the CPU that executed the test.

This Pull Request increases from 0.1 to 0.2 seconds the configuration for slow query in order to try and avoid more false positives.