### PR TITLE
Dont build records if not recording

### DIFF
--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -7,7 +7,6 @@ use Laravel\Telescope\EntryType;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Laravel\Telescope\EntryResult;
-use Illuminate\Support\Facades\Schema;
 use Laravel\Telescope\Contracts\PrunableRepository;
 use Laravel\Telescope\Contracts\ClearableRepository;
 use Laravel\Telescope\Contracts\TerminableRepository;

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -204,6 +204,16 @@ class Telescope
     }
 
     /**
+     * Determine if Telescope is recording.
+     *
+     * @return bool
+     */
+    public static function isRecording()
+    {
+        return static::$shouldRecord;
+    }
+
+    /**
      * Record the given entry.
      *
      * @param  string  $type
@@ -212,7 +222,7 @@ class Telescope
      */
     protected static function record(string $type, IncomingEntry $entry)
     {
-        if (! static::$shouldRecord) {
+        if (! static::isRecording()) {
             return;
         }
 

--- a/src/Watchers/CacheWatcher.php
+++ b/src/Watchers/CacheWatcher.php
@@ -35,7 +35,7 @@ class CacheWatcher extends Watcher
      */
     public function recordCacheHit(CacheHit $event)
     {
-        if ($this->shouldIgnore($event)) {
+        if (! Telescope::isRecording() || $this->shouldIgnore($event)) {
             return;
         }
 

--- a/src/Watchers/CommandWatcher.php
+++ b/src/Watchers/CommandWatcher.php
@@ -28,7 +28,7 @@ class CommandWatcher extends Watcher
      */
     public function recordCommand(CommandFinished $event)
     {
-        if ($this->shouldIgnore($event)) {
+        if (! Telescope::isRecording() || $this->shouldIgnore($event)) {
             return;
         }
 

--- a/src/Watchers/DumpWatcher.php
+++ b/src/Watchers/DumpWatcher.php
@@ -40,7 +40,7 @@ class DumpWatcher extends Watcher
      */
     public function register($app)
     {
-        if (! $this->cache->get('telescope:dump-watcher')) {
+        if (! Telescope::isRecording() || ! $this->cache->get('telescope:dump-watcher')) {
             return;
         }
 

--- a/src/Watchers/EventWatcher.php
+++ b/src/Watchers/EventWatcher.php
@@ -34,7 +34,7 @@ class EventWatcher extends Watcher
      */
     public function recordEvent($eventName, $payload)
     {
-        if ($this->shouldIgnore($eventName)) {
+        if (! Telescope::isRecording() || $this->shouldIgnore($eventName)) {
             return;
         }
 

--- a/src/Watchers/ExceptionWatcher.php
+++ b/src/Watchers/ExceptionWatcher.php
@@ -29,7 +29,7 @@ class ExceptionWatcher extends Watcher
      */
     public function recordException(MessageLogged $event)
     {
-        if (! isset($event->context['exception'])) {
+        if (! Telescope::isRecording() || ! isset($event->context['exception'])) {
             return;
         }
 

--- a/src/Watchers/JobWatcher.php
+++ b/src/Watchers/JobWatcher.php
@@ -41,6 +41,10 @@ class JobWatcher extends Watcher
      */
     public function recordJob($connection, $queue, array $payload)
     {
+        if (! Telescope::isRecording()) {
+            return;
+        }
+
         $content = array_merge([
             'status' => 'pending',
         ], $this->defaultJobData($connection, $queue, $payload, $this->data($payload)));
@@ -61,6 +65,10 @@ class JobWatcher extends Watcher
      */
     public function recordProcessedJob(JobProcessed $event)
     {
+        if (! Telescope::isRecording()) {
+            return;
+        }
+
         $uuid = $event->job->payload()['telescope_uuid'] ?? null;
 
         if (! $uuid) {
@@ -80,6 +88,10 @@ class JobWatcher extends Watcher
      */
     public function recordFailedJob(JobFailed $event)
     {
+        if (! Telescope::isRecording()) {
+            return;
+        }
+
         $uuid = $event->job->payload()['telescope_uuid'] ?? null;
 
         if (! $uuid) {

--- a/src/Watchers/LogWatcher.php
+++ b/src/Watchers/LogWatcher.php
@@ -28,7 +28,7 @@ class LogWatcher extends Watcher
      */
     public function recordLog(MessageLogged $event)
     {
-        if (isset($event->context['exception'])) {
+        if (! Telescope::isRecording() || isset($event->context['exception'])) {
             return;
         }
 

--- a/src/Watchers/MailWatcher.php
+++ b/src/Watchers/MailWatcher.php
@@ -27,6 +27,10 @@ class MailWatcher extends Watcher
      */
     public function recordMail(MessageSent $event)
     {
+        if (! Telescope::isRecording()) {
+            return;
+        }
+
         Telescope::recordMail(IncomingEntry::make([
             'mailable' => $this->getMailable($event),
             'queued' => $this->getQueuedStatus($event),

--- a/src/Watchers/ModelWatcher.php
+++ b/src/Watchers/ModelWatcher.php
@@ -29,7 +29,7 @@ class ModelWatcher extends Watcher
      */
     public function recordAction($event, $data)
     {
-        if (! $this->shouldRecord($event)) {
+        if (! Telescope::isRecording() || ! $this->shouldRecord($event)) {
             return;
         }
 

--- a/src/Watchers/NotificationWatcher.php
+++ b/src/Watchers/NotificationWatcher.php
@@ -32,6 +32,10 @@ class NotificationWatcher extends Watcher
      */
     public function recordNotification(NotificationSent $event)
     {
+        if (! Telescope::isRecording()) {
+            return;
+        }
+
         Telescope::recordNotification(IncomingEntry::make([
             'notification' => get_class($event->notification),
             'queued' => in_array(ShouldQueue::class, class_implements($event->notification)),

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -28,6 +28,10 @@ class QueryWatcher extends Watcher
      */
     public function recordQuery(QueryExecuted $event)
     {
+        if (! Telescope::isRecording()) {
+            return;
+        }
+
         $time = $event->time;
 
         $caller = $this->getCallerFromStackTrace();

--- a/src/Watchers/RedisWatcher.php
+++ b/src/Watchers/RedisWatcher.php
@@ -27,6 +27,10 @@ class RedisWatcher extends Watcher
      */
     public function recordCommand(CommandExecuted $event)
     {
+        if (! Telescope::isRecording()) {
+            return;
+        }
+
         Telescope::recordRedis(IncomingEntry::make([
             'connection' => $event->connectionName,
             'command' => $this->formatCommand($event->command, $event->parameters),

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -35,6 +35,10 @@ class RequestWatcher extends Watcher
      */
     public function recordRequest(RequestHandled $event)
     {
+        if (! Telescope::isRecording()) {
+            return;
+        }
+
         Telescope::recordRequest(IncomingEntry::make([
             'uri' => str_replace($event->request->root(), '', $event->request->fullUrl()) ?: '/',
             'method' => $event->request->method(),

--- a/src/Watchers/ScheduleWatcher.php
+++ b/src/Watchers/ScheduleWatcher.php
@@ -30,7 +30,8 @@ class ScheduleWatcher extends Watcher
      */
     public function recordCommand(CommandStarting $event)
     {
-        if ($event->command !== 'schedule:run' &&
+        if (! Telescope::isRecording() ||
+            $event->command !== 'schedule:run' &&
             $event->command !== 'schedule:finish') {
             return;
         }


### PR DESCRIPTION
This PR will stop Telescope from building records if it's not recording anything.

Before this PR telescope was building the entries, but doesn't record them.

After this PR telescope will not even build the entries, and thus avoid any un-needed CPU usage.