### PR TITLE
Allow telescope to be enabled in testing

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -39,6 +39,8 @@ return [
 
     'enabled' => env('TELESCOPE_ENABLED', true),
 
+    'enabled_in_testing' => env('TELESCOPE_ENABLED_IN_TESTING', false),
+
     /*
     |--------------------------------------------------------------------------
     | Telescope Route Middleware

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -103,7 +103,7 @@ class Telescope
      */
     public static function start($app)
     {
-        if ($app->runningUnitTests()) {
+        if ($app->runningUnitTests() && ! config('telescope.enabled_in_testing', false)) {
             return;
         }
 


### PR DESCRIPTION
It's pretty useful to be able to use telescope during automated testing (say to debug some specific tests). However at the moment, there is no way at all to have telescope enabled during automated test runs and no way to configure this.

This allows the developer to enable telescope in a testing env with a simple .env switch.