### PR TITLE
Check TELESCOPE_ENABLED instead of `runningUnitTests()`

### DIFF
--- a/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -42,7 +42,7 @@ class CreateTelescopeEntriesTable extends Migration
                 $table->string('type', 20);
                 $table->text('content');
                 $table->dateTime('created_at')->nullable();
-    
+
                 $table->unique('uuid');
                 $table->index('batch_id');
                 $table->index(['type', 'should_display_on_index']);
@@ -53,10 +53,10 @@ class CreateTelescopeEntriesTable extends Migration
             $this->schema->create('telescope_entries_tags', function (Blueprint $table) {
                 $table->uuid('entry_uuid');
                 $table->string('tag');
-    
+
                 $table->index(['entry_uuid', 'tag']);
                 $table->index('tag');
-    
+
                 $table->foreign('entry_uuid')
                       ->references('uuid')
                       ->on('telescope_entries')

--- a/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -32,37 +32,43 @@ class CreateTelescopeEntriesTable extends Migration
      */
     public function up()
     {
-        $this->schema->create('telescope_entries', function (Blueprint $table) {
-            $table->bigIncrements('sequence');
-            $table->uuid('uuid');
-            $table->uuid('batch_id');
-            $table->string('family_hash')->nullable()->index();
-            $table->boolean('should_display_on_index')->default(true);
-            $table->string('type', 20);
-            $table->text('content');
-            $table->dateTime('created_at')->nullable();
+        if (!$this->schema->hasTable('telescope_entries')) {
+            $this->schema->create('telescope_entries', function (Blueprint $table) {
+                $table->bigIncrements('sequence');
+                $table->uuid('uuid');
+                $table->uuid('batch_id');
+                $table->string('family_hash')->nullable()->index();
+                $table->boolean('should_display_on_index')->default(true);
+                $table->string('type', 20);
+                $table->text('content');
+                $table->dateTime('created_at')->nullable();
+    
+                $table->unique('uuid');
+                $table->index('batch_id');
+                $table->index(['type', 'should_display_on_index']);
+            });
+        }
 
-            $table->unique('uuid');
-            $table->index('batch_id');
-            $table->index(['type', 'should_display_on_index']);
-        });
+        if (!$this->schema->hasTable('telescope_entries_tags')) {
+            $this->schema->create('telescope_entries_tags', function (Blueprint $table) {
+                $table->uuid('entry_uuid');
+                $table->string('tag');
+    
+                $table->index(['entry_uuid', 'tag']);
+                $table->index('tag');
+    
+                $table->foreign('entry_uuid')
+                      ->references('uuid')
+                      ->on('telescope_entries')
+                      ->onDelete('cascade');
+            });
+        }
 
-        $this->schema->create('telescope_entries_tags', function (Blueprint $table) {
-            $table->uuid('entry_uuid');
-            $table->string('tag');
-
-            $table->index(['entry_uuid', 'tag']);
-            $table->index('tag');
-
-            $table->foreign('entry_uuid')
-                  ->references('uuid')
-                  ->on('telescope_entries')
-                  ->onDelete('cascade');
-        });
-
-        $this->schema->create('telescope_monitoring', function (Blueprint $table) {
-            $table->string('tag');
-        });
+        if (!$this->schema->hasTable('telescope_monitoring')) {
+            $this->schema->create('telescope_monitoring', function (Blueprint $table) {
+                $table->string('tag');
+            });
+        }
     }
 
     /**

--- a/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -32,7 +32,7 @@ class CreateTelescopeEntriesTable extends Migration
      */
     public function up()
     {
-        if (!$this->schema->hasTable('telescope_entries')) {
+        if (! $this->schema->hasTable('telescope_entries')) {
             $this->schema->create('telescope_entries', function (Blueprint $table) {
                 $table->bigIncrements('sequence');
                 $table->uuid('uuid');
@@ -49,7 +49,7 @@ class CreateTelescopeEntriesTable extends Migration
             });
         }
 
-        if (!$this->schema->hasTable('telescope_entries_tags')) {
+        if (! $this->schema->hasTable('telescope_entries_tags')) {
             $this->schema->create('telescope_entries_tags', function (Blueprint $table) {
                 $table->uuid('entry_uuid');
                 $table->string('tag');
@@ -64,7 +64,7 @@ class CreateTelescopeEntriesTable extends Migration
             });
         }
 
-        if (!$this->schema->hasTable('telescope_monitoring')) {
+        if (! $this->schema->hasTable('telescope_monitoring')) {
             $this->schema->create('telescope_monitoring', function (Blueprint $table) {
                 $table->string('tag');
             });

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -103,7 +103,7 @@ class Telescope
      */
     public static function start($app)
     {
-        if ($app->runningUnitTests()) {
+        if (!config('telescope.enabled')) {
             return;
         }
 

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -103,7 +103,7 @@ class Telescope
      */
     public static function start($app)
     {
-        if (!config('telescope.enabled')) {
+        if (! config('telescope.enabled')) {
             return;
         }
 


### PR DESCRIPTION
This is an attempt at Taylor's comment from here: https://github.com/laravel/telescope/pull/415#issuecomment-440304272

This will allow users to enable and use Telescope for unit tests.

**Telescope Changes** 

* Replace `$app->runningUnitTests()` with `config('telescope.enabled')`
* Update the migrations to check if the tables exist before attempting to create them. The reason for this change is because unit tests will often drop/re-migrate the database. However, if you configure Telescope to use a different database than your test database, the Telescope DB will not be dropped, but it will be re-migrated. 

**Application changes**

* Add new database connection for Telescope: 

```
        'telescope' => [
            'driver' => 'sqlite',
            'database' => database_path('telescope.sqlite'),
            'prefix' => '',
        ],
```

* Change my `config/telescope.php` file to use a new environment variable for the database connection: `'connection' => env('TELESCOPE_DB_CONNECTION', 'mysql'),`
* Add the new environment variable to my `.env` file: `TELESCOPE_DB_CONNECTION=telescope`
* Add new sqlite database file: `touch database/telescope.sqlite`
* Change the `Telescope::filter` closure. Calling `$this->app->isLocal()` inside the closure throws an exception which I couldn't figure out:

Change I made:

```
        $telescopeFilter = $this->app->isLocal() || $this->app->runningUnitTests();

        Telescope::filter(function (IncomingEntry $entry) use ($telescopeFilter) {
            if ($telescopeFilter) {
                return true;
            }
            
            return $entry->isReportableException() ||
                   $entry->isFailedJob() ||
                   $entry->isScheduledTask() ||
                   $entry->hasMonitoredTag();
        });
```

Exception when using `$this->app->isLocal()` inside the closure:
```
ReflectionException: Class env does not exist

/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Container/Container.php:779
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Container/Container.php:658
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Container/Container.php:609
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:735
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Container/Container.php:1222
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:495
/var/www/remoteauth-app/app/Providers/TelescopeServiceProvider.php:26
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Support/HigherOrderCollectionProxy.php:60
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Support/HigherOrderCollectionProxy.php:60
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Support/Collection.php:455
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Support/HigherOrderCollectionProxy.php:61
/var/www/telescope/src/Telescope.php:232
/var/www/telescope/src/Telescope.php:201
/var/www/telescope/src/Telescope.php:235
/var/www/telescope/src/Telescope.php:358
/var/www/telescope/src/Watchers/QueryWatcher.php:43
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Events/Dispatcher.php:360
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Events/Dispatcher.php:209
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Database/Connection.php:826
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Database/Connection.php:682
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Database/Connection.php:635
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Database/Connection.php:333
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Database/Connection.php:304
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Database/Schema/Builder.php:73
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php:169
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Database/Migrations/Migrator.php:556
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Database/Console/Migrations/MigrateCommand.php:91
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Database/Console/Migrations/MigrateCommand.php:63
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:29
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:87
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:31
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Container/Container.php:572
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Console/Command.php:183
/var/www/remoteauth-app/vendor/symfony/console/Command/Command.php:255
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Console/Command.php:170
/var/www/remoteauth-app/vendor/symfony/console/Application.php:886
/var/www/remoteauth-app/vendor/symfony/console/Application.php:262
/var/www/remoteauth-app/vendor/symfony/console/Application.php:145
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Console/Application.php:89
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Console/Application.php:188
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php:250
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Foundation/Testing/PendingCommand.php:136
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Foundation/Testing/PendingCommand.php:218
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php:55
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Foundation/Testing/RefreshDatabase.php:40
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Foundation/Testing/RefreshDatabase.php:17
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Foundation/Testing/TestCase.php:104
/var/www/remoteauth-app/vendor/laravel/framework/src/Illuminate/Foundation/Testing/TestCase.php:71
/var/www/remoteauth-app/tests/TestCase.php:15
```

**Unresolved issues/questions**

* [ ] This will enable Telescope during tests by default because Telescope is enabled by default here:  `'enabled' => env('TELESCOPE_ENABLED', true),`
* [ ] If anyone knows why the `ReflectionException: Class env does not exist` exception is thrown when calling `$this->app->isLocal()` inside the Telescope filter, that would be nice to clean up too.