### PR TITLE
Add query explains for MySQL driver

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -87,6 +87,10 @@ return [
         Watchers\QueryWatcher::class => [
             'enabled' => env('TELESCOPE_QUERY_WATCHER', true),
             'slow' => 100,
+            'explain' => [
+                'enabled' => env('TELESCOPE_EXPLAIN_QUERIES', false),
+                'types' => ['select'],  // ['select', 'insert', 'update', 'delete']
+            ],
         ],
 
         Watchers\RedisWatcher::class => env('TELESCOPE_REDIS_WATCHER', true),

--- a/public/app.js
+++ b/public/app.js
@@ -52509,7 +52509,295 @@ var render = function() {
                   )
                 ]
               )
-            ])
+            ]),
+            _vm._v(" "),
+            slotProps.entry.content.explains &&
+            slotProps.entry.content.explains.length
+              ? _c("div", { staticClass: "card mt-5" }, [
+                  _c("div", { staticClass: "card-header" }, [
+                    _c("h5", [_vm._v("Explains")])
+                  ]),
+                  _vm._v(" "),
+                  _c("div", { staticClass: "table-responsive" }, [
+                    _c(
+                      "table",
+                      { staticClass: "table table-hover table-sm mb-0" },
+                      [
+                        _c("thead", [
+                          _c("tr", [
+                            _c("th", [_vm._v("id")]),
+                            _vm._v(" "),
+                            _c("th", [_vm._v("select_type")]),
+                            _vm._v(" "),
+                            _c("th", [_vm._v("table")]),
+                            _vm._v(" "),
+                            _c("th", [_vm._v("partitions")]),
+                            _vm._v(" "),
+                            _c("th", [_vm._v("type")]),
+                            _vm._v(" "),
+                            _c("th", [_vm._v("possible_keys")]),
+                            _vm._v(" "),
+                            _c("th", [_vm._v("key")]),
+                            _vm._v(" "),
+                            _c("th", [_vm._v("key_len")]),
+                            _vm._v(" "),
+                            _c("th", [_vm._v("ref")]),
+                            _vm._v(" "),
+                            _c("th", [_vm._v("rows")]),
+                            _vm._v(" "),
+                            _c("th", [_vm._v("filtered")]),
+                            _vm._v(" "),
+                            _c("th", [_vm._v("Extra")])
+                          ])
+                        ]),
+                        _vm._v(" "),
+                        _c(
+                          "tbody",
+                          _vm._l(slotProps.entry.content.explains, function(
+                            explain
+                          ) {
+                            return _c("tr", [
+                              _c("td", [_vm._v(_vm._s(explain.id))]),
+                              _vm._v(" "),
+                              _c("td", [_vm._v(_vm._s(explain.select_type))]),
+                              _vm._v(" "),
+                              _c("td", { staticClass: "table-fit" }, [
+                                explain.table
+                                  ? _c("span", [
+                                      _vm._v(
+                                        "\n                                    " +
+                                          _vm._s(explain.table) +
+                                          "\n                                "
+                                      )
+                                    ])
+                                  : _c(
+                                      "span",
+                                      {
+                                        staticClass:
+                                          "badge badge-secondary font-weight-light"
+                                      },
+                                      [
+                                        _vm._v(
+                                          "\n                                    NULL\n                                "
+                                        )
+                                      ]
+                                    )
+                              ]),
+                              _vm._v(" "),
+                              _c("td", { staticClass: "table-fit" }, [
+                                explain.partitions
+                                  ? _c("span", [
+                                      _vm._v(
+                                        "\n                                    " +
+                                          _vm._s(explain.partitions) +
+                                          "\n                                "
+                                      )
+                                    ])
+                                  : _c(
+                                      "span",
+                                      {
+                                        staticClass:
+                                          "badge badge-secondary font-weight-light"
+                                      },
+                                      [
+                                        _vm._v(
+                                          "\n                                    NULL\n                                "
+                                        )
+                                      ]
+                                    )
+                              ]),
+                              _vm._v(" "),
+                              _c("td", { staticClass: "table-fit" }, [
+                                explain.type
+                                  ? _c("span", [
+                                      _vm._v(
+                                        "\n                                    " +
+                                          _vm._s(explain.type) +
+                                          "\n                                "
+                                      )
+                                    ])
+                                  : _c(
+                                      "span",
+                                      {
+                                        staticClass:
+                                          "badge badge-secondary font-weight-light"
+                                      },
+                                      [
+                                        _vm._v(
+                                          "\n                                    NULL\n                                "
+                                        )
+                                      ]
+                                    )
+                              ]),
+                              _vm._v(" "),
+                              _c("td", { staticClass: "table-fit" }, [
+                                explain.possible_keys
+                                  ? _c("span", [
+                                      _vm._v(
+                                        "\n                                    " +
+                                          _vm._s(explain.possible_keys) +
+                                          "\n                                "
+                                      )
+                                    ])
+                                  : _c(
+                                      "span",
+                                      {
+                                        staticClass:
+                                          "badge badge-secondary font-weight-light"
+                                      },
+                                      [
+                                        _vm._v(
+                                          "\n                                    NULL\n                                "
+                                        )
+                                      ]
+                                    )
+                              ]),
+                              _vm._v(" "),
+                              _c("td", { staticClass: "table-fit" }, [
+                                explain.key
+                                  ? _c("span", [
+                                      _vm._v(
+                                        "\n                                    " +
+                                          _vm._s(explain.key) +
+                                          "\n                                "
+                                      )
+                                    ])
+                                  : _c(
+                                      "span",
+                                      {
+                                        staticClass:
+                                          "badge badge-secondary font-weight-light"
+                                      },
+                                      [
+                                        _vm._v(
+                                          "\n                                    NULL\n                                "
+                                        )
+                                      ]
+                                    )
+                              ]),
+                              _vm._v(" "),
+                              _c("td", { staticClass: "table-fit" }, [
+                                explain.key_len
+                                  ? _c("span", [
+                                      _vm._v(
+                                        "\n                                    " +
+                                          _vm._s(explain.key_len) +
+                                          "\n                                "
+                                      )
+                                    ])
+                                  : _c(
+                                      "span",
+                                      {
+                                        staticClass:
+                                          "badge badge-secondary font-weight-light"
+                                      },
+                                      [
+                                        _vm._v(
+                                          "\n                                    NULL\n                                "
+                                        )
+                                      ]
+                                    )
+                              ]),
+                              _vm._v(" "),
+                              _c("td", { staticClass: "table-fit" }, [
+                                explain.ref
+                                  ? _c("span", [
+                                      _vm._v(
+                                        "\n                                    " +
+                                          _vm._s(explain.ref) +
+                                          "\n                                "
+                                      )
+                                    ])
+                                  : _c(
+                                      "span",
+                                      {
+                                        staticClass:
+                                          "badge badge-secondary font-weight-light"
+                                      },
+                                      [
+                                        _vm._v(
+                                          "\n                                    NULL\n                                "
+                                        )
+                                      ]
+                                    )
+                              ]),
+                              _vm._v(" "),
+                              _c("td", { staticClass: "table-fit" }, [
+                                explain.rows
+                                  ? _c("span", [
+                                      _vm._v(
+                                        "\n                                    " +
+                                          _vm._s(explain.rows) +
+                                          "\n                                "
+                                      )
+                                    ])
+                                  : _c(
+                                      "span",
+                                      {
+                                        staticClass:
+                                          "badge badge-secondary font-weight-light"
+                                      },
+                                      [
+                                        _vm._v(
+                                          "\n                                    NULL\n                                "
+                                        )
+                                      ]
+                                    )
+                              ]),
+                              _vm._v(" "),
+                              _c("td", { staticClass: "table-fit" }, [
+                                explain.filtered
+                                  ? _c("span", [
+                                      _vm._v(
+                                        "\n                                    " +
+                                          _vm._s(explain.filtered) +
+                                          "\n                                "
+                                      )
+                                    ])
+                                  : _c(
+                                      "span",
+                                      {
+                                        staticClass:
+                                          "badge badge-secondary font-weight-light"
+                                      },
+                                      [
+                                        _vm._v(
+                                          "\n                                    NULL\n                                "
+                                        )
+                                      ]
+                                    )
+                              ]),
+                              _vm._v(" "),
+                              _c("td", { staticClass: "table-fit" }, [
+                                explain.Extra
+                                  ? _c("span", [
+                                      _vm._v(
+                                        "\n                                    " +
+                                          _vm._s(explain.Extra) +
+                                          "\n                                "
+                                      )
+                                    ])
+                                  : _c(
+                                      "span",
+                                      {
+                                        staticClass:
+                                          "badge badge-secondary font-weight-light"
+                                      },
+                                      [
+                                        _vm._v(
+                                          "\n                                    NULL\n                                "
+                                        )
+                                      ]
+                                    )
+                              ])
+                            ])
+                          })
+                        )
+                      ]
+                    )
+                  ])
+                ])
+              : _vm._e()
           ])
         }
       }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/app.js": "/app.js?id=c10397f5ef92f6ad64a0",
+    "/app.js": "/app.js?id=0f2db35845789d2401e0",
     "/app.css": "/app.css?id=0c1e654d28f1c73326c1",
     "/app-dark.css": "/app-dark.css?id=13df33880547628477b2"
 }

--- a/resources/js/screens/queries/preview.vue
+++ b/resources/js/screens/queries/preview.vue
@@ -66,6 +66,138 @@
 
                 <pre class="code-bg p-4 mb-0 text-white" ref="sqlcode">{{formatSQL(slotProps.entry.content.sql, slotProps.entry.content.bindings)}}</pre>
             </div>
+
+            <div class="card mt-5" v-if="slotProps.entry.content.explains && slotProps.entry.content.explains.length">
+                <div class="card-header"><h5>Explains</h5></div>
+
+                <div class="table-responsive">
+                    <table class="table table-hover table-sm mb-0">
+                        <thead>
+                            <tr>
+                                <th>id</th>
+                                <th>select_type</th>
+                                <th>table</th>
+                                <th>partitions</th>
+                                <th>type</th>
+                                <th>possible_keys</th>
+                                <th>key</th>
+                                <th>key_len</th>
+                                <th>ref</th>
+                                <th>rows</th>
+                                <th>filtered</th>
+                                <th>Extra</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr v-for="explain in slotProps.entry.content.explains">
+                                <td>{{explain.id}}</td>
+
+                                <td>{{explain.select_type}}</td>
+
+                                <td class="table-fit">
+                                    <span v-if="explain.table">
+                                        {{explain.table}}
+                                    </span>
+
+                                    <span class="badge badge-secondary font-weight-light" v-else>
+                                        NULL
+                                    </span>
+                                </td>
+
+                                <td class="table-fit">
+                                    <span v-if="explain.partitions">
+                                        {{explain.partitions}}
+                                    </span>
+
+                                    <span class="badge badge-secondary font-weight-light" v-else>
+                                        NULL
+                                    </span>
+                                </td>
+
+                                <td class="table-fit">
+                                    <span v-if="explain.type">
+                                        {{explain.type}}
+                                    </span>
+
+                                    <span class="badge badge-secondary font-weight-light" v-else>
+                                        NULL
+                                    </span>
+                                </td>
+
+                                <td class="table-fit">
+                                    <span v-if="explain.possible_keys">
+                                        {{explain.possible_keys}}
+                                    </span>
+
+                                    <span class="badge badge-secondary font-weight-light" v-else>
+                                        NULL
+                                    </span>
+                                </td>
+
+                                <td class="table-fit">
+                                    <span v-if="explain.key">
+                                        {{explain.key}}
+                                    </span>
+
+                                    <span class="badge badge-secondary font-weight-light" v-else>
+                                        NULL
+                                    </span>
+                                </td>
+
+                                <td class="table-fit">
+                                    <span v-if="explain.key_len">
+                                        {{explain.key_len}}
+                                    </span>
+
+                                    <span class="badge badge-secondary font-weight-light" v-else>
+                                        NULL
+                                    </span>
+                                </td>
+
+                                <td class="table-fit">
+                                    <span v-if="explain.ref">
+                                        {{explain.ref}}
+                                    </span>
+
+                                    <span class="badge badge-secondary font-weight-light" v-else>
+                                        NULL
+                                    </span>
+                                </td>
+
+                                <td class="table-fit">
+                                    <span v-if="explain.rows">
+                                        {{explain.rows}}
+                                    </span>
+
+                                    <span class="badge badge-secondary font-weight-light" v-else>
+                                        NULL
+                                    </span>
+                                </td>
+
+                                <td class="table-fit">
+                                    <span v-if="explain.filtered">
+                                        {{explain.filtered}}
+                                    </span>
+
+                                    <span class="badge badge-secondary font-weight-light" v-else>
+                                        NULL
+                                    </span>
+                                </td>
+
+                                <td class="table-fit">
+                                    <span v-if="explain.Extra">
+                                        {{explain.Extra}}
+                                    </span>
+
+                                    <span class="badge badge-secondary font-weight-light" v-else>
+                                        NULL
+                                    </span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
     </preview-screen>
 </template>

--- a/tests/Watchers/QueryWatcherTest.php
+++ b/tests/Watchers/QueryWatcherTest.php
@@ -17,6 +17,9 @@ class QueryWatcherTest extends FeatureTestCase
             QueryWatcher::class => [
                 'enabled' => true,
                 'slow' => 0.2,
+                'explain' => [
+                    'enabled' => false,
+                ],
             ],
         ]);
     }


### PR DESCRIPTION
[Explain](https://dev.mysql.com/doc/refman/8.0/en/explain.html) can be useful to [improve query performance](https://dev.mysql.com/doc/workbench/en/wb-tutorial-visual-explain-dbt3.html) while developing an app.

A new `Explains` table will be shown under the `Query` card in the query details page if the query has any explain data. Which type of queries will gather explain information, can be controlled from the config.

![telescope-explain-queries](https://user-images.githubusercontent.com/10138936/48619175-dbc8d000-e9c5-11e8-83d0-11ee1f996329.png)