### PR TITLE
Add documentation about pruning the older entries to reduce disk space

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,21 @@ protected function gate()
 }
 ```
 
+#### Cleaning up old entries
+
+If your application throws a lot of exceptions, the `telescope_entries` table can get very large, very quickly. Telescope can prune older entries from its database to help reduce this size.
+
+Either run this `artisan` command as a one-time cleanup or add it to your `Console/Kernel.php` as a scheduled task.
+
+```
+php artisan telescope:prune
+```
+
+As a scheduled task:
+```
+$schedule->command('telescope:prune')->dailyAt(1, '07:30');
+```
+
 ## License
 
 Laravel Telescope is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
We got bitten a bit by this (`telescope_entries` growing at a rate of 10GB/day due to the large stacktraces it can store), I figured we might warn others that pruning the content is a wise idea. :-)