### PR TITLE
Hide disabled watchers from navigation

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -57,6 +57,7 @@
         <div class="row mt-4">
             <div class="col-2 sidebar">
                 <ul class="nav flex-column">
+                    @if(in_array('Request', $navigation))
                     <li class="nav-item">
                         <router-link active-class="active" to="/requests" class="nav-link d-flex align-items-center pt-0">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -65,6 +66,8 @@
                             <span>Requests</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if(in_array('Command', $navigation))
                     <li class="nav-item">
                         <router-link active-class="active" to="/commands" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -73,6 +76,8 @@
                             <span>Commands</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if(in_array('Schedule', $navigation))
                     <li class="nav-item">
                         <router-link active-class="active" to="/schedule" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -81,6 +86,8 @@
                             <span>Schedule</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if(in_array('Job', $navigation))
                     <li class="nav-item">
                         <router-link active-class="active" to="/jobs" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -89,7 +96,8 @@
                             <span>Jobs</span>
                         </router-link>
                     </li>
-
+                    @endif
+                    @if(in_array('Exception', $navigation))
                     <li class="nav-item mt-3">
                         <router-link active-class="active" to="/exceptions" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -98,6 +106,8 @@
                             <span>Exceptions</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if(in_array('Log', $navigation))
                     <li class="nav-item">
                         <router-link active-class="active" to="/logs" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -106,6 +116,8 @@
                             <span>Logs</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if(in_array('Dump', $navigation))
                     <li class="nav-item">
                         <router-link active-class="active" to="/dumps" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -114,6 +126,8 @@
                             <span>Dumps</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if(in_array('Query', $navigation))
                     <li class="nav-item">
                         <router-link active-class="active" to="/queries" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -122,6 +136,8 @@
                             <span>Queries</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if(in_array('Model', $navigation))
                     <li class="nav-item">
                         <router-link active-class="active" to="/models" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -130,6 +146,8 @@
                             <span>Models</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if(in_array('Event', $navigation))
                     <li class="nav-item">
                         <router-link active-class="active" to="/events" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -138,6 +156,8 @@
                             <span>Events</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if(in_array('Mail', $navigation))
                     <li class="nav-item">
                         <router-link active-class="active" to="/mail" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -146,6 +166,8 @@
                             <span>Mail</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if(in_array('Notification', $navigation))
                     <li class="nav-item">
                         <router-link active-class="active" to="/notifications" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -154,6 +176,8 @@
                             <span>Notifications</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if(in_array('Cache', $navigation))
                     <li class="nav-item">
                         <router-link active-class="active" to="/cache" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -162,6 +186,8 @@
                             <span>Cache</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if(in_array('Redis', $navigation))
                     <li class="nav-item">
                         <router-link active-class="active" to="/redis" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -170,6 +196,7 @@
                             <span>Redis</span>
                         </router-link>
                     </li>
+                    @endif
                 </ul>
             </div>
 

--- a/src/Http/Controllers/HomeController.php
+++ b/src/Http/Controllers/HomeController.php
@@ -17,6 +17,7 @@ class HomeController extends Controller
         return view('telescope::layout', [
             'cssFile' => Telescope::$useDarkTheme ? 'app-dark.css' : 'app.css',
             'telescopeScriptVariables' => Telescope::scriptVariables(),
+            'navigation' => Telescope::navigation(),
         ]);
     }
 }

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -601,4 +601,31 @@ class Telescope
             'recording' => ! cache('telescope:pause-recording'),
         ];
     }
+
+    /**
+     * Get the navigation items for telescope.
+     *
+     * @return array
+     */
+    public static function navigation()
+    {
+        return array_map(function ($watcher) {
+            return $watcher::$label ?? Str::replaceFirst('Watcher', '', class_basename($watcher));
+        },
+        array_keys(static::enabledWatchers()));
+    }
+
+    /**
+     * Get list of the enabled watchers.
+     *
+     * @return array
+     */
+    public static function enabledWatchers()
+    {
+        return array_filter(config('telescope.watchers'), function ($options) {
+            $status = is_array($options) ? $options['enabled'] : $options;
+
+            return $status === true;
+        });
+    }
 }

--- a/tests/Http/NavigationTest.php
+++ b/tests/Http/NavigationTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Laravel\Telescope\Tests\Unit;
+
+use Laravel\Telescope\Telescope;
+use Laravel\Telescope\Watchers\JobWatcher;
+use Laravel\Telescope\Watchers\LogWatcher;
+use Laravel\Telescope\Watchers\DumpWatcher;
+use Laravel\Telescope\Watchers\MailWatcher;
+use Laravel\Telescope\Tests\FeatureTestCase;
+use Laravel\Telescope\Watchers\CacheWatcher;
+use Laravel\Telescope\Watchers\EventWatcher;
+use Laravel\Telescope\Watchers\ModelWatcher;
+use Laravel\Telescope\Watchers\QueryWatcher;
+use Laravel\Telescope\Watchers\RedisWatcher;
+use Laravel\Telescope\Watchers\CommandWatcher;
+use Laravel\Telescope\Watchers\RequestWatcher;
+use Laravel\Telescope\Watchers\ScheduleWatcher;
+use Laravel\Telescope\Watchers\ExceptionWatcher;
+use Laravel\Telescope\Watchers\NotificationWatcher;
+
+class NavigationTest extends FeatureTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+    }
+
+    public function telescopeIndexRoutesProvider()
+    {
+        return [
+            'Mail' => ['Mail', MailWatcher::class],
+            'Exceptions' => ['Exception', ExceptionWatcher::class],
+            'Dumps' => ['Dump', DumpWatcher::class],
+            'Logs' => ['Log', LogWatcher::class],
+            'Notifications' => ['Notification', NotificationWatcher::class],
+            'Jobs' => ['Job', JobWatcher::class],
+            'Events' => ['Event', EventWatcher::class],
+            'Cache' => ['Cache', CacheWatcher::class],
+            'Queries' => ['Query', QueryWatcher::class],
+            'Models' => ['Model', ModelWatcher::class],
+            'Request' => ['Request', RequestWatcher::class],
+            'Commands' => ['Command', CommandWatcher::class],
+            'Schedule' => ['Schedule', ScheduleWatcher::class],
+            'Redis' => ['Redis', RedisWatcher::class],
+        ];
+    }
+
+    /**
+     * @dataProvider telescopeIndexRoutesProvider
+     */
+    public function test_navigation_visible($label, $watcher)
+    {
+        $this->app->get('config')->set(
+            'telescope.watchers', [
+            $watcher => true,
+        ]);
+
+        $this->assertContains($label, Telescope::navigation());
+    }
+
+    /**
+     * @dataProvider telescopeIndexRoutesProvider
+     */
+    public function test_navigation_hidden($label, $watcher)
+    {
+        $this->app->get('config')->set(
+            'telescope.watchers', [
+            $watcher => false,
+        ]);
+
+        $this->assertNotContains($label, Telescope::navigation());
+    }
+}


### PR DESCRIPTION
Hides watchers from navigation if there are disabled in the config file as requested in #441.

On Problem exists, when disabling the ExceptionWatcher, the spacing between the two navigation groups disapears. I am open for suggestions that are not as ugly as the ones I am thinking of 😄 

