### PR TITLE
[1.0] Add clear entries button

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -68563,6 +68563,11 @@ new __WEBPACK_IMPORTED_MODULE_0_vue___default.a({
                 localStorage.autoLoadsNewEntries = 0;
             }
         },
+        clearEntries: function clearEntries() {
+            __WEBPACK_IMPORTED_MODULE_2_axios___default.a.post('/' + Telescope.path + '/telescope-api/clear-entries').then(function () {
+                return router.go();
+            });
+        },
         toggleRecording: function toggleRecording() {
             __WEBPACK_IMPORTED_MODULE_2_axios___default.a.post('/' + Telescope.path + '/telescope-api/toggle-recording');
 

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/app.js": "/app.js?id=5db39309abcb7c25c6b1",
+    "/app.js": "/app.js?id=886bdbcae39234bffaa7",
     "/app.css": "/app.css?id=c097a04c12c993b0b389",
     "/app-dark.css": "/app-dark.css?id=1afefefbd103a662cdcf"
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -67,6 +67,10 @@ new Vue({
             }
         },
 
+        clearEntries(){
+            axios.post('/' + Telescope.path + '/telescope-api/clear-entries')
+                .then(() => router.go());
+        },
 
         toggleRecording(){
             axios.post('/' + Telescope.path + '/telescope-api/toggle-recording');

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -39,6 +39,12 @@
                 </svg>
             </button>
 
+            <button class="btn btn-outline-primary mr-3" v-on:click.prevent="clearEntries" title="Clear Entries">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="icon fill-primary">
+                    <path d="M6 4V2a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2h5a1 1 0 0 1 0 2h-1v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6H1a1 1 0 1 1 0-2h5zM4 6v12h12V6H4zm8-2V2H8v2h4zM8 8a1 1 0 0 1 1 1v6a1 1 0 0 1-2 0V9a1 1 0 0 1 1-1zm4 0a1 1 0 0 1 1 1v6a1 1 0 0 1-2 0V9a1 1 0 0 1 1-1z"></path>
+                </svg>
+            </button>
+
             <button class="btn btn-outline-primary mr-3" :class="{active: autoLoadsNewEntries}" v-on:click.prevent="autoLoadNewEntries" title="Auto Load Entries">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="icon fill-primary">
                     <path d="M10 3v2a5 5 0 0 0-3.54 8.54l-1.41 1.41A7 7 0 0 1 10 3zm4.95 2.05A7 7 0 0 1 10 17v-2a5 5 0 0 0 3.54-8.54l1.41-1.41zM10 20l-4-4 4-4v8zm0-12V0l4 4-4 4z"></path>

--- a/src/Http/Controllers/ClearEntriesController.php
+++ b/src/Http/Controllers/ClearEntriesController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Laravel\Telescope\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Artisan;
+
+class ClearEntriesController extends Controller
+{
+    /**
+     * Clear entries.
+     *
+     * @return void
+     */
+    public function clear()
+    {
+        Artisan::call('telescope:clear');
+    }
+}

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -65,4 +65,7 @@ Route::post('/telescope-api/monitored-tags/delete', 'MonitoredTagController@dest
 // Toggle Recording...
 Route::post('/telescope-api/toggle-recording', 'RecordingController@toggle');
 
+// Clear entries...
+Route::post('/telescope-api/clear-entries', 'ClearEntriesController@clear');
+
 Route::get('/{view?}', 'HomeController@index')->where('view', '(.*)')->name('telescope');


### PR DESCRIPTION
This PR adds a clear entries button (next to the Pause/Play button) to clear all Telescope entries by simply running the `ClearCommand`. Closes #454. The UI looks like this (trash icon button, 2nd from left):

<img width="1168" alt="screen shot 2018-12-02 at 11 44 29 pm" src="https://user-images.githubusercontent.com/16099046/49343295-9296a280-f68c-11e8-9dbd-d6137f1446b3.png">
