### PR TITLE
shouldListen method modelWatcher.php

### DIFF
--- a/src/Watchers/ModelWatcher.php
+++ b/src/Watchers/ModelWatcher.php
@@ -28,7 +28,7 @@ class ModelWatcher extends Watcher
      */
     public function recordAction($event, $data)
     {
-        if ($this->shouldIgnore($event)) {
+        if (!$this->shouldListen($event)) {
             return;
         }
 
@@ -62,11 +62,10 @@ class ModelWatcher extends Watcher
      * @param  string  $eventName
      * @return bool
      */
-    private function shouldIgnore($eventName)
+    private function shouldListen($eventName)
     {
         return Str::is([
-            '*booting*', '*booted*', '*creating*', '*retrieved*', '*updating*',
-            '*saving*', '*saved*', '*restoring*', '*deleting*'
+            '*created*', '*updated*', '*restored*', '*deleted*'
         ], $eventName);
     }
 }


### PR DESCRIPTION
- changed `shouldIgnore` method to `shouldListen`, and updated the array of accepted model events
- 3rd party packages such as [this](https://github.com/fico7489/laravel-pivot/blob/master/src/Traits/ExtendFireModelEventTrait.php#L37) register additional events onto the event dispatched prepended with `eloquent.` 
-`ModelWatcher.php` listens to these additional events, and errs since the structure of the event payloads differ

closes #187 