### PR TITLE
[1.0] Add ability to ignore routes with better performance

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -105,7 +105,7 @@ class Telescope
     {
         if ($app->runningUnitTests() ||
             ! (static::runningApprovedArtisanCommand($app) ||
-            static::handlingNonTelescopeRequest($app))) {
+            static::handlingApprovedRequest($app))) {
             return;
         }
 
@@ -143,19 +143,21 @@ class Telescope
     }
 
     /**
-     * Determine if the application is handling a request not originating from Telescope, or Horizon.
+     * Determine if the application is handling an approved request.
      *
      * @param  \Illuminate\Foundation\Application  $app
      * @return bool
      */
-    protected static function handlingNonTelescopeRequest($app)
+    protected static function handlingApprovedRequest($app)
     {
         return ! $app->runningInConsole() && ! $app['request']->is(
-            config('telescope.path').'*',
-            'telescope-api*',
-            'vendor/telescope*',
-            'horizon*',
-            'vendor/horizon*'
+            array_merge([
+                config('telescope.path').'*',
+                'telescope-api*',
+                'vendor/telescope*',
+                'horizon*',
+                'vendor/horizon*'
+            ], config('telescope.ignore_routes', []))
         );
     }
 


### PR DESCRIPTION
This PR adds the ability to add ignored routes. Although this could be done with `Telescope::filter`, adding it to config is better performance due to #368.

I haven't changed the config file due to the comment conventions (both `ignore_commands` and `ignore_routes` are currently missing in `config/telescope.php`). I can take a go at it as a separate PR once (if) this is merged.