### PR TITLE
Purge view data

### DIFF
--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -140,9 +140,11 @@ class RequestWatcher extends Watcher
         }
 
         if ($response instanceof IlluminateResponse && $response->getOriginalContent() instanceof View) {
+            $data = $this->extractDataFromView($response->getOriginalContent());
+
             return [
                 'view' => $response->getOriginalContent()->getPath(),
-                'data' => $this->extractDataFromView($response->getOriginalContent()),
+                'data' => $this->contentWithinLimits(json_encode($data)) ? $data : 'Purged By Telescope',
             ];
         }
 


### PR DESCRIPTION
Related to https://github.com/laravel/telescope/pull/291 - I have the same problem but for views with a lot of data, for example a bunch of models.

Not super happy for the solution - `json_encode()` on a large body of data is probably not for free and feels a bit odd to do the purging in multiple places.

