### PR TITLE
Add package discover command to ignore list

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -133,6 +133,7 @@ class Telescope
                 // 'migrate:refresh',
                 'migrate:reset',
                 'migrate:install',
+                'package:discover',
                 'queue:listen',
                 'queue:work',
                 'horizon',


### PR DESCRIPTION
Currently, a `composer require laravel/telescope` triggers database calls while trying to load monitored tags. This can cause certain CI/CD issues when not having the database configured at the `composer require` stage. This PR attempts to fix this issue by adding the package discover command to the ignored list.

Although the `CommandWatcher` does not record the package discover command, it still triggers the database calls. Fixes #402 