### PR TITLE
[1.0] Provide AfterRecording Hook

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -35,6 +35,13 @@ class Telescope
     public static $filterBatchUsing = [];
 
     /**
+     * The callback executed after queuing a new entry.
+     *
+     * @var \Closure
+     */
+    public static $recordingCallback;
+
+    /**
      * The callback that adds tags to the record.
      *
      * @var \Closure
@@ -241,6 +248,10 @@ class Telescope
         static::withoutRecording(function () use ($entry) {
             if (collect(static::$filterUsing)->every->__invoke($entry)) {
                 static::$entriesQueue[] = $entry;
+            }
+
+            if (static::$recordingCallback) {
+                call_user_func(static::$recordingCallback, new static);
             }
         });
     }
@@ -465,6 +476,19 @@ class Telescope
     public static function filterBatch(Closure $callback)
     {
         static::$filterBatchUsing[] = $callback;
+
+        return new static;
+    }
+
+    /**
+     * Set the callback that will be executed after an entry is recorded in the queue.
+     *
+     * @param  \Closure  $callback
+     * @return static
+     */
+    public static function afterRecording(Closure $callback)
+    {
+        static::$recordingCallback = $callback;
 
         return new static;
     }

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -39,7 +39,7 @@ class Telescope
      *
      * @var \Closure
      */
-    public static $recordingCallback;
+    public static $afterRecordingHook;
 
     /**
      * The callback that adds tags to the record.
@@ -250,8 +250,8 @@ class Telescope
                 static::$entriesQueue[] = $entry;
             }
 
-            if (static::$recordingCallback) {
-                call_user_func(static::$recordingCallback, new static);
+            if (static::$afterRecordingHook) {
+                call_user_func(static::$afterRecordingHook, new static);
             }
         });
     }
@@ -488,7 +488,7 @@ class Telescope
      */
     public static function afterRecording(Closure $callback)
     {
-        static::$recordingCallback = $callback;
+        static::$afterRecordingHook = $callback;
 
         return new static;
     }

--- a/tests/Telescope/TelescopeTest.php
+++ b/tests/Telescope/TelescopeTest.php
@@ -2,10 +2,10 @@
 
 namespace Laravel\Telescope\Tests\Telescope;
 
-use Laravel\Telescope\Contracts\EntriesRepository;
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\Tests\FeatureTestCase;
 use Laravel\Telescope\Watchers\QueryWatcher;
+use Laravel\Telescope\Contracts\EntriesRepository;
 
 class TelescopeTest extends FeatureTestCase
 {

--- a/tests/Telescope/TelescopeTest.php
+++ b/tests/Telescope/TelescopeTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Laravel\Telescope\Tests\Telescope;
+
+use Laravel\Telescope\Contracts\EntriesRepository;
+use Laravel\Telescope\Telescope;
+use Laravel\Telescope\Tests\FeatureTestCase;
+use Laravel\Telescope\Watchers\QueryWatcher;
+
+class TelescopeTest extends FeatureTestCase
+{
+    private $count = 0;
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app->get('config')->set('telescope.watchers', [
+            QueryWatcher::class => [
+                'enabled' => true,
+                'slow' => 0.9,
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function run_after_recording_callback()
+    {
+        Telescope::afterRecording(function () {
+            $this->count++;
+        });
+
+        $this->app->get('db')->table('telescope_entries')->count();
+
+        $this->app->get('db')->table('telescope_entries')->count();
+
+        $this->assertSame(2, $this->count);
+    }
+
+    /**
+     * @test
+     */
+    public function after_recording_callback_can_store_and_flush()
+    {
+        Telescope::afterRecording(function (Telescope $telescope) {
+            if (count($telescope::$entriesQueue) > 1) {
+                $repository = $this->app->make(EntriesRepository::class);
+                $telescope->store($repository);
+            }
+        });
+
+        $this->app->get('db')->table('telescope_entries')->count();
+
+        $this->assertCount(1, Telescope::$entriesQueue);
+
+        $this->app->get('db')->table('telescope_entries')->count();
+
+        $this->assertCount(0, Telescope::$entriesQueue);
+
+        $this->app->get('db')->table('telescope_entries')->count();
+
+        $this->assertCount(1, Telescope::$entriesQueue);
+    }
+}

--- a/tests/Telescope/TelescopeTest.php
+++ b/tests/Telescope/TelescopeTest.php
@@ -23,6 +23,13 @@ class TelescopeTest extends FeatureTestCase
         ]);
     }
 
+    protected function tearDown()
+    {
+        Telescope::$afterRecordingHook = null;
+
+        parent::tearDown();
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
This pull request adds a `afterRecording` hook on Telescope. This will allow the developer to do whatever he/she wants when Telescope makes a new Entry. There could be lots of possibilities since the callback allows the developer to implement any logic desired.
The driver for this pull request for me is a long-running background process that does too many things.
I would still like to be able to record everything that the background job is doing for later analyzes. However, the background process can run for up to 30 minutes and can perform millions of actions.
With an `afterRecording` hook, I can monitor Telescope and force it to store and flush after each 20'000 records. This will free up memory and avoid building up more entries than the Insert Query can handle.