### PR TITLE
Add verbose times toggle

### DIFF
--- a/resources/js/mixins/indexScreens.js
+++ b/resources/js/mixins/indexScreens.js
@@ -1,0 +1,40 @@
+import moment from 'moment-timezone';
+
+export default {
+    data() {
+        return {
+            displayVerboseTimes: localStorage.displayVerboseTimes === '1',
+        }
+    },
+
+    methods: {
+        /**
+         * Toggle displaying verbose or terse times.
+         */
+        toggleVerboseTimes(){
+            if (!this.displayVerboseTimes) {
+                this.displayVerboseTimes = true;
+                localStorage.displayVerboseTimes = 1;
+            } else {
+                this.displayVerboseTimes = false;
+                localStorage.displayVerboseTimes = 0;
+            }
+        },
+
+        /**
+         * Format to verbose time
+         */
+        verboseTime(time){
+            return moment(time + ' Z').utc().local().format('DD/MM/YY HH:mm:ss');
+        },
+    },
+
+    computed: {
+        /**
+         * Check if terse times should be displayed.
+         */
+        displayTerseTimes(){
+            return ! this.displayVerboseTimes;
+        },
+    },
+}

--- a/resources/js/screens/cache/index.vue
+++ b/resources/js/screens/cache/index.vue
@@ -1,8 +1,10 @@
 <script type="text/ecmascript-6">
+    import IndexMixin from './../../mixins/indexScreens';
     import StylesMixin from './../../mixins/entriesStyles';
 
     export default {
         mixins: [
+            IndexMixin,
             StylesMixin,
         ],
     }
@@ -13,7 +15,11 @@
         <tr slot="table-header">
             <th scope="col">Key</th>
             <th scope="col">Action</th>
-            <th scope="col">Happened</th>
+            <th scope="col">
+                <button class="btn btn-link p-0" :class="{active: displayVerboseTimes}" href="#" v-on:click.prevent="toggleVerboseTimes" title="Verbose times">
+                    Happened
+                </button>
+            </th>
             <th scope="col"></th>
         </tr>
 
@@ -27,7 +33,8 @@
                 </span>
             </td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td v-if="displayVerboseTimes" class="table-fit">{{verboseTime(slotProps.entry.created_at)}}</td>
+            <td v-else class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
 
             <td class="table-fit">
                 <router-link :to="{name:'cache-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/commands/index.vue
+++ b/resources/js/screens/commands/index.vue
@@ -1,5 +1,11 @@
 <script type="text/ecmascript-6">
-    export default {}
+    import IndexMixin from './../../mixins/indexScreens';
+
+    export default {
+        mixins: [
+            IndexMixin,
+        ],
+    }
 </script>
 
 <template>
@@ -7,7 +13,11 @@
         <tr slot="table-header">
             <th scope="col">Command</th>
             <th scope="col" class="table-fit">Exit Code</th>
-            <th scope="col">Happened</th>
+            <th scope="col">
+                <button class="btn btn-link p-0" :class="{active: displayVerboseTimes}" href="#" v-on:click.prevent="toggleVerboseTimes" title="Verbose times">
+                    Happened
+                </button>
+            </th>
             <th scope="col"></th>
         </tr>
 
@@ -16,7 +26,8 @@
 
             <td class="table-fit">{{slotProps.entry.content.exit_code}}</td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td v-if="displayVerboseTimes" class="table-fit">{{verboseTime(slotProps.entry.created_at)}}</td>
+            <td v-else class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
 
             <td class="table-fit">
                 <router-link :to="{name:'command-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/dumps/index.vue
+++ b/resources/js/screens/dumps/index.vue
@@ -1,5 +1,6 @@
 <script type="text/ecmascript-6">
     import axios from 'axios';
+    import IndexMixin from './../../mixins/indexScreens';
 
     export default {
         /**
@@ -14,6 +15,9 @@
             };
         },
 
+        mixins: [
+            IndexMixin,
+        ],
 
         /**
          * Prepare the component.
@@ -87,7 +91,10 @@
                             Command: {{entry.content.entry_point_description}}
                         </router-link>
 
-                        <span class="text-white text-monospace" style="font-size: 12px;">{{timeAgo(entry.created_at)}}</span>
+                        <button class="btn btn-link p-0 text-white text-monospace" :class="{active: displayVerboseTimes}" style="font-size: 12px;" href="#" v-on:click.prevent="toggleVerboseTimes" title="Verbose times">
+                            <span v-if="displayVerboseTimes">{{verboseTime(entry.created_at)}}</span>
+                            <span v-else>{{timeAgo(entry.created_at)}}</span>
+                        </button>
                     </div>
 
                     <div v-html="entry.content.dump"></div>

--- a/resources/js/screens/events/index.vue
+++ b/resources/js/screens/events/index.vue
@@ -1,5 +1,11 @@
 <script type="text/ecmascript-6">
-    export default {}
+    import IndexMixin from './../../mixins/indexScreens';
+
+    export default {
+        mixins: [
+            IndexMixin,
+        ],
+    }
 </script>
 
 <template>
@@ -7,7 +13,11 @@
         <tr slot="table-header">
             <th scope="col">Name</th>
             <th scope="col">Listeners</th>
-            <th scope="col">Happened</th>
+            <th scope="col">
+                <button class="btn btn-link p-0" :class="{active: displayVerboseTimes}" href="#" v-on:click.prevent="toggleVerboseTimes" title="Verbose times">
+                    Happened
+                </button>
+            </th>
             <th scope="col"></th>
         </tr>
 
@@ -23,7 +33,8 @@
 
             <td class="table-fit">{{slotProps.entry.content.listeners.length}}</td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td v-if="displayVerboseTimes" class="table-fit">{{verboseTime(slotProps.entry.created_at)}}</td>
+            <td v-else class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
 
             <td class="table-fit">
                 <router-link :to="{name:'event-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/exceptions/index.vue
+++ b/resources/js/screens/exceptions/index.vue
@@ -1,5 +1,11 @@
 <script type="text/ecmascript-6">
-    export default {}
+    import IndexMixin from './../../mixins/indexScreens';
+
+    export default {
+        mixins: [
+            IndexMixin,
+        ],
+    }
 </script>
 
 <template>
@@ -8,7 +14,11 @@
             <th scope="col" v-if="!$route.query.family_hash">Type</th>
             <th scope="col" v-if="!$route.query.family_hash && !$route.query.tag">Occurrences</th>
             <th scope="col" v-if="$route.query.family_hash">Message</th>
-            <th scope="col">Happened</th>
+            <th scope="col">
+                <button class="btn btn-link p-0" :class="{active: displayVerboseTimes}" href="#" v-on:click.prevent="toggleVerboseTimes" title="Verbose times">
+                    Happened
+                </button>
+            </th>
             <th scope="col"></th>
         </tr>
 
@@ -37,7 +47,8 @@
                 </small>
             </td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td v-if="displayVerboseTimes" class="table-fit">{{verboseTime(slotProps.entry.created_at)}}</td>
+            <td v-else class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
 
             <td class="table-fit">
                 <router-link :to="{name:'exception-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/jobs/index.vue
+++ b/resources/js/screens/jobs/index.vue
@@ -1,8 +1,10 @@
 <script type="text/ecmascript-6">
+    import IndexMixin from './../../mixins/indexScreens';
     import StylesMixin from './../../mixins/entriesStyles';
 
     export default {
         mixins: [
+            IndexMixin,
             StylesMixin,
         ],
     }
@@ -13,7 +15,11 @@
         <tr slot="table-header">
             <th scope="col">Job</th>
             <th scope="col">Status</th>
-            <th scope="col">Happened</th>
+            <th scope="col">
+                <button class="btn btn-link p-0" :class="{active: displayVerboseTimes}" href="#" v-on:click.prevent="toggleVerboseTimes" title="Verbose times">
+                    Happened
+                </button>
+            </th>
             <th scope="col"></th>
         </tr>
 
@@ -32,7 +38,8 @@
                 </span>
             </td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{ timeAgo(slotProps.entry.created_at) }}</td>
+            <td v-if="displayVerboseTimes" class="table-fit">{{verboseTime(slotProps.entry.created_at)}}</td>
+            <td v-else class="table-fit" :data-timeago="slotProps.entry.created_at">{{ timeAgo(slotProps.entry.created_at) }}</td>
 
             <td class="table-fit">
                 <router-link :to="{name:'job-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/logs/index.vue
+++ b/resources/js/screens/logs/index.vue
@@ -1,8 +1,10 @@
 <script type="text/ecmascript-6">
+    import IndexMixin from './../../mixins/indexScreens';
     import StylesMixin from './../../mixins/entriesStyles';
 
     export default {
         mixins: [
+            IndexMixin,
             StylesMixin,
         ],
     }
@@ -13,7 +15,11 @@
         <tr slot="table-header">
             <th scope="col">Message</th>
             <th scope="col">Level</th>
-            <th scope="col">Happened</th>
+            <th scope="col">
+                <button class="btn btn-link p-0" :class="{active: displayVerboseTimes}" href="#" v-on:click.prevent="toggleVerboseTimes" title="Verbose times">
+                    Happened
+                </button>
+            </th>
             <th scope="col"></th>
         </tr>
 
@@ -26,7 +32,8 @@
                 </span>
             </td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td v-if="displayVerboseTimes" class="table-fit">{{verboseTime(slotProps.entry.created_at)}}</td>
+            <td v-else class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
 
             <td class="table-fit">
                 <router-link :to="{name:'log-preview', params: {id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/mail/index.vue
+++ b/resources/js/screens/mail/index.vue
@@ -1,5 +1,11 @@
 <script type="text/ecmascript-6">
+    import IndexMixin from './../../mixins/indexScreens';
+
     export default {
+        mixins: [
+            IndexMixin,
+        ],
+
         methods: {
             recipientsCount(entry){
                 return _.union(Object.keys(entry.content.to),
@@ -16,7 +22,11 @@
         <tr slot="table-header">
             <th scope="col">Mailable</th>
             <th scope="col">Recipients</th>
-            <th scope="col">Happened</th>
+            <th scope="col">
+                <button class="btn btn-link p-0" :class="{active: displayVerboseTimes}" href="#" v-on:click.prevent="toggleVerboseTimes" title="Verbose times">
+                    Happened
+                </button>
+            </th>
             <th scope="col"></th>
         </tr>
 
@@ -38,7 +48,8 @@
 
             <td class="table-fit">{{recipientsCount(slotProps.entry)}}</td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td v-if="displayVerboseTimes" class="table-fit">{{verboseTime(slotProps.entry.created_at)}}</td>
+            <td v-else class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
 
             <td class="table-fit">
                 <router-link :to="{name:'mail-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/models/index.vue
+++ b/resources/js/screens/models/index.vue
@@ -1,8 +1,10 @@
 <script type="text/ecmascript-6">
+    import IndexMixin from './../../mixins/indexScreens';
     import StylesMixin from './../../mixins/entriesStyles';
 
     export default {
         mixins: [
+            IndexMixin,
             StylesMixin,
         ],
     }
@@ -13,7 +15,11 @@
         <tr slot="table-header">
             <th scope="col">Model</th>
             <th scope="col">Action</th>
-            <th scope="col">Happened</th>
+            <th scope="col">
+                <button class="btn btn-link p-0" :class="{active: displayVerboseTimes}" href="#" v-on:click.prevent="toggleVerboseTimes" title="Verbose times">
+                    Happened
+                </button>
+            </th>
             <th scope="col"></th>
         </tr>
 
@@ -27,7 +33,8 @@
                 </span>
             </td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td v-if="displayVerboseTimes" class="table-fit">{{verboseTime(slotProps.entry.created_at)}}</td>
+            <td v-else class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
 
             <td class="table-fit">
                 <router-link :to="{name:'model-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/notifications/index.vue
+++ b/resources/js/screens/notifications/index.vue
@@ -1,5 +1,11 @@
 <script type="text/ecmascript-6">
-    export default {}
+    import IndexMixin from './../../mixins/indexScreens';
+
+    export default {
+        mixins: [
+            IndexMixin,
+        ],
+    }
 </script>
 
 <template>
@@ -7,7 +13,11 @@
         <tr slot="table-header">
             <th scope="col">Notification</th>
             <th scope="col">Channel</th>
-            <th scope="col">Happened</th>
+            <th scope="col">
+                <button class="btn btn-link p-0" :class="{active: displayVerboseTimes}" href="#" v-on:click.prevent="toggleVerboseTimes" title="Verbose times">
+                    Happened
+                </button>
+            </th>
             <th scope="col"></th>
         </tr>
 
@@ -29,7 +39,8 @@
 
             <td class="table-fit">{{truncate(slotProps.entry.content.channel, 20)}}</td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td v-if="displayVerboseTimes" class="table-fit">{{verboseTime(slotProps.entry.created_at)}}</td>
+            <td v-else class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
 
             <td class="table-fit">
                 <router-link :to="{name:'notification-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/queries/index.vue
+++ b/resources/js/screens/queries/index.vue
@@ -1,5 +1,11 @@
 <script type="text/ecmascript-6">
-    export default {}
+    import IndexMixin from './../../mixins/indexScreens';
+
+    export default {
+        mixins: [
+            IndexMixin,
+        ],
+    }
 </script>
 
 <template>
@@ -7,7 +13,11 @@
         <tr slot="table-header">
             <th scope="col">Query</th>
             <th scope="col">Duration</th>
-            <th scope="col">Happened</th>
+            <th scope="col">
+                <button class="btn btn-link p-0" :class="{active: displayVerboseTimes}" href="#" v-on:click.prevent="toggleVerboseTimes" title="Verbose times">
+                    Happened
+                </button>
+            </th>
             <th scope="col"></th>
         </tr>
 
@@ -25,7 +35,8 @@
                 </span>
             </td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td v-if="displayVerboseTimes" class="table-fit">{{verboseTime(slotProps.entry.created_at)}}</td>
+            <td v-else class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
 
             <td class="table-fit">
                 <router-link :to="{name:'query-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/redis/index.vue
+++ b/resources/js/screens/redis/index.vue
@@ -1,5 +1,11 @@
 <script type="text/ecmascript-6">
-    export default {}
+    import IndexMixin from './../../mixins/indexScreens';
+
+    export default {
+        mixins: [
+            IndexMixin,
+        ],
+    }
 </script>
 
 <template>
@@ -7,7 +13,11 @@
         <tr slot="table-header">
             <th scope="col">Command</th>
             <th scope="col">Duration</th>
-            <th scope="col">Happened</th>
+            <th scope="col">
+                <button class="btn btn-link p-0" :class="{active: displayVerboseTimes}" href="#" v-on:click.prevent="toggleVerboseTimes" title="Verbose times">
+                    Happened
+                </button>
+            </th>
             <th scope="col"></th>
         </tr>
 
@@ -17,7 +27,8 @@
 
             <td class="table-fit">{{slotProps.entry.content.time}}ms</td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td v-if="displayVerboseTimes" class="table-fit">{{verboseTime(slotProps.entry.created_at)}}</td>
+            <td v-else class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
 
             <td class="table-fit">
                 <router-link :to="{name:'redis-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/requests/index.vue
+++ b/resources/js/screens/requests/index.vue
@@ -1,8 +1,10 @@
 <script type="text/ecmascript-6">
+    import IndexMixin from './../../mixins/indexScreens';
     import StylesMixin from './../../mixins/entriesStyles';
 
     export default {
         mixins: [
+            IndexMixin,
             StylesMixin,
         ],
     }
@@ -14,7 +16,11 @@
             <th scope="col">Verb</th>
             <th scope="col">Path</th>
             <th scope="col">Status</th>
-            <th scope="col">Happened</th>
+            <th scope="col">
+                <button class="btn btn-link p-0" :class="{active: displayVerboseTimes}" href="#" v-on:click.prevent="toggleVerboseTimes" title="Verbose times">
+                    Happened
+                </button>
+            </th>
             <th scope="col"></th>
         </tr>
 
@@ -34,7 +40,8 @@
                 </span>
             </td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td v-if="displayVerboseTimes" class="table-fit">{{verboseTime(slotProps.entry.created_at)}}</td>
+            <td v-else class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
 
             <td class="table-fit">
                 <router-link :to="{name:'request-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/schedule/index.vue
+++ b/resources/js/screens/schedule/index.vue
@@ -1,5 +1,11 @@
 <script type="text/ecmascript-6">
-    export default {}
+    import IndexMixin from './../../mixins/indexScreens';
+
+    export default {
+        mixins: [
+            IndexMixin,
+        ],
+    }
 </script>
 
 <template>
@@ -7,7 +13,11 @@
         <tr slot="table-header">
             <th scope="col">Command</th>
             <th scope="col">Expression</th>
-            <th scope="col">Happened</th>
+            <th scope="col">
+                <button class="btn btn-link p-0" :class="{active: displayVerboseTimes}" href="#" v-on:click.prevent="toggleVerboseTimes" title="Verbose times">
+                    Happened
+                </button>
+            </th>
             <th scope="col"></th>
         </tr>
 
@@ -16,7 +26,8 @@
 
             <td class="table-fit">{{slotProps.entry.content.expression}}</td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td v-if="displayVerboseTimes" class="table-fit">{{verboseTime(slotProps.entry.created_at)}}</td>
+            <td v-else class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
 
             <td class="table-fit">
                 <router-link :to="{name:'schedule-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/sass/base.scss
+++ b/resources/sass/base.scss
@@ -156,6 +156,10 @@ button:hover{
   box-shadow: none !important;
 }
 
+.btn-link.active {
+  font-weight: 600;
+}
+
 .control-action {
   svg {
     fill: $control-action-icon-color;
@@ -165,6 +169,9 @@ button:hover{
     &:hover {
       fill: $primary;
     }
+  }
+  &.active svg {
+    fill: $primary;
   }
 }
 


### PR DESCRIPTION
This PR introduces the ability to toggle "verbose times" on index pages, allowing for more fine grained monitoring of requests.

Currently you might get 60 requests in a second OR 60 requests every second of a minute and it will appear the same on the index views. This hopes to make it easier to differentiate which - only when needed.

**TODO**
- [ ] Needs an icon

---

Here is what I've introduced...

Off (default / existing behaviour):

<img width="1195" alt="screen shot 2018-11-30 at 6 08 41 pm" src="https://user-images.githubusercontent.com/24803032/49274320-12c1da00-f4cc-11e8-8be0-1c050ea20ce9.png">

On:

<img width="1159" alt="screen shot 2018-11-30 at 6 06 43 pm" src="https://user-images.githubusercontent.com/24803032/49274327-17868e00-f4cc-11e8-95e3-e1a1e01da64b.png">

## Reasoning

A Laravel app I'm working with is serving an API that is used by an iOS and an Android app. The mobile app makes a *heap* of requests at once and I'm currently using Telescope to monitor those requests in hopes I can get the mobile dev to chill out with all the dang requests (at one point it was over 25 a second every time the user navigated 😳) but also to stupid check everything else like cache hits etc.

I was struggling to keep track of the large number of requests being made as the "Happened" time only shows minute increments. I needed more precise time information on the index page to see when those requests are coming through. I know that verbose time is available in the preview screen, but I needed it specifically on the index page as I am watching the requests in real-time.

## Technical notes

- I didn't disable the `updateTimeAgo`. It still runs in the background, but I figure as it won't find any elements with the `data-timeago` attribute it isn't going to matter performance wise. Happy to disable / enable though if you wanted.
- I made the  `penultimate-column-right` class (great naming there!) only apply when the terse times are shown so that the label is left aligned with the longer times.

Hopefully this seems useful - it really helped me to understand how the requests were coming in.

---
Telescope is a fantastic tool, thank you for making and maintaining it!