### PR TITLE
Allow Telescope routes to be "domain-based"

### DIFF
--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -52,6 +52,7 @@ class TelescopeServiceProvider extends ServiceProvider
     private function routeConfiguration()
     {
         return [
+            'domain' => config('telescope.domain'),
             'namespace' => 'Laravel\Telescope\Http\Controllers',
             'prefix' => config('telescope.path'),
             'middleware' => 'telescope',


### PR DESCRIPTION
Such as Nova, for example, it would be nice to allow to configure Telescope to serve routes only on a specific domain.

Taken Nova as a "best practice", the PR does not include pre-defined config in the configuration file. Also, I don't see a reason to include this change in Tests (_domain routing is a standard feature of Router, so tested there_).

Routes are protected via Authorization, but just for a project with more subdomains running one Laravel instance (_serving different content on different subdomains_), I simply like everything clean.
