### PR TITLE
Added command to update/publish Telescope assets

### DIFF
--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -4,7 +4,6 @@ namespace Laravel\Telescope\Console;
 
 use Illuminate\Console\DetectsApplicationNamespace;
 use Illuminate\Console\Command;
-use Illuminate\Support\Str;
 
 class PublishCommand extends Command
 {

--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Laravel\Telescope\Console;
+
+use Illuminate\Console\DetectsApplicationNamespace;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class PublishCommand extends Command
+{
+    use DetectsApplicationNamespace;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'telescope:publish {--force : Overwrite any existing files}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Publish all of the Telescope resources';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->call('vendor:publish', [
+            '--tag' => 'telescope-config',
+            '--force' => $this->option('force'),
+        ]);
+
+        $this->call('vendor:publish', [
+            '--tag' => 'telescope-assets',
+            '--force' => true,
+        ]);
+    }
+}

--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -109,6 +109,7 @@ class TelescopeServiceProvider extends ServiceProvider
             Console\InstallCommand::class,
             Console\PruneCommand::class,
             Console\ClearCommand::class,
+            Console\PublishCommand::class,
         ]);
     }
 


### PR DESCRIPTION
This PR adds a command to update Telescope assets. Currently, there is no way to do so as the `php artisan telescope:install` command does not overwrite telescope assets.

Fixes #308 