### PR TITLE
[1.0] Add ability to watch specific model events

### DIFF
--- a/src/Watchers/ModelWatcher.php
+++ b/src/Watchers/ModelWatcher.php
@@ -17,7 +17,7 @@ class ModelWatcher extends Watcher
      */
     public function register($app)
     {
-        $app['events']->listen('eloquent.*', [$this, 'recordAction']);
+        $app['events']->listen($this->options['events'] ?? 'eloquent.*', [$this, 'recordAction']);
     }
 
     /**

--- a/tests/Watchers/ModelWatcherTest.php
+++ b/tests/Watchers/ModelWatcherTest.php
@@ -63,7 +63,7 @@ class ModelWatcherTest extends FeatureTestCase
         $this->assertCount(1, $entries);
         $this->assertSame(EntryType::MODEL, $entry->type);
         $this->assertSame('created', $entry->content['action']);
-        $this->assertSame(UserEloquent::class . ':1', $entry->content['model']);
+        $this->assertSame(UserEloquent::class.':1', $entry->content['model']);
     }
 }
 

--- a/tests/Watchers/ModelWatcherTest.php
+++ b/tests/Watchers/ModelWatcherTest.php
@@ -15,7 +15,10 @@ class ModelWatcherTest extends FeatureTestCase
         parent::getEnvironmentSetUp($app);
 
         $app->get('config')->set('telescope.watchers', [
-            ModelWatcher::class => true,
+            ModelWatcher::class => [
+                'enabled' => true,
+                'events' => ['eloquent.created*', 'eloquent.updated*'],
+            ],
         ]);
     }
 
@@ -37,6 +40,30 @@ class ModelWatcherTest extends FeatureTestCase
         $this->assertSame(EntryType::MODEL, $entry->type);
         $this->assertSame('created', $entry->content['action']);
         $this->assertSame(UserEloquent::class.':1', $entry->content['model']);
+    }
+
+    public function test_model_watcher_can_restrict_events()
+    {
+        Telescope::withoutRecording(function () {
+            $this->loadLaravelMigrations();
+        });
+
+        $user = UserEloquent::query()
+            ->create([
+                'name' => 'Telescope',
+                'email' => 'telescope@laravel.com',
+                'password' => 1,
+            ]);
+
+        $user->delete();
+
+        $entries = $this->loadTelescopeEntries();
+        $entry = $entries->last();
+
+        $this->assertCount(1, $entries);
+        $this->assertSame(EntryType::MODEL, $entry->type);
+        $this->assertSame('created', $entry->content['action']);
+        $this->assertSame(UserEloquent::class . ':1', $entry->content['model']);
     }
 }
 


### PR DESCRIPTION
This PR adds the ability to specify specific model events to watch. So, say we only wanted to watch the created and updated events, we could specify the configuration of the ModelWatcher like so:

```php
ModelWatcher::class => [
    'enabled' => true,
    'events' => ['eloquent.created*', 'eloquent.updated*'],
],
```

Also, there are some libraries like [Laravel-Pivot](https://github.com/fico7489/laravel-pivot) that fire custom events and that creates issues such as #351. This PR fixes #351 and other such issues as we can now specify specific events to listen to, and they can exclude the custom events fired by the library. This is not a breaking change.