### PR TITLE
[1.0] Remove duplicate config call

### DIFF
--- a/src/RegistersWatchers.php
+++ b/src/RegistersWatchers.php
@@ -30,10 +30,6 @@ trait RegistersWatchers
      */
     protected static function registerWatchers($app)
     {
-        if (! config('telescope.enabled')) {
-            return;
-        }
-
         foreach (config('telescope.watchers') as $key => $watcher) {
             if (is_string($key) && $watcher === false) {
                 continue;


### PR DESCRIPTION
Removing duplicate `config` call as this check already exists in the `Telescope::start` method. So, the if block is unreachable.