### PR TITLE
added "Duration" column to Requests tab

### DIFF
--- a/resources/js/screens/requests/index.vue
+++ b/resources/js/screens/requests/index.vue
@@ -14,6 +14,7 @@
             <th scope="col">Verb</th>
             <th scope="col">Path</th>
             <th scope="col">Status</th>
+            <th scope="col">Duration</th>
             <th scope="col">Happened</th>
             <th scope="col"></th>
         </tr>
@@ -32,6 +33,10 @@
                 <span class="badge font-weight-light" :class="'badge-'+requestStatusClass(slotProps.entry.content.response_status)">
                     {{slotProps.entry.content.response_status}}
                 </span>
+            </td>
+
+            <td class="table-fit">
+                {{slotProps.entry.content.duration || '-'}} ms
             </td>
 
             <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>


### PR DESCRIPTION
I find it very useful to see the duration of a request when looking at the list. And since this information is already stored and easy to access, I think it would be useful to include it in the list

<img width="1154" alt="screenshot 2018-11-30 15 26 34" src="https://user-images.githubusercontent.com/816028/49294890-8a840a80-f4b4-11e8-932b-d083c80dadac.png">
