### PR TITLE
[1.0] Fix unliked uploaded files for request watcher

### DIFF
--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -110,7 +110,7 @@ class RequestWatcher extends Watcher
         array_walk_recursive($files, function (&$file) {
             $file = [
                 'name' => $file->getClientOriginalName(),
-                'size' => ($file->getSize() / 1000).'KB',
+                'size' => ($file->isValid() && $file->isFile() ? $file->getSize() : 0) / 1000 .'KB',
             ];
         });
 

--- a/tests/Watchers/RequestWatchersTest.php
+++ b/tests/Watchers/RequestWatchersTest.php
@@ -3,10 +3,10 @@
 namespace Laravel\Telescope\Tests\Watchers;
 
 use Laravel\Telescope\EntryType;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Route;
 use Laravel\Telescope\Tests\FeatureTestCase;
 use Laravel\Telescope\Watchers\RequestWatcher;
-use Illuminate\Http\UploadedFile;
 
 class RequestWatchersTest extends FeatureTestCase
 {
@@ -96,14 +96,14 @@ class RequestWatchersTest extends FeatureTestCase
         $image = UploadedFile::fake()->image('avatar.jpg');
 
         $this->post('fake-upload-file-route', [
-            'image' => $image
+            'image' => $image,
         ]);
 
         $uploadedImage = $this->loadTelescopeEntries()->first()->content['payload']['image'];
 
         $this->assertSame($image->getClientOriginalName(), $uploadedImage['name']);
 
-        $this->assertSame($image->getSize() / 1000 . 'KB', $uploadedImage['size']);
+        $this->assertSame($image->getSize() / 1000 .'KB', $uploadedImage['size']);
     }
 
     public function test_request_watcher_handles_unlinked_file_uploads()
@@ -113,7 +113,7 @@ class RequestWatchersTest extends FeatureTestCase
         unlink($image->getPathName());
 
         $this->post('fake-upload-file-route', [
-            'unlinked-image' => $image
+            'unlinked-image' => $image,
         ]);
 
         $uploadedImage = $this->loadTelescopeEntries()->first()->content['payload']['unlinked-image'];

--- a/tests/Watchers/RequestWatchersTest.php
+++ b/tests/Watchers/RequestWatchersTest.php
@@ -6,6 +6,7 @@ use Laravel\Telescope\EntryType;
 use Illuminate\Support\Facades\Route;
 use Laravel\Telescope\Tests\FeatureTestCase;
 use Laravel\Telescope\Watchers\RequestWatcher;
+use Illuminate\Http\UploadedFile;
 
 class RequestWatchersTest extends FeatureTestCase
 {
@@ -88,5 +89,37 @@ class RequestWatchersTest extends FeatureTestCase
         $this->assertSame('POST', $entry->content['method']);
         $this->assertSame('application/json', $entry->content['headers']['content-type']);
         $this->assertSame('********', $entry->content['headers']['authorization']);
+    }
+
+    public function test_request_watcher_handles_file_uploads()
+    {
+        $image = UploadedFile::fake()->image('avatar.jpg');
+
+        $this->post('fake-upload-file-route', [
+            'image' => $image
+        ]);
+
+        $uploadedImage = $this->loadTelescopeEntries()->first()->content['payload']['image'];
+
+        $this->assertSame($image->getClientOriginalName(), $uploadedImage['name']);
+
+        $this->assertSame($image->getSize() / 1000 . 'KB', $uploadedImage['size']);
+    }
+
+    public function test_request_watcher_handles_unlinked_file_uploads()
+    {
+        $image = UploadedFile::fake()->image('unlinked-image.jpg');
+
+        unlink($image->getPathName());
+
+        $this->post('fake-upload-file-route', [
+            'unlinked-image' => $image
+        ]);
+
+        $uploadedImage = $this->loadTelescopeEntries()->first()->content['payload']['unlinked-image'];
+
+        $this->assertSame($image->getClientOriginalName(), $uploadedImage['name']);
+
+        $this->assertSame('0KB', $uploadedImage['size']);
     }
 }


### PR DESCRIPTION
this **PR** , resolves #387 , as i found that the problem happens when the file get unliked and when using [Spatie/Media library this line cause the problem](https://github.com/spatie/laravel-medialibrary/blob/master/src/FileAdder/FileAdder.php#L308)

so the solution makes sure that the file is uploaded succesfully using ```isValid()``` and make sure that the file exist using [PHP ```isFile()```](http://php.net/manual/en/splfileinfo.isfile.php) method