### PR TITLE
Fix container contract violation

### DIFF
--- a/src/RegistersWatchers.php
+++ b/src/RegistersWatchers.php
@@ -43,7 +43,7 @@ trait RegistersWatchers
                 continue;
             }
 
-            $watcher = $app->makeWith(is_string($key) ? $key : $watcher, [
+            $watcher = $app->make(is_string($key) ? $key : $watcher, [
                 'options' => is_array($watcher) ? $watcher : [],
             ]);
 


### PR DESCRIPTION
The `makeWith` method is not on the contract and it is just an alias for the `make` method which is on the contract.