### PR TITLE
[1.0] Provide Migrate command for telescope-only

### DIFF
--- a/src/Console/MigrateTelescopeCommand.php
+++ b/src/Console/MigrateTelescopeCommand.php
@@ -2,8 +2,8 @@
 
 namespace App\Console\Commands;
 
-use Illuminate\Config\Repository;
 use Illuminate\Console\Command;
+use Illuminate\Config\Repository;
 use Illuminate\Database\Migrations\Migrator;
 
 class MigrateTelescopeCommand extends Command

--- a/src/Console/MigrateTelescopeCommand.php
+++ b/src/Console/MigrateTelescopeCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Config\Repository;
+use Illuminate\Console\Command;
+use Illuminate\Database\Migrations\Migrator;
+
+class MigrateTelescopeCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'telescope:migrate';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create Telescope tables in a separate database without creating the app\'s tables.';
+
+    public function handle(Migrator $migrator, Repository $config)
+    {
+        $connection = $config->get('telescope.storage.database.connection');
+
+        $migrator->setConnection($connection);
+
+        $migrator->setOutput($this->output);
+
+        if (! $migrator->repositoryExists()) {
+            $migrator->getRepository()->createRepository();
+        }
+
+        $migrator->setOutput($this->output)->run([__DIR__.'/../Storage/migrations']);
+    }
+}


### PR DESCRIPTION
When running Telescope on a telescope-only dedicated database, even if we do `php artisan migrate --database=telescope` Laravel will still try to run all migrations (telescope and app) into the telescope-only database. Not only that's a bit wasteful, it also creates confusion when looking at the database. The developer might think he's deleting the telescope database when in fact he's deleting the app's database.

With `php artisan telescope:migrate`, only the Telescope migrations will be executed in the target connection. So if the target connection is a dedicated for telescope, it will only have the telescope tables.