### PR TITLE
Add ability to filter batches of entries

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -28,6 +28,13 @@ class Telescope
     public static $filterUsing = [];
 
     /**
+     * The callbacks that filter the entries that should be recorded.
+     *
+     * @var array
+     */
+    public static $filterBatchUsing = [];
+
+    /**
      * The callback that adds tags to the record.
      *
      * @var \Closure
@@ -423,6 +430,19 @@ class Telescope
     }
 
     /**
+     * Set the callback that filters the batches that should be recorded.
+     *
+     * @param  \Closure  $callback
+     * @return static
+     */
+    public static function filterBatch(Closure $callback)
+    {
+        static::$filterBatchUsing[] = $callback;
+
+        return new static;
+    }
+
+    /**
      * Set the callback that adds tags to the record.
      *
      * @param  \Closure  $callback
@@ -445,6 +465,10 @@ class Telescope
     {
         if (empty(static::$entriesQueue) && empty(static::$updatesQueue)) {
             return;
+        }
+
+        if (!collect(static::$filterBatchUsing)->every->__invoke(collect(static::$entriesQueue))) {
+            static::flushEntries();
         }
 
         try {


### PR DESCRIPTION
Currently there is no way to filter batches of entries. For example, say we need to record all entries for an app lifecycle that result in an exception (e.g. the queries fired, the request, etc.).

This PR fixes #318 and adds the ability to filter batches like so:

```php
Telescope::filterBatch(function ($entries) {
	return $entries->contains(function($entry) {
		return $entry->isReportableException();
	});
}
```

The above code enables us to record all entries for any app lifecycle that results in a reportable exception. If this is merged, I think we should also change the `TelescopeServiceProvider.stub` to add this as an example.

On a side note, I saw many methods in `Telescope.php` that `return new static`. I don't know if this serves any purpose. Perhaps we should delete that and just have them as `void` methods since I can't find any non-static member or function in the `Telescope` class. Currently, I have followed the same pattern in my PR for consistency.