### PR TITLE
Make index table responsive

### DIFF
--- a/resources/js/components/IndexScreen.vue
+++ b/resources/js/components/IndexScreen.vue
@@ -287,7 +287,7 @@
         </div>
 
 
-        <table id="indexScreen" class="table table-hover table-sm mb-0 penultimate-column-right" v-if="ready && entries.length > 0">
+        <table id="indexScreen" class="table table-hover table-sm mb-0 penultimate-column-right table-responsive" v-if="ready && entries.length > 0">
             <thead>
             <slot name="table-header"></slot>
             </thead>


### PR DESCRIPTION
Text overflows if the content is big in the column.

#### Before
![image](https://user-images.githubusercontent.com/12662173/49141367-6a214800-f31c-11e8-92d4-7b388999b246.png)
Row overflows

----
#### Proposed
![image](https://user-images.githubusercontent.com/12662173/49141399-8329f900-f31c-11e8-9f59-e627594fcf17.png)
Adds horizontal bar below the table by adding `table-responsive` class.

Thanks.