### PR TITLE
[1.0] Hide security critical params and headers

### DIFF
--- a/stubs/TelescopeServiceProvider.stub
+++ b/stubs/TelescopeServiceProvider.stub
@@ -28,6 +28,13 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
                    $entry->isScheduledTask() ||
                    $entry->hasMonitoredTag();
         });
+
+        Telescope::hideRequestParameters(['_token']);
+        Telescope::hideRequestHeaders([
+            'cookie',
+            'x-csrf-token',
+            'x-xsrf-token',
+        ]);
     }
 
     /**

--- a/stubs/TelescopeServiceProvider.stub
+++ b/stubs/TelescopeServiceProvider.stub
@@ -29,12 +29,14 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
                    $entry->hasMonitoredTag();
         });
 
-        Telescope::hideRequestParameters(['_token']);
-        Telescope::hideRequestHeaders([
-            'cookie',
-            'x-csrf-token',
-            'x-xsrf-token',
-        ]);
+        if (! $this->app->isLocal()) {
+            Telescope::hideRequestParameters(['_token']);
+            Telescope::hideRequestHeaders([
+                'cookie',
+                'x-csrf-token',
+                'x-xsrf-token',
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
Resubmission of #369, hiding params moved to `TelescopeServiceProvider` stub and applied on non-local environments.