### PR TITLE
Remove adding TelescopeServiceProvider to app.php in installCommand because package-auto-discovery

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -54,18 +54,6 @@ class InstallCommand extends Command
     {
         $namespace = str_replace_last('\\', '', $this->getAppNamespace());
 
-        $appConfig = file_get_contents(config_path('app.php'));
-
-        if (Str::contains($appConfig, $namespace."\\Providers\\TelescopeServiceProvider::class")) {
-            return;
-        }
-
-        file_put_contents(config_path('app.php'), str_replace(
-            "{$namespace}\\Providers\EventServiceProvider::class,".PHP_EOL,
-            "{$namespace}\\Providers\EventServiceProvider::class,".PHP_EOL."        {$namespace}\Providers\TelescopeServiceProvider::class,".PHP_EOL,
-            $appConfig
-        ));
-
         file_put_contents(app_path('Providers/TelescopeServiceProvider.php'), str_replace(
             "namespace App\Providers;",
             "namespace {$namespace}\Providers;",


### PR DESCRIPTION
Telescope already implement package-auto-discovery so isn't necessary to add TelescopeServiceProvider to app.php.

In my case I add to one project and install locally, added telescope files to gitignore (because I only want it in local env), but the installation process modify my app.php so I have to remove manually the register of the provider and if I forget it, it breaks my app.