### PR TITLE
Snake case config option

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -123,7 +123,7 @@ class Telescope
                 'horizon',
                 'horizon:work',
                 'horizon:supervisor',
-            ], config('telescope.ignoreCommands', []))
+            ], config('telescope.ignoreCommands', []), config('telescope.ignore_commands', []))
         );
     }
 


### PR DESCRIPTION
All config options in Laravel are snake_cased, there's no reason why this one should be camelCased. I left support for the old casing to ensure backwards compatibility.

Imho this option should also be added to the default config file, but I didn't want to invest time now to come up with a comment of exactly three lines, each one three characters shorter than the other. 😀