### PR TITLE
fixed request watcher overflow for large response payloads

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -71,7 +71,10 @@ return [
         ],
 
         Watchers\RedisWatcher::class => env('TELESCOPE_REDIS_WATCHER', true),
-        Watchers\RequestWatcher::class => env('TELESCOPE_REQUEST_WATCHER', true),
+        Watchers\RequestWatcher::class => [
+            'enabled' => env('TELESCOPE_REQUEST_WATCHER', true),
+            'response_purge_size' => env('TELESCOPE_RESPONSE_PURGE_SIZE_KB', 64),
+        ],
         Watchers\ScheduleWatcher::class => env('TELESCOPE_SCHEDULE_WATCHER', true),
     ],
 ];

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -82,6 +82,12 @@ class RequestWatcher extends Watcher
         if (is_string($response->getContent()) &&
             is_array(json_decode($response->getContent(), true)) &&
             json_last_error() === JSON_ERROR_NONE) {
+            $purgeLimit = isset($this->options['response_purge_size']) ?
+                            intval($this->options['response_purge_size']) : 64;
+            if (($size = strlen($response->getContent()) / 1000) > $purgeLimit) {
+                return 'Response purged (' . round($size) . ' KB)';
+            }
+
             return json_decode($response->getContent(), true);
         }
 


### PR DESCRIPTION
This PR fixes #166 and #228. Large response payloads currently throw an SQL exception due to the size exceeding the `content` column's max length and due to this exception, entries for all watchers are missed. 

This PR purges response payloads beyond a size limit that can be specified as an option to the `RequestWatcher`. This is a non-breaking change.