### PR TITLE
Add request metadata: controller, action, middleware, duration

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -53773,6 +53773,34 @@ var render = function() {
             _vm._v(" "),
             _c("tr", [
               _c("td", { staticClass: "table-fit font-weight-bold" }, [
+                _vm._v("Controller Action")
+              ]),
+              _vm._v(" "),
+              _c("td", [
+                _vm._v(
+                  "\n            " +
+                    _vm._s(slotProps.entry.content.controller_action) +
+                    "\n        "
+                )
+              ])
+            ]),
+            _vm._v(" "),
+            _c("tr", [
+              _c("td", { staticClass: "table-fit font-weight-bold" }, [
+                _vm._v("Middleware")
+              ]),
+              _vm._v(" "),
+              _c("td", [
+                _vm._v(
+                  "\n            " +
+                    _vm._s(slotProps.entry.content.middleware.join(", ")) +
+                    "\n        "
+                )
+              ])
+            ]),
+            _vm._v(" "),
+            _c("tr", [
+              _c("td", { staticClass: "table-fit font-weight-bold" }, [
                 _vm._v("Path")
               ]),
               _vm._v(" "),
@@ -53795,6 +53823,20 @@ var render = function() {
                   "\n            " +
                     _vm._s(slotProps.entry.content.response_status) +
                     "\n        "
+                )
+              ])
+            ]),
+            _vm._v(" "),
+            _c("tr", [
+              _c("td", { staticClass: "table-fit font-weight-bold" }, [
+                _vm._v("Duration")
+              ]),
+              _vm._v(" "),
+              _c("td", [
+                _vm._v(
+                  "\n            " +
+                    _vm._s(slotProps.entry.content.duration) +
+                    " ms\n        "
                 )
               ])
             ])

--- a/public/app.js
+++ b/public/app.js
@@ -53835,7 +53835,7 @@ var render = function() {
               _c("td", [
                 _vm._v(
                   "\n            " +
-                    _vm._s(slotProps.entry.content.duration) +
+                    _vm._s(slotProps.entry.content.duration || "-") +
                     " ms\n        "
                 )
               ])

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/app.js": "/app.js?id=7e3c32dec4b89dcd1de7",
+    "/app.js": "/app.js?id=6722b362321839d2d6da",
     "/app.css": "/app.css?id=0c1e654d28f1c73326c1",
     "/app-dark.css": "/app-dark.css?id=13df33880547628477b2"
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/app.js": "/app.js?id=97d2c4a7d65b638d9806",
+    "/app.js": "/app.js?id=7e3c32dec4b89dcd1de7",
     "/app.css": "/app.css?id=0c1e654d28f1c73326c1",
     "/app-dark.css": "/app-dark.css?id=13df33880547628477b2"
 }

--- a/resources/js/screens/requests/preview.vue
+++ b/resources/js/screens/requests/preview.vue
@@ -53,7 +53,7 @@
         <tr>
             <td class="table-fit font-weight-bold">Duration</td>
             <td>
-                {{slotProps.entry.content.duration}} ms
+                {{slotProps.entry.content.duration || '-'}} ms
             </td>
         </tr>
         </template>

--- a/resources/js/screens/requests/preview.vue
+++ b/resources/js/screens/requests/preview.vue
@@ -23,6 +23,20 @@
         </tr>
 
         <tr>
+            <td class="table-fit font-weight-bold">Controller Action</td>
+            <td>
+                {{slotProps.entry.content.controller_action}}
+            </td>
+        </tr>
+
+        <tr>
+            <td class="table-fit font-weight-bold">Middleware</td>
+            <td>
+                {{slotProps.entry.content.middleware.join(", ")}}
+            </td>
+        </tr>
+        
+        <tr>
             <td class="table-fit font-weight-bold">Path</td>
             <td>
                 {{slotProps.entry.content.uri}}
@@ -33,6 +47,13 @@
             <td class="table-fit font-weight-bold">Status</td>
             <td>
                 {{slotProps.entry.content.response_status}}
+            </td>
+        </tr>
+
+        <tr>
+            <td class="table-fit font-weight-bold">Duration</td>
+            <td>
+                {{slotProps.entry.content.duration}} ms
             </td>
         </tr>
         </template>

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -8,6 +8,7 @@ use Laravel\Telescope\Telescope;
 use Laravel\Telescope\IncomingEntry;
 use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Foundation\Http\Events\RequestHandled;
+use Illuminate\Routing\Router;
 
 class RequestWatcher extends Watcher
 {
@@ -33,11 +34,14 @@ class RequestWatcher extends Watcher
         Telescope::recordRequest(IncomingEntry::make([
             'uri' => str_replace($event->request->root(), '', $event->request->fullUrl()),
             'method' => $event->request->method(),
+            'controller_action' => optional($event->request->route())->getActionName(),
+            'middleware' => optional($event->request->route())->gatherMiddleware(),
             'headers' => $this->headers($event->request->headers->all()),
             'payload' => $this->payload($event->request->all()),
             'session' => $this->payload($this->sessionVariables($event->request)),
             'response_status' => $event->response->getStatusCode(),
             'response' => $this->response($event->response),
+            'duration' => defined('LARAVEL_START') ? floor((microtime(true) - LARAVEL_START) * 1000) : null,
         ]));
     }
 

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -35,7 +35,7 @@ class RequestWatcher extends Watcher
             'uri' => str_replace($event->request->root(), '', $event->request->fullUrl()),
             'method' => $event->request->method(),
             'controller_action' => optional($event->request->route())->getActionName(),
-            'middleware' => optional($event->request->route())->gatherMiddleware(),
+            'middleware' => optional($event->request->route())->gatherMiddleware() ?? [],
             'headers' => $this->headers($event->request->headers->all()),
             'payload' => $this->payload($event->request->all()),
             'session' => $this->payload($this->sessionVariables($event->request)),

--- a/tests/Watchers/RequestWatchersTest.php
+++ b/tests/Watchers/RequestWatchersTest.php
@@ -16,6 +16,10 @@ class RequestWatchersTest extends FeatureTestCase
         $app->get('config')->set('telescope.watchers', [
             RequestWatcher::class => true,
         ]);
+
+        if (!defined('LARAVEL_START')) {
+            define('LARAVEL_START', microtime(true));
+        }
     }
 
     public function test_request_watcher_registers_requests()


### PR DESCRIPTION
This PR adds the following request metadata to the detail screen:

1. Controller and action
2. Middleware
3. Request duration (in ms)

Fixes #314 and fixes #265. Here's how the screen looks like:

<img width="922" alt="screen shot 2018-11-04 at 11 00 51 pm" src="https://user-images.githubusercontent.com/16099046/47967771-2b82cf80-e087-11e8-974e-2a054c4a60d2.png">

