### PR TITLE
Fix: Assets not loading when Laravel is installed in a subdirectory

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -12,9 +12,9 @@
     <!-- Style sheets-->
     <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet">
     @if(\Laravel\Telescope\Telescope::$useDarkTheme)
-        <link href='{{mix('app-dark.css', 'vendor/telescope')}}' rel='stylesheet' type='text/css'>
+        <link href='{{asset(mix('app-dark.css', 'vendor/telescope'))}}' rel='stylesheet' type='text/css'>
     @else
-        <link href='{{mix('app.css', 'vendor/telescope')}}' rel='stylesheet' type='text/css'>
+        <link href='{{asset(mix('app.css', 'vendor/telescope'))}}' rel='stylesheet' type='text/css'>
     @endif
 </head>
 <body>
@@ -182,6 +182,6 @@
     )); ?>;
 </script>
 
-<script src="{{mix('app.js', 'vendor/telescope')}}"></script>
+<script src="{{asset(mix('app.js', 'vendor/telescope'))}}"></script>
 </body>
 </html>


### PR DESCRIPTION
I encountered this problem while trying to run Laravel telescope in a subdirectory (e.g localhost/laravel/public/telescope). Apparently, the assets are being called from the root directory (/), not from the public path.

## Steps to reproduce
Install Laravel in a subdirectory:

```
cd /var/www/ # or whatever your root directory is
laravel new telescope-test
cd telescope-test
php artisan key:generate
composer require laravel/telescope --dev
php artisan telescope:install
# connect to a database here and then run
php artisan migrate
```

You should see this:

![selection_104](https://user-images.githubusercontent.com/2019162/47743025-62ef1780-dc54-11e8-919a-c548289a503c.png)

## The fix

If we use the asset function to get the asset URL with mix, the full URL will be called, and then we should see this:

![selection_105](https://user-images.githubusercontent.com/2019162/47743112-a0ec3b80-dc54-11e8-8b6c-78916703a439.png)

