### PR TITLE
Format file uploads while recording a request

### DIFF
--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -40,7 +40,7 @@ class RequestWatcher extends Watcher
             'controller_action' => optional($event->request->route())->getActionName(),
             'middleware' => optional($event->request->route())->gatherMiddleware() ?? [],
             'headers' => $this->headers($event->request->headers->all()),
-            'payload' => $this->payload($event->request->all()),
+            'payload' => $this->payload($this->input($event->request)),
             'session' => $this->payload($this->sessionVariables($event->request)),
             'response_status' => $event->response->getStatusCode(),
             'response' => $this->response($event->response),
@@ -95,6 +95,23 @@ class RequestWatcher extends Watcher
     private function sessionVariables(Request $request)
     {
         return $request->hasSession() ? $request->session()->all() : [];
+    }
+
+    /**
+     * Extract the input from the given request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    private function input(Request $request)
+    {
+        $files = $request->files->all();
+
+        array_walk_recursive($files, function (&$value) {
+            $value = 'File detected by Telescope';
+        });
+
+        return array_replace_recursive($request->input(), $files);
     }
 
     /**

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -138,7 +138,7 @@ class RequestWatcher extends Watcher
         if ($response instanceof IlluminateResponse && $response->getOriginalContent() instanceof View) {
             return [
                 'view' => $response->getOriginalContent()->getPath(),
-                'data' => $this->extractDataFromView($response->getOriginalContent())
+                'data' => $this->extractDataFromView($response->getOriginalContent()),
             ];
         }
 

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -107,8 +107,11 @@ class RequestWatcher extends Watcher
     {
         $files = $request->files->all();
 
-        array_walk_recursive($files, function (&$value) {
-            $value = 'File detected by Telescope';
+        array_walk_recursive($files, function (&$file) {
+            $file = [
+                'name' => $file->getClientOriginalName(),
+                'size' => ($file->getSize() / 1000).'KB',
+            ];
         });
 
         return array_replace_recursive($request->input(), $files);


### PR DESCRIPTION
This PR fixes https://github.com/laravel/telescope/issues/377

We'll iterate over file uploads and display a placeholder instead of trying to use the actual file.

<img width="568" alt="screen shot 2018-11-14 at 4 05 40 pm" src="https://user-images.githubusercontent.com/4332182/48487371-b18cdc00-e826-11e8-81d9-f6b229ac77a9.png">

