### PR TITLE
Add named route for Telescope

### DIFF
--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -62,4 +62,4 @@ Route::get('/telescope-api/monitored-tags', 'MonitoredTagController@index');
 Route::post('/telescope-api/monitored-tags/', 'MonitoredTagController@store');
 Route::post('/telescope-api/monitored-tags/delete', 'MonitoredTagController@destroy');
 
-Route::get('/{view?}', 'HomeController@index')->where('view', '(.*)');
+Route::get('/{view?}', 'HomeController@index')->where('view', '(.*)')->name('telescope');

--- a/tests/Http/RouteTest.php
+++ b/tests/Http/RouteTest.php
@@ -86,7 +86,6 @@ class RouteTest extends FeatureTestCase
 
     public function test_named_route()
     {
-
         $this->assertEquals(
             url(config('telescope.path')),
             route('telescope')

--- a/tests/Http/RouteTest.php
+++ b/tests/Http/RouteTest.php
@@ -83,4 +83,13 @@ class RouteTest extends FeatureTestCase
             return $this;
         });
     }
+
+    public function test_named_route()
+    {
+
+        $this->assertEquals(
+            url(config('telescope.path')),
+            route('telescope')
+        );
+    }
 }


### PR DESCRIPTION
Allows applications to add the Telescope base url by a named route.

Should the config `telescope.path` be changed, then the named route would automatically be updated. As currently this either needs to be manually defined or built from the `telescope.path` config in the parent application. 
Navigation paths often use the named routes to build the url links, this would allow a Telescope navigation path to be defined by a named route.