### PR TITLE
Add capacity to hide headers as well as parameters on RequestWatcher

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -545,6 +545,21 @@ class Telescope
     }
 
     /**
+     * Hide the given request header.
+     *
+     * @param  array  $headers
+     * @return static
+     */
+    public static function hideRequestHeader(array $headers)
+    {
+        static::$hiddenRequestHeaders= array_merge(
+            static::$hiddenRequestHeaders, $headers
+        );
+
+        return new static;
+    }
+
+    /**
      * Specifies that Telescope should record events fired by Laravel.
      *
      * @return static

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -66,6 +66,15 @@ class Telescope
     ];
 
     /**
+     * The list of hidden request headers.
+     *
+     * @var array
+     */
+    public static $hiddenRequestHeaders = [
+        'authorization',
+    ];
+
+    /**
      * Indicates if Telescope should ignore events fired by Laravel.
      *
      * @var bool

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -52,9 +52,17 @@ class RequestWatcher extends Watcher
      */
     protected function headers($headers)
     {
-        return collect($headers)->map(function ($header) {
+        $headers = collect($headers)->map(function ($header) {
             return $header[0];
         })->toArray();
+
+        foreach(Telescope::$hiddenRequestHeaders as $header) {
+            if (Arr::get($headers, $header)) {
+                Arr::set($headers, $header, '********');
+            }
+        }
+
+        return $headers;
     }
 
     /**

--- a/tests/Watchers/RequestWatchersTest.php
+++ b/tests/Watchers/RequestWatchersTest.php
@@ -70,4 +70,23 @@ class RequestWatchersTest extends FeatureTestCase
         $this->assertSame('********', $entry->content['payload']['password']);
         $this->assertSame('********', $entry->content['payload']['password_confirmation']);
     }
+
+    public function test_request_watcher_hides_authorization()
+    {
+        Route::post('/dashboard', function () {
+            return response('success');
+        });
+
+        $this->post('/dashboard', [], [
+            'Authorization' => 'Basic YWxhZGRpbjpvcGVuc2VzYW1l',
+            'Content-Type' => 'application/json'
+        ]);
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::REQUEST, $entry->type);
+        $this->assertSame('POST', $entry->content['method']);
+        $this->assertSame('application/json', $entry->content['headers']['content-type']);
+        $this->assertSame('********', $entry->content['headers']['authorization']);
+    }
 }


### PR DESCRIPTION
We'll need to be able to hide the user Authorization Token as well