### PR TITLE
[1.0] Improve performance: dont register watchers when not recording

### DIFF
--- a/src/Contracts/BootableWatcher.php
+++ b/src/Contracts/BootableWatcher.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laravel\Telescope\Contracts;
+
+interface BootableWatcher
+{
+    /**
+     * Boot the watcher.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return void
+     */
+    public function boot($app);
+}

--- a/src/RegistersWatchers.php
+++ b/src/RegistersWatchers.php
@@ -26,9 +26,10 @@ trait RegistersWatchers
      * Register the configured Telescope watchers.
      *
      * @param  \Illuminate\Foundation\Application  $app
+     * @param  bool  $bootOnly
      * @return void
      */
-    protected static function registerWatchers($app)
+    protected static function registerWatchers($app, $bootOnly = false)
     {
         if (! config('telescope.enabled')) {
             return;
@@ -49,7 +50,13 @@ trait RegistersWatchers
 
             static::$watchers[] = get_class($watcher);
 
-            $watcher->register($app);
+            if (method_exists($watcher, 'boot')) {
+                $watcher->boot($app);
+            }
+
+            if (! $bootOnly) {
+                $watcher->register($app);
+            }
         }
     }
 }

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -107,13 +107,14 @@ class Telescope
             return;
         }
 
-        static::registerWatchers($app);
+        $needsRecording = static::runningApprovedArtisanCommand($app) ||
+            static::handlingApprovedRequest($app);
+        
+        static::registerWatchers($app, ! $needsRecording);
 
         static::registerMailableTagExtractor();
 
-        if (static::runningApprovedArtisanCommand($app) ||
-            static::handlingApprovedRequest($app)
-        ) {
+        if ($needsRecording) {
             static::startRecording();
         }
     }

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -109,7 +109,7 @@ class Telescope
 
         $needsRecording = static::runningApprovedArtisanCommand($app) ||
             static::handlingApprovedRequest($app);
-        
+
         static::registerWatchers($app, ! $needsRecording);
 
         static::registerMailableTagExtractor();

--- a/src/Watchers/JobWatcher.php
+++ b/src/Watchers/JobWatcher.php
@@ -16,7 +16,6 @@ use Laravel\Telescope\Contracts\BootableWatcher;
 
 class JobWatcher extends Watcher implements BootableWatcher
 {
-
     /**
      * Boot the watcher.
      *


### PR DESCRIPTION
Currently, the watchers are registered and listen to events (and store entries in memory) even on ignored commands or paths. This PR improves Telescope performance by only registering watchers & event listeners on approved commands/paths. 

Resubmit of #368. The earlier PR was reverted because of a bug in failing to record failed/processed jobs. That has been fixed in this PR by adding the ability to boot watchers.

Watchers will be booted even on ignored commands and paths, but they would only be registered on approved commands and paths. 

Fixes #443 