### PR TITLE
Use double quotes for HTML attributes.

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -11,7 +11,7 @@
 
     <!-- Style sheets-->
     <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet">
-    <link href='{{ asset(mix($cssFile, 'vendor/telescope')) }}' rel='stylesheet' type='text/css'>
+    <link href="{{ asset(mix($cssFile, 'vendor/telescope')) }}" rel="stylesheet" type="text/css">
 </head>
 <body>
 <div id="telescope" v-cloak>


### PR DESCRIPTION
Using single quotes on the style sheet link tag causes problems when used with beyondcode/laravel-tag-helper -package (see https://github.com/beyondcode/laravel-tag-helper/issues/9). 

To get around this issue, this change swaps those single quotes for doubles. All the other tags have double quotes so this also makes the style more consistent.