### PR TITLE
Fix storing session errors field

### DIFF
--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -111,6 +111,9 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
         $this->storeExceptions($exceptions);
 
         $this->table('telescope_entries')->insert($entries->map(function ($entry) {
+            if (isset($entry->content['session']) && isset($entry->content['session']['errors'])) {
+                $entry->content['session']['errors'] = $entry->content['session']['errors']->getBags();
+            }
             $entry->content = json_encode($entry->content);
 
             return $entry->toArray();


### PR DESCRIPTION
ViewErrorBag can't be serialized to json and stored as empty object '{}', it's becouse $basg (in ViewErrorBag) array of the view error bags is protected.