### PR TITLE
Fix RedisWatcher by enabling events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,12 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+services:
+  - redis-server
+
 before_install:
   - phpenv config-rm xdebug.ini || true
+  - printf "\n" | pecl install -f redis
   - travis_retry composer self-update
 
 install:

--- a/src/Watchers/RedisWatcher.php
+++ b/src/Watchers/RedisWatcher.php
@@ -16,6 +16,7 @@ class RedisWatcher extends Watcher
      */
     public function register($app)
     {
+        $app['redis']->enableEvents();
         $app['events']->listen(CommandExecuted::class, [$this, 'recordCommand']);
     }
 

--- a/tests/Watchers/RedisWatcherTest.php
+++ b/tests/Watchers/RedisWatcherTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Laravel\Telescope\Tests\Watchers;
+
+use Laravel\Telescope\EntryType;
+use Laravel\Telescope\Tests\FeatureTestCase;
+use Laravel\Telescope\Watchers\RedisWatcher;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
+use Illuminate\Support\Facades\Redis;
+
+class RedisWatcherTest extends FeatureTestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        if (!extension_loaded('redis')) {
+            $this->markTestSkipped('The phpredis extension is required for this test.');
+        }
+
+        $app->get('config')->set('database.redis.client', 'phpredis');
+
+        $app->get('config')->set('telescope.watchers', [
+            RedisWatcher::class => true,
+        ]);
+    }
+
+    public function test_redis_watcher_registers_entries()
+    {
+        Redis::connection('default')->get('telescope:test');
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        self::assertSame(EntryType::REDIS, $entry->type);
+        self::assertSame('get telescope:test', $entry->content['command']);
+        self::assertSame('default', $entry->content['connection']);
+    }
+}

--- a/tests/Watchers/RedisWatcherTest.php
+++ b/tests/Watchers/RedisWatcherTest.php
@@ -5,7 +5,6 @@ namespace Laravel\Telescope\Tests\Watchers;
 use Laravel\Telescope\EntryType;
 use Laravel\Telescope\Tests\FeatureTestCase;
 use Laravel\Telescope\Watchers\RedisWatcher;
-use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Support\Facades\Redis;
 
 class RedisWatcherTest extends FeatureTestCase


### PR DESCRIPTION
RedisWatcher currently does not record Redis entries since Redis events are disabled by default. This PR enables events to allow RedisWatcher to record Redis entries. Fixes #321 