### PR TITLE
[1.0] Fix prune command hours option

### DIFF
--- a/src/Console/PruneCommand.php
+++ b/src/Console/PruneCommand.php
@@ -12,7 +12,7 @@ class PruneCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'telescope:prune {hours=24 : The number of hours to retain Telescope data}';
+    protected $signature = 'telescope:prune {--hours=24 : The number of hours to retain Telescope data}';
 
     /**
      * The console command description.
@@ -29,6 +29,6 @@ class PruneCommand extends Command
      */
     public function handle(PrunableRepository $repository)
     {
-        $this->info($repository->prune(now()->subHours($this->argument('hours'))).' entries pruned.');
+        $this->info($repository->prune(now()->subHours($this->option('hours'))).' entries pruned.');
     }
 }

--- a/src/Console/PruneCommand.php
+++ b/src/Console/PruneCommand.php
@@ -12,7 +12,7 @@ class PruneCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'telescope:prune {--hours=24 : The number of hours to retain Telescope data}';
+    protected $signature = 'telescope:prune {hours=24 : The number of hours to retain Telescope data}';
 
     /**
      * The console command description.

--- a/tests/Console/PruneCommandTest.php
+++ b/tests/Console/PruneCommandTest.php
@@ -30,7 +30,7 @@ class PruneCommandTest extends FeatureTestCase
 
         $this->artisan('telescope:prune')->expectsOutput('0 entries pruned.');
 
-        $this->artisan('telescope:prune', ['hours' => 4])->expectsOutput('1 entries pruned.');
+        $this->artisan('telescope:prune', ['--hours' => 4])->expectsOutput('1 entries pruned.');
 
         $this->assertDatabaseMissing('telescope_entries', ['uuid' => $recent->uuid]);
     }

--- a/tests/Console/PruneCommandTest.php
+++ b/tests/Console/PruneCommandTest.php
@@ -21,4 +21,17 @@ class PruneCommandTest extends FeatureTestCase
 
         $this->assertDatabaseMissing('telescope_entries', ['uuid' => $old->uuid]);
     }
+
+    public function test_prune_command_can_vary_hours()
+    {
+        $this->loadFactoriesUsing($this->app, __DIR__ . '/../../src/Storage/factories');
+
+        $recent = factory(EntryModel::class)->create(['created_at' => now()->subHours(5)]);
+
+        $this->artisan('telescope:prune')->expectsOutput('0 entries pruned.');
+
+        $this->artisan('telescope:prune', ['hours' => 4])->expectsOutput('1 entries pruned.');
+
+        $this->assertDatabaseMissing('telescope_entries', ['uuid' => $recent->uuid]);
+    }
 }

--- a/tests/Console/PruneCommandTest.php
+++ b/tests/Console/PruneCommandTest.php
@@ -24,7 +24,7 @@ class PruneCommandTest extends FeatureTestCase
 
     public function test_prune_command_can_vary_hours()
     {
-        $this->loadFactoriesUsing($this->app, __DIR__ . '/../../src/Storage/factories');
+        $this->loadFactoriesUsing($this->app, __DIR__.'/../../src/Storage/factories');
 
         $recent = factory(EntryModel::class)->create(['created_at' => now()->subHours(5)]);
 


### PR DESCRIPTION
The prune command is currently broken and tests are failing because of the `argument` call for the option. This PR fixes the hours option.

Closes #403  