### PR TITLE
Implement shouldIgnore method for other watchers

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -49,7 +49,8 @@ return [
     |
     | The following array lists the "watchers" that will be registered with
     | Telescope. The watchers gather the application's profile data when
-    | a request or task is executed. Feel free to customize this list.
+    | a request or task is executed. You can also ignore specific entries
+    | from being stored. Feel free to customize this list.
     |
     */
 

--- a/src/Watchers/CacheWatcher.php
+++ b/src/Watchers/CacheWatcher.php
@@ -110,9 +110,9 @@ class CacheWatcher extends Watcher
      */
     private function shouldIgnore($event)
     {
-        return Str::is([
+        return Str::is(array_merge($this->options['ignore'] ?? [], [
             'illuminate:queue:restart',
             'framework/schedule*',
-        ], $event->key);
+        ]), $event->key);
     }
 }

--- a/src/Watchers/EventWatcher.php
+++ b/src/Watchers/EventWatcher.php
@@ -132,21 +132,21 @@ class EventWatcher extends Watcher
      */
     protected function shouldIgnore($eventName)
     {
-        return Telescope::$ignoreFrameworkEvents &&
-               $this->eventIsFiredByTheFramework($eventName);
+        return Str::is(array_merge(
+            $this->options['ignore'] ?? [],
+            $this->eventsFiredByTheFramework()
+        ), $eventName);
     }
 
     /**
-     * Determine if the event was fired internally by Laravel.
+     * Determine the events that fired internally by Laravel.
      *
-     * @param  string  $eventName
-     * @return bool
+     * @return array
      */
-    protected function eventIsFiredByTheFramework($eventName)
+    protected function eventsFiredByTheFramework()
     {
-        return Str::is(
-            ['Illuminate\*', 'eloquent*', 'bootstrapped*', 'bootstrapping*', 'creating*', 'composing*'],
-            $eventName
-        );
+        return Telescope::$ignoreFrameworkEvents ? [
+            'Illuminate\*', 'eloquent*', 'bootstrapped*', 'bootstrapping*', 'creating*', 'composing*'
+        ] : [];
     }
 }

--- a/src/Watchers/ExceptionWatcher.php
+++ b/src/Watchers/ExceptionWatcher.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Telescope\Watchers;
 
+use Illuminate\Support\Str;
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\ExtractTags;
 use Laravel\Telescope\ExceptionContext;
@@ -35,6 +36,10 @@ class ExceptionWatcher extends Watcher
 
         $exception = $event->context['exception'];
 
+        if ($this->shouldIgnore(get_class($exception))) {
+            return;
+        }
+
         Telescope::recordException(
             IncomingExceptionEntry::make($exception, [
                 'class' => get_class($exception),
@@ -58,5 +63,16 @@ class ExceptionWatcher extends Watcher
         return array_merge(ExtractTags::from($event->context['exception']),
             $event->context['telescope'] ?? []
         );
+    }
+
+    /**
+     * Determine if the exception should be ignored.
+     *
+     * @param  string  $exception
+     * @return bool
+     */
+    protected function shouldIgnore($exception)
+    {
+        return Str::is($this->options['ignore'] ?? [], $exception);
     }
 }

--- a/src/Watchers/MailWatcher.php
+++ b/src/Watchers/MailWatcher.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Telescope\Watchers;
 
+use Illuminate\Support\Str;
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\IncomingEntry;
 use Illuminate\Mail\Events\MessageSent;
@@ -27,6 +28,10 @@ class MailWatcher extends Watcher
      */
     public function recordMail(MessageSent $event)
     {
+        if ($this->shouldIgnore($this->getMailable($event))) {
+            return;
+        }
+
         Telescope::recordMail(IncomingEntry::make([
             'mailable' => $this->getMailable($event),
             'queued' => $this->getQueuedStatus($event),
@@ -86,5 +91,16 @@ class MailWatcher extends Watcher
             array_keys($message->getBcc() ?: []),
             $data['__telescope'] ?? []
         );
+    }
+
+    /**
+     * Determine if the mailable should be ignored.
+     *
+     * @param  string  $mailable
+     * @return bool
+     */
+    protected function shouldIgnore($mailable)
+    {
+        return Str::is($this->options['ignore'] ?? [], $mailable);
     }
 }

--- a/src/Watchers/NotificationWatcher.php
+++ b/src/Watchers/NotificationWatcher.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Telescope\Watchers;
 
+use Illuminate\Support\Str;
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\ExtractTags;
 use Laravel\Telescope\IncomingEntry;
@@ -31,6 +32,10 @@ class NotificationWatcher extends Watcher
      */
     public function recordNotification(NotificationSent $event)
     {
+        if ($this->shouldIgnore(get_class($event->notification))) {
+            return;
+        }
+
         Telescope::recordNotification(IncomingEntry::make([
             'notification' => get_class($event->notification),
             'queued' => in_array(ShouldQueue::class, class_implements($event->notification)),
@@ -68,5 +73,16 @@ class NotificationWatcher extends Watcher
         }
 
         return $notifiable;
+    }
+
+    /**
+     * Determine if the notification should be ignored.
+     *
+     * @param  string  $notification
+     * @return bool
+     */
+    protected function shouldIgnore($notification)
+    {
+        return Str::is($this->options['ignore'] ?? [], $notification);
     }
 }

--- a/src/Watchers/RedisWatcher.php
+++ b/src/Watchers/RedisWatcher.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Telescope\Watchers;
 
+use Illuminate\Support\Str;
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\IncomingEntry;
 use Illuminate\Redis\Events\CommandExecuted;
@@ -27,6 +28,10 @@ class RedisWatcher extends Watcher
      */
     public function recordCommand(CommandExecuted $event)
     {
+        if ($this->shouldIgnore($event->command)) {
+            return;
+        }
+
         Telescope::recordRedis(IncomingEntry::make([
             'connection' => $event->connectionName,
             'command' => $this->formatCommand($event->command, $event->parameters),
@@ -54,5 +59,16 @@ class RedisWatcher extends Watcher
         })->implode(' ');
 
         return "{$command} {$parameters}";
+    }
+
+    /**
+     * Determine if the Redis command should be ignored.
+     *
+     * @param  string  $command
+     * @return bool
+     */
+    protected function shouldIgnore($command)
+    {
+        return Str::is($this->options['ignore'] ?? [], $command);
     }
 }

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -30,6 +30,10 @@ class RequestWatcher extends Watcher
      */
     public function recordRequest(RequestHandled $event)
     {
+        if ($this->shouldIgnore($event)) {
+            return;
+        }
+
         Telescope::recordRequest(IncomingEntry::make([
             'uri' => str_replace($event->request->root(), '', $event->request->fullUrl()),
             'method' => $event->request->method(),
@@ -113,5 +117,16 @@ class RequestWatcher extends Watcher
         $limit = $this->options['size_limit'] ?? 64;
 
         return mb_strlen($content) / 1000 <= $limit;
+    }
+
+    /**
+     * Determine if the current request should be ignored.
+     *
+     * @param  \Illuminate\Foundation\Http\Events\RequestHandled  $event
+     * @return bool
+     */
+    private function shouldIgnore($event)
+    {
+        return $event->request->is($this->options['ignore'] ?? []);
     }
 }


### PR DESCRIPTION
@taylorotwell @themsaid  How should we proceed with tests? Should I change the environment setup to something like:

```php
$app->get('config')->set('telescope.watchers', [
    RequestWatcher::class => [
        'enabled' => true,
        'ignore' => [
             'something/*',
        ],
    ],
]);
```

or do you have some other and better suggestion?