### PR TITLE
QueryWatcher location can ignore Composer packages

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -99,6 +99,7 @@ return [
 
         Watchers\QueryWatcher::class => [
             'enabled' => env('TELESCOPE_QUERY_WATCHER', true),
+            'ignore_packages' => true,
             'slow' => 100,
         ],
 

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -80,8 +80,20 @@ class QueryWatcher extends Watcher
             }
 
             return ! Str::contains($frame['file'],
-                base_path('vendor'.DIRECTORY_SEPARATOR.'laravel')
+                base_path('vendor'.DIRECTORY_SEPARATOR.$this->ignoredVendorPath())
             );
         });
+    }
+
+    /**
+     * Choose the frame outside of either Telescope/Laravel or all packages.
+     *
+     * @return string|null
+     */
+    protected function ignoredVendorPath()
+    {
+        if (! ($this->options['ignore_packages'] ?? true)) {
+            return 'laravel';
+        }
     }
 }


### PR DESCRIPTION
![query-location](https://user-images.githubusercontent.com/823566/49189064-f17db400-f33a-11e8-943c-4cb4ffb48d3f.png)

When Eloquent models use third-party Composer packages to build queries, the query watcher can log class / line number location for a file outside of the Laravel `app/` or `resources/views` subdirectories.

Example Composer packages:

* https://packagist.org/packages/spatie/laravel-translatable
* https://packagist.org/packages/dimsav/laravel-translatable
* https://packagist.org/packages/staudenmeir/eloquent-eager-limit

## Find query location _in your application code_

~Example configuration:~ Changed in a comment below to `['ignore_packages' => true]`.

```php
Watchers\QueryWatcher::class => [
    'enabled' => env('TELESCOPE_QUERY_WATCHER', true),
    'ignore_packages' => [
        'dimsav/laravel-translatable',
    ],
    'slow' => 100,
],
```

In addition to ignoring `vendor/laravel/*`, this will also ignore `vendor/dimsav/laravel-translatable` file paths (or `vendor\dimsav\laravel-translatable` on Windows) and go further up the callee stacktrace to find where the query was started.

## PHPUnit Coverage

This is difficult to test in PHPUnit since `getCallerFromStackTrace()` calls PHP function `debug_backtrace()` that can't be overloaded.

I confirmed this works as intended for two Laravel codebases affected by this.