### PR TITLE
[1.0] Add decoding uri params for get requests in requests index screen

### DIFF
--- a/resources/js/screens/requests/index.vue
+++ b/resources/js/screens/requests/index.vue
@@ -1,10 +1,18 @@
 <script type="text/ecmascript-6">
     import StylesMixin from './../../mixins/entriesStyles';
+    import $ from 'jquery';
 
     export default {
         mixins: [
             StylesMixin,
         ],
+
+        methods: {
+            uri({method, payload, uri}) {
+                const decodedUri = method.toUpperCase() === 'GET' && Object.keys(payload).length ? uri + decodeURIComponent( '?' + $.param(payload) ) : uri;
+                return this.truncate(decodedUri, 70);                
+            }
+        },
     }
 </script>
 
@@ -26,7 +34,7 @@
                 </span>
             </td>
 
-            <td :title="slotProps.entry.content.uri">{{truncate(slotProps.entry.content.uri, 70)}}</td>
+            <td :title="slotProps.entry.content.uri">{{uri(slotProps.entry.content)}}</td>
 
             <td class="table-fit">
                 <span class="badge font-weight-light" :class="'badge-'+requestStatusClass(slotProps.entry.content.response_status)">


### PR DESCRIPTION
this **PR** resolves #140  and decodes the payload in requests index screen to be like this screenshot

![screenshot from 2018-11-01 08-43-55](https://user-images.githubusercontent.com/17250137/47836810-5385e080-ddb2-11e8-8011-83584fa662bf.png)
