### PR TITLE
[1.0] Only register migrations for database driver

### DIFF
--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -65,7 +65,7 @@ class TelescopeServiceProvider extends ServiceProvider
      */
     private function registerMigrations()
     {
-        if ($this->app->runningInConsole()) {
+        if ($this->app->runningInConsole() && $this->shouldMigrate()) {
             $this->loadMigrationsFrom(__DIR__.'/Storage/migrations');
         }
     }
@@ -149,5 +149,15 @@ class TelescopeServiceProvider extends ServiceProvider
         $this->app->when(DatabaseEntriesRepository::class)
             ->needs('$connection')
             ->give(config('telescope.storage.database.connection'));
+    }
+
+    /**
+     * Determine if we should register the migrations.
+     *
+     * @return bool
+     */
+    protected function shouldMigrate()
+    {
+        return config('telescope.driver') === 'database';
     }
 }


### PR DESCRIPTION
The database migrations should only be loaded when telescope is running with the database driver to avoid that we create tables that are not needed.