### PR TITLE
Fix: front-end not working when Laravel is installed in a subdirectory

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -542,8 +542,15 @@ class Telescope
      */
     public static function scriptVariables()
     {
+        $document_root = rtrim($_SERVER['DOCUMENT_ROOT'], '/');
+        $path = str_replace($document_root, '', public_path());
+        $path = ltrim($path, '/');
+        if ($path) {
+            $path .= '/';
+        }
+
         return [
-            'path' => config('telescope.path'),
+            'path' => $path . config('telescope.path'),
             'timezone' => config('app.timezone')
         ];
     }


### PR DESCRIPTION
After my pull request #272 I found out that the routes in vue-route were also pointing at /telescope (in the root directory), so anytime I clicked on something, it just showed me a 404 error. I fixed this again after hours of experimenting, and after testing, it works when:

- Laravel is installed in the DOCUMENT_ROOT directory
- Laravel is installed in a subdirectory
- Laravel is called from a subdomain

I can finally use it in peace.

![image](https://user-images.githubusercontent.com/2019162/47764083-03b3f600-dc9a-11e8-8054-a197d505fbb6.png)
![image](https://user-images.githubusercontent.com/2019162/47764126-352cc180-dc9a-11e8-8e16-409ea2fd937d.png)

Hope this is useful. 