### PR TITLE
Load monitored tags early in the lifecycle

### DIFF
--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -233,10 +233,20 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
     public function isMonitoring(array $tags)
     {
         if (is_null($this->monitoredTags)) {
-            $this->monitoredTags = $this->monitoring();
+            $this->loadMonitoredTags();
         }
 
         return count(array_intersect($tags, $this->monitoredTags)) > 0;
+    }
+
+    /**
+     * Load the monitored tags from storage.
+     *
+     * @return void
+     */
+    public function loadMonitoredTags()
+    {
+        $this->monitoredTags = $this->monitoring();
     }
 
     /**

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -168,6 +168,8 @@ class Telescope
      */
     public static function startRecording()
     {
+        app(EntriesRepository::class)->loadMonitoredTags();
+
         static::$shouldRecord = ! cache('telescope:pause-recording');
     }
 


### PR DESCRIPTION
This fixes https://github.com/laravel/telescope/issues/289

The problem was the query to collect monitored tags is called while recording the first entry in Telescope, and if you're recording a modal creation for example; that tags query will run between `INSERT` and PDO's `lastInsertId` causing the Model to have a `0` id.