### PR TITLE
[1.0] Improve performance: dont register watchers on ignored commands / routes

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -103,7 +103,9 @@ class Telescope
      */
     public static function start($app)
     {
-        if ($app->runningUnitTests()) {
+        if ($app->runningUnitTests() ||
+            ! (static::runningApprovedArtisanCommand($app) ||
+            static::handlingNonTelescopeRequest($app))) {
             return;
         }
 
@@ -111,10 +113,7 @@ class Telescope
 
         static::registerMailableTagExtractor();
 
-        if (static::runningApprovedArtisanCommand($app) ||
-            static::handlingNonTelescopeRequest($app)) {
-            static::startRecording();
-        }
+        static::startRecording();
     }
 
     /**


### PR DESCRIPTION
Currently, the watchers are registered and listen to events (and store entries in memory) even on ignored commands or routes. This PR improves Telescope performance by only registering watchers & events on approved commands/routes.