### PR TITLE
[1.0] Add Gate watcher to record gate checks

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -91,6 +91,7 @@ return [
         Watchers\DumpWatcher::class => env('TELESCOPE_DUMP_WATCHER', true),
         Watchers\EventWatcher::class => env('TELESCOPE_EVENT_WATCHER', true),
         Watchers\ExceptionWatcher::class => env('TELESCOPE_EXCEPTION_WATCHER', true),
+        Watchers\GateWatcher::class => env('TELESCOPE_GATE_WATCHER', false),
         Watchers\JobWatcher::class => env('TELESCOPE_JOB_WATCHER', true),
         Watchers\LogWatcher::class => env('TELESCOPE_LOG_WATCHER', true),
         Watchers\MailWatcher::class => env('TELESCOPE_MAIL_WATCHER', true),

--- a/public/app.js
+++ b/public/app.js
@@ -50567,7 +50567,25 @@ var render = function() {
                   ]
                 )
               ])
-            ])
+            ]),
+            _vm._v(" "),
+            slotProps.entry.content.file
+              ? _c("tr", [
+                  _c("td", { staticClass: "table-fit font-weight-bold" }, [
+                    _vm._v("Location")
+                  ]),
+                  _vm._v(" "),
+                  _c("td", [
+                    _vm._v(
+                      "\n                " +
+                        _vm._s(slotProps.entry.content.file) +
+                        ":" +
+                        _vm._s(slotProps.entry.content.line) +
+                        "\n            "
+                    )
+                  ])
+                ])
+              : _vm._e()
           ]
         }
       },

--- a/public/app.js
+++ b/public/app.js
@@ -2216,6 +2216,8 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
                 this.currentTab = 'events';
             } else if (this.cache.length) {
                 this.currentTab = 'cache';
+            } else if (this.gates.length) {
+                this.currentTab = 'gates';
             } else if (this.redis.length) {
                 this.currentTab = 'redis';
             }
@@ -2233,6 +2235,9 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
         },
         exceptions: function exceptions() {
             return _.filter(this.batch, { type: 'exception' });
+        },
+        gates: function gates() {
+            return _.filter(this.batch, { type: 'gate' });
         },
         logs: function logs() {
             return _.filter(this.batch, { type: 'log' });
@@ -2262,7 +2267,7 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
             return _.filter(this.batch, { type: 'notification' });
         },
         tabs: function tabs() {
-            return _.filter([{ title: "Exceptions", type: "exceptions", count: this.exceptions.length }, { title: "Logs", type: "logs", count: this.logs.length }, { title: "Queries", type: "queries", count: this.queries.length }, { title: "Models", type: "models", count: this.models.length }, { title: "Jobs", type: "jobs", count: this.jobs.length }, { title: "Mail", type: "mails", count: this.mails.length }, { title: "Notifications", type: "notifications", count: this.notifications.length }, { title: "Events", type: "events", count: this.events.length }, { title: "Cache", type: "cache", count: this.cache.length }, { title: "Redis", type: "redis", count: this.redis.length }], function (tab) {
+            return _.filter([{ title: "Exceptions", type: "exceptions", count: this.exceptions.length }, { title: "Logs", type: "logs", count: this.logs.length }, { title: "Queries", type: "queries", count: this.queries.length }, { title: "Models", type: "models", count: this.models.length }, { title: "Gates", type: "gates", count: this.gates.length }, { title: "Jobs", type: "jobs", count: this.jobs.length }, { title: "Mail", type: "mails", count: this.mails.length }, { title: "Notifications", type: "notifications", count: this.notifications.length }, { title: "Events", type: "events", count: this.events.length }, { title: "Cache", type: "cache", count: this.cache.length }, { title: "Redis", type: "redis", count: this.redis.length }], function (tab) {
                 return tab.count > 0;
             });
         },
@@ -2511,6 +2516,43 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
             entry: null,
             batch: [],
             currentTab: 'message'
+        };
+    }
+});
+
+/***/ }),
+
+/***/ "./node_modules/babel-loader/lib/index.js?{\"cacheDirectory\":true,\"presets\":[[\"env\",{\"modules\":false,\"targets\":{\"browsers\":[\"> 2%\"],\"uglify\":true}}]],\"plugins\":[\"transform-object-rest-spread\",[\"transform-runtime\",{\"polyfill\":false,\"helpers\":false}]]}!./node_modules/vue-loader/lib/selector.js?type=script&index=0!./resources/js/screens/gates/index.vue":
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__mixins_entriesStyles__ = __webpack_require__("./resources/js/mixins/entriesStyles.js");
+
+
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+    mixins: [__WEBPACK_IMPORTED_MODULE_0__mixins_entriesStyles__["a" /* default */]]
+});
+
+/***/ }),
+
+/***/ "./node_modules/babel-loader/lib/index.js?{\"cacheDirectory\":true,\"presets\":[[\"env\",{\"modules\":false,\"targets\":{\"browsers\":[\"> 2%\"],\"uglify\":true}}]],\"plugins\":[\"transform-object-rest-spread\",[\"transform-runtime\",{\"polyfill\":false,\"helpers\":false}]]}!./node_modules/vue-loader/lib/selector.js?type=script&index=0!./resources/js/screens/gates/preview.vue":
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__mixins_entriesStyles__ = __webpack_require__("./resources/js/mixins/entriesStyles.js");
+
+
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+    mixins: [__WEBPACK_IMPORTED_MODULE_0__mixins_entriesStyles__["a" /* default */]],
+
+    data: function data() {
+        return {
+            entry: null,
+            batch: []
         };
     }
 });
@@ -48458,6 +48500,124 @@ if (false) {
 
 /***/ }),
 
+/***/ "./node_modules/vue-loader/lib/template-compiler/index.js?{\"id\":\"data-v-0a825c16\",\"hasScoped\":false,\"buble\":{\"transforms\":{}}}!./node_modules/vue-loader/lib/selector.js?type=template&index=0!./resources/js/screens/gates/index.vue":
+/***/ (function(module, exports, __webpack_require__) {
+
+var render = function() {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _c(
+    "index-screen",
+    {
+      attrs: { title: "Gates", resource: "gates" },
+      scopedSlots: _vm._u([
+        {
+          key: "row",
+          fn: function(slotProps) {
+            return [
+              _c("td", [
+                _vm._v(
+                  _vm._s(_vm.truncate(slotProps.entry.content.ability, 80))
+                )
+              ]),
+              _vm._v(" "),
+              _c("td", { staticClass: "table-fit" }, [
+                _c(
+                  "span",
+                  {
+                    staticClass: "badge font-weight-light",
+                    class:
+                      "badge-" +
+                      _vm.gateResultClass(slotProps.entry.content.result)
+                  },
+                  [
+                    _vm._v(
+                      "\n                " +
+                        _vm._s(slotProps.entry.content.result) +
+                        "\n            "
+                    )
+                  ]
+                )
+              ]),
+              _vm._v(" "),
+              _c(
+                "td",
+                {
+                  staticClass: "table-fit",
+                  attrs: { "data-timeago": slotProps.entry.created_at }
+                },
+                [_vm._v(_vm._s(_vm.timeAgo(slotProps.entry.created_at)))]
+              ),
+              _vm._v(" "),
+              _c(
+                "td",
+                { staticClass: "table-fit" },
+                [
+                  _c(
+                    "router-link",
+                    {
+                      staticClass: "control-action",
+                      attrs: {
+                        to: {
+                          name: "gate-preview",
+                          params: { id: slotProps.entry.id }
+                        }
+                      }
+                    },
+                    [
+                      _c(
+                        "svg",
+                        {
+                          attrs: {
+                            xmlns: "http://www.w3.org/2000/svg",
+                            viewBox: "0 0 22 16"
+                          }
+                        },
+                        [
+                          _c("path", {
+                            attrs: {
+                              d:
+                                "M16.56 13.66a8 8 0 0 1-11.32 0L.3 8.7a1 1 0 0 1 0-1.42l4.95-4.95a8 8 0 0 1 11.32 0l4.95 4.95a1 1 0 0 1 0 1.42l-4.95 4.95-.01.01zm-9.9-1.42a6 6 0 0 0 8.48 0L19.38 8l-4.24-4.24a6 6 0 0 0-8.48 0L2.4 8l4.25 4.24h.01zM10.9 12a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"
+                            }
+                          })
+                        ]
+                      )
+                    ]
+                  )
+                ],
+                1
+              )
+            ]
+          }
+        }
+      ])
+    },
+    [
+      _c("tr", { attrs: { slot: "table-header" }, slot: "table-header" }, [
+        _c("th", { attrs: { scope: "col" } }, [_vm._v("Ability")]),
+        _vm._v(" "),
+        _c("th", { attrs: { scope: "col" } }, [_vm._v("Result")]),
+        _vm._v(" "),
+        _c("th", { attrs: { scope: "col" } }, [_vm._v("Happened")]),
+        _vm._v(" "),
+        _c("th", { attrs: { scope: "col" } })
+      ])
+    ]
+  )
+}
+var staticRenderFns = []
+render._withStripped = true
+module.exports = { render: render, staticRenderFns: staticRenderFns }
+if (false) {
+  module.hot.accept()
+  if (module.hot.data) {
+    require("vue-hot-reload-api")      .rerender("data-v-0a825c16", module.exports)
+  }
+}
+
+/***/ }),
+
 /***/ "./node_modules/vue-loader/lib/template-compiler/index.js?{\"id\":\"data-v-13e318c7\",\"hasScoped\":false,\"buble\":{\"transforms\":{}}}!./node_modules/vue-loader/lib/selector.js?type=template&index=0!./resources/js/screens/commands/preview.vue":
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -49390,6 +49550,92 @@ var render = function() {
                 {
                   name: "show",
                   rawName: "v-show",
+                  value: _vm.currentTab == "gates" && _vm.gates.length,
+                  expression: "currentTab=='gates' && gates.length"
+                }
+              ],
+              staticClass: "table table-hover table-sm mb-0"
+            },
+            [
+              _vm._m(4),
+              _vm._v(" "),
+              _c(
+                "tbody",
+                _vm._l(_vm.gates, function(entry) {
+                  return _c("tr", [
+                    _c("td", { attrs: { title: entry.content.ability } }, [
+                      _vm._v(_vm._s(_vm.truncate(entry.content.ability, 80)))
+                    ]),
+                    _vm._v(" "),
+                    _c("td", { staticClass: "table-fit" }, [
+                      _c(
+                        "span",
+                        {
+                          staticClass: "badge font-weight-light",
+                          class:
+                            "badge-" + _vm.gateResultClass(entry.content.result)
+                        },
+                        [
+                          _vm._v(
+                            "\n                        " +
+                              _vm._s(entry.content.result) +
+                              "\n                    "
+                          )
+                        ]
+                      )
+                    ]),
+                    _vm._v(" "),
+                    _c(
+                      "td",
+                      { staticClass: "table-fit" },
+                      [
+                        _c(
+                          "router-link",
+                          {
+                            staticClass: "control-action",
+                            attrs: {
+                              to: {
+                                name: "gate-preview",
+                                params: { id: entry.id }
+                              }
+                            }
+                          },
+                          [
+                            _c(
+                              "svg",
+                              {
+                                attrs: {
+                                  xmlns: "http://www.w3.org/2000/svg",
+                                  viewBox: "0 0 22 16"
+                                }
+                              },
+                              [
+                                _c("path", {
+                                  attrs: {
+                                    d:
+                                      "M16.56 13.66a8 8 0 0 1-11.32 0L.3 8.7a1 1 0 0 1 0-1.42l4.95-4.95a8 8 0 0 1 11.32 0l4.95 4.95a1 1 0 0 1 0 1.42l-4.95 4.95-.01.01zm-9.9-1.42a6 6 0 0 0 8.48 0L19.38 8l-4.24-4.24a6 6 0 0 0-8.48 0L2.4 8l4.25 4.24h.01zM10.9 12a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"
+                                  }
+                                })
+                              ]
+                            )
+                          ]
+                        )
+                      ],
+                      1
+                    )
+                  ])
+                })
+              )
+            ]
+          ),
+          _vm._v(" "),
+          _c(
+            "table",
+            {
+              directives: [
+                {
+                  name: "show",
+                  rawName: "v-show",
                   value: _vm.currentTab == "jobs" && _vm.jobs.length,
                   expression: "currentTab=='jobs' && jobs.length"
                 }
@@ -49397,7 +49643,7 @@ var render = function() {
               staticClass: "table table-hover table-sm mb-0"
             },
             [
-              _vm._m(4),
+              _vm._m(5),
               _vm._v(" "),
               _c(
                 "tbody",
@@ -49496,7 +49742,7 @@ var render = function() {
               staticClass: "table table-hover table-sm mb-0"
             },
             [
-              _vm._m(5),
+              _vm._m(6),
               _vm._v(" "),
               _c(
                 "tbody",
@@ -49586,7 +49832,7 @@ var render = function() {
               staticClass: "table table-hover table-sm mb-0"
             },
             [
-              _vm._m(6),
+              _vm._m(7),
               _vm._v(" "),
               _c(
                 "tbody",
@@ -49673,7 +49919,7 @@ var render = function() {
               staticClass: "table table-hover table-sm mb-0"
             },
             [
-              _vm._m(7),
+              _vm._m(8),
               _vm._v(" "),
               _c(
                 "tbody",
@@ -49745,7 +49991,7 @@ var render = function() {
               staticClass: "table table-hover table-sm mb-0"
             },
             [
-              _vm._m(8),
+              _vm._m(9),
               _vm._v(" "),
               _c(
                 "tbody",
@@ -49854,7 +50100,7 @@ var render = function() {
               staticClass: "table table-hover table-sm mb-0"
             },
             [
-              _vm._m(9),
+              _vm._m(10),
               _vm._v(" "),
               _c(
                 "tbody",
@@ -50008,6 +50254,20 @@ var staticRenderFns = [
         _c("th", [_vm._v("Model")]),
         _vm._v(" "),
         _c("th", [_vm._v("Action")]),
+        _vm._v(" "),
+        _c("th")
+      ])
+    ])
+  },
+  function() {
+    var _vm = this
+    var _h = _vm.$createElement
+    var _c = _vm._self._c || _h
+    return _c("thead", [
+      _c("tr", [
+        _c("th", [_vm._v("Ability")]),
+        _vm._v(" "),
+        _c("th", [_vm._v("Result")]),
         _vm._v(" "),
         _c("th")
       ])
@@ -50247,6 +50507,103 @@ if (false) {
   module.hot.accept()
   if (module.hot.data) {
     require("vue-hot-reload-api")      .rerender("data-v-2a5930cd", module.exports)
+  }
+}
+
+/***/ }),
+
+/***/ "./node_modules/vue-loader/lib/template-compiler/index.js?{\"id\":\"data-v-2f8729aa\",\"hasScoped\":false,\"buble\":{\"transforms\":{}}}!./node_modules/vue-loader/lib/selector.js?type=template&index=0!./resources/js/screens/gates/preview.vue":
+/***/ (function(module, exports, __webpack_require__) {
+
+var render = function() {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _c("preview-screen", {
+    attrs: {
+      title: "Gate Details",
+      resource: "gates",
+      id: _vm.$route.params.id
+    },
+    scopedSlots: _vm._u([
+      {
+        key: "table-parameters",
+        fn: function(slotProps) {
+          return [
+            _c("tr", [
+              _c("td", { staticClass: "table-fit font-weight-bold" }, [
+                _vm._v("Ability")
+              ]),
+              _vm._v(" "),
+              _c("td", [
+                _vm._v(
+                  "\n                " +
+                    _vm._s(slotProps.entry.content.ability) +
+                    "\n            "
+                )
+              ])
+            ]),
+            _vm._v(" "),
+            _c("tr", [
+              _c("td", { staticClass: "table-fit font-weight-bold" }, [
+                _vm._v("Result")
+              ]),
+              _vm._v(" "),
+              _c("td", [
+                _c(
+                  "span",
+                  {
+                    staticClass: "badge font-weight-light",
+                    class:
+                      "badge-" +
+                      _vm.gateResultClass(slotProps.entry.content.result)
+                  },
+                  [
+                    _vm._v(
+                      "\n                    " +
+                        _vm._s(slotProps.entry.content.result) +
+                        "\n                "
+                    )
+                  ]
+                )
+              ])
+            ])
+          ]
+        }
+      },
+      {
+        key: "after-attributes-card",
+        fn: function(slotProps) {
+          return _c("div", {}, [
+            _c("div", { staticClass: "card mt-5" }, [
+              _c("div", { staticClass: "card-header" }, [
+                _c("h5", [_vm._v("Arguments")])
+              ]),
+              _vm._v(" "),
+              _c(
+                "div",
+                { staticClass: "code-bg p-4 mb-0 text-white" },
+                [
+                  _c("vue-json-pretty", {
+                    attrs: { data: slotProps.entry.content.arguments }
+                  })
+                ],
+                1
+              )
+            ])
+          ])
+        }
+      }
+    ])
+  })
+}
+var staticRenderFns = []
+render._withStripped = true
+module.exports = { render: render, staticRenderFns: staticRenderFns }
+if (false) {
+  module.hot.accept()
+  if (module.hot.data) {
+    require("vue-hot-reload-api")      .rerender("data-v-2f8729aa", module.exports)
   }
 }
 
@@ -69126,6 +69483,10 @@ module.exports = Component.exports
             if (type === 'forget') return 'warning';
             if (type === 'missed') return 'danger';
         },
+        gateResultClass: function gateResultClass(result) {
+            if (result === 'allowed') return 'success';
+            if (result === 'denied') return 'danger';
+        },
         jobStatusClass: function jobStatusClass(status) {
             if (status === 'pending') return 'secondary';
             if (status === 'processed') return 'success';
@@ -69189,6 +69550,14 @@ module.exports = Component.exports
     path: '/dumps',
     name: 'dumps',
     component: __webpack_require__("./resources/js/screens/dumps/index.vue")
+}, {
+    path: '/gate/:id',
+    name: 'gate-preview',
+    component: __webpack_require__("./resources/js/screens/gates/preview.vue")
+}, {
+    path: '/gates',
+    name: 'gates',
+    component: __webpack_require__("./resources/js/screens/gates/index.vue")
 }, {
     path: '/logs/:id',
     name: 'log-preview',
@@ -69714,6 +70083,102 @@ if (false) {(function () {
     hotAPI.createRecord("data-v-159acac3", Component.options)
   } else {
     hotAPI.reload("data-v-159acac3", Component.options)
+  }
+  module.hot.dispose(function (data) {
+    disposed = true
+  })
+})()}
+
+module.exports = Component.exports
+
+
+/***/ }),
+
+/***/ "./resources/js/screens/gates/index.vue":
+/***/ (function(module, exports, __webpack_require__) {
+
+var disposed = false
+var normalizeComponent = __webpack_require__("./node_modules/vue-loader/lib/component-normalizer.js")
+/* script */
+var __vue_script__ = __webpack_require__("./node_modules/babel-loader/lib/index.js?{\"cacheDirectory\":true,\"presets\":[[\"env\",{\"modules\":false,\"targets\":{\"browsers\":[\"> 2%\"],\"uglify\":true}}]],\"plugins\":[\"transform-object-rest-spread\",[\"transform-runtime\",{\"polyfill\":false,\"helpers\":false}]]}!./node_modules/vue-loader/lib/selector.js?type=script&index=0!./resources/js/screens/gates/index.vue")
+/* template */
+var __vue_template__ = __webpack_require__("./node_modules/vue-loader/lib/template-compiler/index.js?{\"id\":\"data-v-0a825c16\",\"hasScoped\":false,\"buble\":{\"transforms\":{}}}!./node_modules/vue-loader/lib/selector.js?type=template&index=0!./resources/js/screens/gates/index.vue")
+/* template functional */
+var __vue_template_functional__ = false
+/* styles */
+var __vue_styles__ = null
+/* scopeId */
+var __vue_scopeId__ = null
+/* moduleIdentifier (server only) */
+var __vue_module_identifier__ = null
+var Component = normalizeComponent(
+  __vue_script__,
+  __vue_template__,
+  __vue_template_functional__,
+  __vue_styles__,
+  __vue_scopeId__,
+  __vue_module_identifier__
+)
+Component.options.__file = "resources/js/screens/gates/index.vue"
+
+/* hot reload */
+if (false) {(function () {
+  var hotAPI = require("vue-hot-reload-api")
+  hotAPI.install(require("vue"), false)
+  if (!hotAPI.compatible) return
+  module.hot.accept()
+  if (!module.hot.data) {
+    hotAPI.createRecord("data-v-0a825c16", Component.options)
+  } else {
+    hotAPI.reload("data-v-0a825c16", Component.options)
+  }
+  module.hot.dispose(function (data) {
+    disposed = true
+  })
+})()}
+
+module.exports = Component.exports
+
+
+/***/ }),
+
+/***/ "./resources/js/screens/gates/preview.vue":
+/***/ (function(module, exports, __webpack_require__) {
+
+var disposed = false
+var normalizeComponent = __webpack_require__("./node_modules/vue-loader/lib/component-normalizer.js")
+/* script */
+var __vue_script__ = __webpack_require__("./node_modules/babel-loader/lib/index.js?{\"cacheDirectory\":true,\"presets\":[[\"env\",{\"modules\":false,\"targets\":{\"browsers\":[\"> 2%\"],\"uglify\":true}}]],\"plugins\":[\"transform-object-rest-spread\",[\"transform-runtime\",{\"polyfill\":false,\"helpers\":false}]]}!./node_modules/vue-loader/lib/selector.js?type=script&index=0!./resources/js/screens/gates/preview.vue")
+/* template */
+var __vue_template__ = __webpack_require__("./node_modules/vue-loader/lib/template-compiler/index.js?{\"id\":\"data-v-2f8729aa\",\"hasScoped\":false,\"buble\":{\"transforms\":{}}}!./node_modules/vue-loader/lib/selector.js?type=template&index=0!./resources/js/screens/gates/preview.vue")
+/* template functional */
+var __vue_template_functional__ = false
+/* styles */
+var __vue_styles__ = null
+/* scopeId */
+var __vue_scopeId__ = null
+/* moduleIdentifier (server only) */
+var __vue_module_identifier__ = null
+var Component = normalizeComponent(
+  __vue_script__,
+  __vue_template__,
+  __vue_template_functional__,
+  __vue_styles__,
+  __vue_scopeId__,
+  __vue_module_identifier__
+)
+Component.options.__file = "resources/js/screens/gates/preview.vue"
+
+/* hot reload */
+if (false) {(function () {
+  var hotAPI = require("vue-hot-reload-api")
+  hotAPI.install(require("vue"), false)
+  if (!hotAPI.compatible) return
+  module.hot.accept()
+  if (!module.hot.data) {
+    hotAPI.createRecord("data-v-2f8729aa", Component.options)
+  } else {
+    hotAPI.reload("data-v-2f8729aa", Component.options)
   }
   module.hot.dispose(function (data) {
     disposed = true

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/app.js": "/app.js?id=8b839cf52d8d2895ec73",
+    "/app.js": "/app.js?id=cfc93f63ab192bcfa68d",
     "/app.css": "/app.css?id=7c1ff2a14db6cf79b2c3",
     "/app-dark.css": "/app-dark.css?id=3499432c9dbc93b0f541"
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/app.js": "/app.js?id=cb082a14c0f0bb5764c9",
+    "/app.js": "/app.js?id=8b839cf52d8d2895ec73",
     "/app.css": "/app.css?id=7c1ff2a14db6cf79b2c3",
     "/app-dark.css": "/app-dark.css?id=3499432c9dbc93b0f541"
 }

--- a/resources/js/components/RelatedEntries.vue
+++ b/resources/js/components/RelatedEntries.vue
@@ -56,6 +56,8 @@
                     this.currentTab = 'events'
                 } else if (this.cache.length) {
                     this.currentTab = 'cache'
+                } else if (this.gates.length) {
+                    this.currentTab = 'gates'
                 } else if (this.redis.length) {
                     this.currentTab = 'redis'
                 }
@@ -76,6 +78,10 @@
 
             exceptions() {
                 return _.filter(this.batch, {type: 'exception'});
+            },
+
+            gates() {
+                return _.filter(this.batch, {type: 'gate'});
             },
 
             logs() {
@@ -120,6 +126,7 @@
                     {title: "Logs", type: "logs", count: this.logs.length},
                     {title: "Queries", type: "queries", count: this.queries.length},
                     {title: "Models", type: "models", count: this.models.length},
+                    {title: "Gates", type: "gates", count: this.gates.length},
                     {title: "Jobs", type: "jobs", count: this.jobs.length},
                     {title: "Mail", type: "mails", count: this.mails.length},
                     {title: "Notifications", type: "notifications", count: this.notifications.length},
@@ -275,6 +282,36 @@
 
                     <td class="table-fit">
                         <router-link :to="{name:'model-preview', params:{id: entry.id}}" class="control-action">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 16">
+                                <path d="M16.56 13.66a8 8 0 0 1-11.32 0L.3 8.7a1 1 0 0 1 0-1.42l4.95-4.95a8 8 0 0 1 11.32 0l4.95 4.95a1 1 0 0 1 0 1.42l-4.95 4.95-.01.01zm-9.9-1.42a6 6 0 0 0 8.48 0L19.38 8l-4.24-4.24a6 6 0 0 0-8.48 0L2.4 8l4.25 4.24h.01zM10.9 12a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"></path>
+                            </svg>
+                        </router-link>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+
+            <!-- Related Gates -->
+            <table class="table table-hover table-sm mb-0" v-show="currentTab=='gates' && gates.length">
+                <thead>
+                <tr>
+                    <th>Ability</th>
+                    <th>Result</th>
+                    <th></th>
+                </tr>
+                </thead>
+
+                <tbody>
+                <tr v-for="entry in gates">
+                    <td :title="entry.content.ability">{{truncate(entry.content.ability, 80)}}</td>
+                    <td class="table-fit">
+                        <span class="badge font-weight-light" :class="'badge-'+gateResultClass(entry.content.result)">
+                            {{entry.content.result}}
+                        </span>
+                    </td>
+
+                    <td class="table-fit">
+                        <router-link :to="{name:'gate-preview', params:{id: entry.id}}" class="control-action">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 16">
                                 <path d="M16.56 13.66a8 8 0 0 1-11.32 0L.3 8.7a1 1 0 0 1 0-1.42l4.95-4.95a8 8 0 0 1 11.32 0l4.95 4.95a1 1 0 0 1 0 1.42l-4.95 4.95-.01.01zm-9.9-1.42a6 6 0 0 0 8.48 0L19.38 8l-4.24-4.24a6 6 0 0 0-8.48 0L2.4 8l4.25 4.24h.01zM10.9 12a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"></path>
                             </svg>

--- a/resources/js/mixins/entriesStyles.js
+++ b/resources/js/mixins/entriesStyles.js
@@ -7,6 +7,12 @@ export default {
             if (type === 'missed') return 'danger';
         },
 
+        
+        gateResultClass(result){
+            if (result === 'allowed') return 'success';
+            if (result === 'denied') return 'danger';
+        },
+
 
         jobStatusClass(status){
             if (status === 'pending') return 'secondary';

--- a/resources/js/routes.js
+++ b/resources/js/routes.js
@@ -32,6 +32,18 @@ export default [
     },
 
     {
+        path: '/gate/:id',
+        name: 'gate-preview',
+        component: require('./screens/gates/preview')
+    },
+
+    {
+        path: '/gates',
+        name: 'gates',
+        component: require('./screens/gates/index')
+    },
+
+    {
         path: '/logs/:id',
         name: 'log-preview',
         component: require('./screens/logs/preview')

--- a/resources/js/screens/gates/index.vue
+++ b/resources/js/screens/gates/index.vue
@@ -1,0 +1,41 @@
+<script type="text/ecmascript-6">
+    import StylesMixin from './../../mixins/entriesStyles';
+
+    export default {
+        mixins: [
+            StylesMixin,
+        ],
+    }
+</script>
+
+<template>
+    <index-screen title="Gates" resource="gates">
+        <tr slot="table-header">
+            <th scope="col">Ability</th>
+            <th scope="col">Result</th>
+            <th scope="col">Happened</th>
+            <th scope="col"></th>
+        </tr>
+
+
+        <template slot="row" slot-scope="slotProps">
+            <td>{{truncate(slotProps.entry.content.ability, 80)}}</td>
+
+            <td class="table-fit">
+                <span class="badge font-weight-light" :class="'badge-'+gateResultClass(slotProps.entry.content.result)">
+                    {{slotProps.entry.content.result}}
+                </span>
+            </td>
+
+            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+
+            <td class="table-fit">
+                <router-link :to="{name:'gate-preview', params:{id: slotProps.entry.id}}" class="control-action">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 16">
+                        <path d="M16.56 13.66a8 8 0 0 1-11.32 0L.3 8.7a1 1 0 0 1 0-1.42l4.95-4.95a8 8 0 0 1 11.32 0l4.95 4.95a1 1 0 0 1 0 1.42l-4.95 4.95-.01.01zm-9.9-1.42a6 6 0 0 0 8.48 0L19.38 8l-4.24-4.24a6 6 0 0 0-8.48 0L2.4 8l4.25 4.24h.01zM10.9 12a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"></path>
+                    </svg>
+                </router-link>
+            </td>
+        </template>
+    </index-screen>
+</template>

--- a/resources/js/screens/gates/preview.vue
+++ b/resources/js/screens/gates/preview.vue
@@ -34,6 +34,13 @@
                     </span>
                 </td>
             </tr>
+
+            <tr  v-if="slotProps.entry.content.file">
+                <td class="table-fit font-weight-bold">Location</td>
+                <td>
+                    {{slotProps.entry.content.file}}:{{slotProps.entry.content.line}}
+                </td>
+            </tr>
         </template>
 
         <div slot="after-attributes-card" slot-scope="slotProps">

--- a/resources/js/screens/gates/preview.vue
+++ b/resources/js/screens/gates/preview.vue
@@ -1,0 +1,49 @@
+<script type="text/ecmascript-6">
+    import StylesMixin from './../../mixins/entriesStyles';
+
+    export default {
+        mixins: [
+            StylesMixin,
+        ],
+
+
+        data() {
+            return {
+                entry: null,
+                batch: [],
+            };
+        }
+    }
+</script>
+
+<template>
+    <preview-screen title="Gate Details" resource="gates" :id="$route.params.id">
+        <template slot="table-parameters" slot-scope="slotProps">
+            <tr>
+                <td class="table-fit font-weight-bold">Ability</td>
+                <td>
+                    {{slotProps.entry.content.ability}}
+                </td>
+            </tr>
+
+            <tr>
+                <td class="table-fit font-weight-bold">Result</td>
+                <td>
+                    <span class="badge font-weight-light" :class="'badge-'+gateResultClass(slotProps.entry.content.result)">
+                        {{slotProps.entry.content.result}}
+                    </span>
+                </td>
+            </tr>
+        </template>
+
+        <div slot="after-attributes-card" slot-scope="slotProps">
+            <div class="card mt-5">
+                <div class="card-header"><h5>Arguments</h5></div>
+
+                <div class="code-bg p-4 mb-0 text-white">
+                    <vue-json-pretty :data="slotProps.entry.content.arguments"></vue-json-pretty>
+                </div>
+            </div>
+        </div>
+    </preview-screen>
+</template>

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -131,6 +131,14 @@
                         </router-link>
                     </li>
                     <li class="nav-item">
+                        <router-link active-class="active" to="/gates" class="nav-link d-flex align-items-center">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                                <path d="M7 10V7a5 5 0 1 1 10 0v3h2a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-8c0-1.1.9-2 2-2h2zm2 0h6V7a3 3 0 0 0-6 0v3zm-4 2v8h14v-8H5zm7 2a1 1 0 0 1 1 1v2a1 1 0 0 1-2 0v-2a1 1 0 0 1 1-1z"></path>
+                            </svg>
+                            <span>Gates</span>
+                        </router-link>
+                    </li>
+                    <li class="nav-item">
                         <router-link active-class="active" to="/events" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
                                 <path d="M16 8A6 6 0 1 0 4 8v11H2a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2V8a8 8 0 1 1 16 0v3a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-2V8zm-4 2h3v10h-3V10zm-7 0h3v10H5V10z"></path>

--- a/src/EntryType.php
+++ b/src/EntryType.php
@@ -9,6 +9,7 @@ class EntryType
     public const DUMP = 'dump';
     public const EVENT = 'event';
     public const EXCEPTION = 'exception';
+    public const GATE = 'gate';
     public const JOB = 'job';
     public const LOG = 'log';
     public const MAIL = 'mail';

--- a/src/Http/Controllers/GatesController.php
+++ b/src/Http/Controllers/GatesController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Laravel\Telescope\Http\Controllers;
+
+use Laravel\Telescope\EntryType;
+use Laravel\Telescope\Watchers\GateWatcher;
+
+class GatesController extends EntryController
+{
+    /**
+     * The entry type for the controller.
+     *
+     * @return string
+     */
+    protected function entryType()
+    {
+        return EntryType::GATE;
+    }
+
+    /**
+     * The watcher class for the controller.
+     *
+     * @return string
+     */
+    protected function watcher()
+    {
+        return GateWatcher::class;
+    }
+}

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -29,6 +29,10 @@ Route::get('/telescope-api/jobs/{telescopeEntryId}', 'QueueController@show');
 Route::post('/telescope-api/events', 'EventsController@index');
 Route::get('/telescope-api/events/{telescopeEntryId}', 'EventsController@show');
 
+// Gates entries...
+Route::post('/telescope-api/gates', 'GatesController@index');
+Route::get('/telescope-api/gates/{telescopeEntryId}', 'GatesController@show');
+
 // Cache entries...
 Route::post('/telescope-api/cache', 'CacheController@index');
 Route::get('/telescope-api/cache/{telescopeEntryId}', 'CacheController@show');

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -330,6 +330,17 @@ class Telescope
      * @param  \Laravel\Telescope\IncomingEntry  $entry
      * @return void
      */
+    public static function recordGate(IncomingEntry $entry)
+    {
+        static::record(EntryType::GATE, $entry);
+    }
+
+    /**
+     * Record the given entry.
+     *
+     * @param  \Laravel\Telescope\IncomingEntry  $entry
+     * @return void
+     */
     public static function recordJob($entry)
     {
         static::record(EntryType::JOB, $entry);
@@ -580,7 +591,8 @@ class Telescope
     public static function hideRequestHeaders(array $headers)
     {
         static::$hiddenRequestHeaders = array_merge(
-            static::$hiddenRequestHeaders, $headers
+            static::$hiddenRequestHeaders,
+            $headers
         );
 
         return new static;
@@ -595,7 +607,8 @@ class Telescope
     public static function hideRequestParameters(array $attributes)
     {
         static::$hiddenRequestParameters = array_merge(
-            static::$hiddenRequestParameters, $attributes
+            static::$hiddenRequestParameters,
+            $attributes
         );
 
         return new static;

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -591,8 +591,7 @@ class Telescope
     public static function hideRequestHeaders(array $headers)
     {
         static::$hiddenRequestHeaders = array_merge(
-            static::$hiddenRequestHeaders,
-            $headers
+            static::$hiddenRequestHeaders, $headers
         );
 
         return new static;
@@ -607,8 +606,7 @@ class Telescope
     public static function hideRequestParameters(array $attributes)
     {
         static::$hiddenRequestParameters = array_merge(
-            static::$hiddenRequestParameters,
-            $attributes
+            static::$hiddenRequestParameters, $attributes
         );
 
         return new static;

--- a/src/Watchers/FetchesStackTrace.php
+++ b/src/Watchers/FetchesStackTrace.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Laravel\Telescope\Watchers;
+
+use Illuminate\Support\Str;
+
+trait FetchesStackTrace
+{
+    /**
+     * Find the first frame in the stack trace outside of Telescope/Laravel.
+     *
+     * @return array
+     */
+    protected function getCallerFromStackTrace()
+    {
+        $trace = collect(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))->forget(0);
+
+        return $trace->first(function ($frame) {
+            if (! isset($frame['file'])) {
+                return false;
+            }
+
+            return ! Str::contains($frame['file'],
+                base_path('vendor'.DIRECTORY_SEPARATOR.$this->ignoredVendorPath())
+            );
+        });
+    }
+
+    /**
+     * Choose the frame outside of either Telescope/Laravel or all packages.
+     *
+     * @return string|null
+     */
+    protected function ignoredVendorPath()
+    {
+        if (! ($this->options['ignore_packages'] ?? true)) {
+            return 'laravel';
+        }
+    }
+}

--- a/src/Watchers/GateWatcher.php
+++ b/src/Watchers/GateWatcher.php
@@ -10,6 +10,8 @@ use Illuminate\Contracts\Auth\Authenticatable;
 
 class GateWatcher extends Watcher
 {
+    use FetchesStackTrace;
+
     /**
      * Register the watcher.
      *
@@ -36,10 +38,14 @@ class GateWatcher extends Watcher
             return;
         }
 
+        $caller = $this->getCallerFromStackTrace();
+
         Telescope::recordGate(IncomingEntry::make([
             'ability' => $ability,
             'result' => $result ? 'allowed' : 'denied',
             'arguments' => $arguments,
+            'file' => $caller['file'],
+            'line' => $caller['line'],
         ]));
 
         return $result;

--- a/src/Watchers/GateWatcher.php
+++ b/src/Watchers/GateWatcher.php
@@ -4,8 +4,8 @@ namespace Laravel\Telescope\Watchers;
 
 use Illuminate\Support\Str;
 use Laravel\Telescope\Telescope;
-use Laravel\Telescope\IncomingEntry;
 use Illuminate\Support\Facades\Gate;
+use Laravel\Telescope\IncomingEntry;
 use Illuminate\Contracts\Auth\Authenticatable;
 
 class GateWatcher extends Watcher

--- a/src/Watchers/GateWatcher.php
+++ b/src/Watchers/GateWatcher.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Str;
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\IncomingEntry;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Contracts\Auth\Authenticatable;
 
 class GateWatcher extends Watcher
 {
@@ -29,7 +30,7 @@ class GateWatcher extends Watcher
      * @param  array  $arguments
      * @return bool
      */
-    public function recordGateCheck($user, $ability, $result, $arguments)
+    public function recordGateCheck(?Authenticatable $user, $ability, $result, $arguments)
     {
         if (! Telescope::isRecording() || $this->shouldIgnore($ability)) {
             return;

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -2,13 +2,14 @@
 
 namespace Laravel\Telescope\Watchers;
 
-use Illuminate\Support\Str;
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\IncomingEntry;
 use Illuminate\Database\Events\QueryExecuted;
 
 class QueryWatcher extends Watcher
 {
+    use FetchesStackTrace;
+
     /**
      * Register the watcher.
      *
@@ -67,37 +68,5 @@ class QueryWatcher extends Watcher
     protected function formatBindings($event)
     {
         return $event->connection->prepareBindings($event->bindings);
-    }
-
-    /**
-     * Find the first frame in the stack trace outside of Telescope/Laravel.
-     *
-     * @return array
-     */
-    protected function getCallerFromStackTrace()
-    {
-        $trace = collect(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))->forget(0);
-
-        return $trace->first(function ($frame) {
-            if (! isset($frame['file'])) {
-                return false;
-            }
-
-            return ! Str::contains($frame['file'],
-                base_path('vendor'.DIRECTORY_SEPARATOR.$this->ignoredVendorPath())
-            );
-        });
-    }
-
-    /**
-     * Choose the frame outside of either Telescope/Laravel or all packages.
-     *
-     * @return string|null
-     */
-    protected function ignoredVendorPath()
-    {
-        if (! ($this->options['ignore_packages'] ?? true)) {
-            return 'laravel';
-        }
     }
 }

--- a/tests/Watchers/GateWatcherTest.php
+++ b/tests/Watchers/GateWatcherTest.php
@@ -100,7 +100,7 @@ class GateWatcherTest extends FeatureTestCase
         Gate::policy(TestResource::class, TestPolicy::class);
 
         (new TestController())->create(new TestResource());
-        
+
         $entry = $this->loadTelescopeEntries()->first();
 
         $this->assertSame(EntryType::GATE, $entry->type);
@@ -117,7 +117,7 @@ class GateWatcherTest extends FeatureTestCase
 
         try {
             (new TestController())->update(new TestResource());
-        } catch(\Exception $ex) {
+        } catch (\Exception $ex) {
             // ignore
         }
         
@@ -179,11 +179,11 @@ class TestResource
 
 class TestController
 {
-	use AuthorizesRequests;
+    use AuthorizesRequests;
 
-	public function create($object)
-	{
-		$this->authorize($object);
+    public function create($object)
+    {
+        $this->authorize($object);
     }
 
     public function update($object)

--- a/tests/Watchers/GateWatcherTest.php
+++ b/tests/Watchers/GateWatcherTest.php
@@ -19,6 +19,8 @@ class GateWatcherTest extends FeatureTestCase
             GateWatcher::class => true,
         ]);
 
+        $app->setBasePath(dirname(__FILE__, 3));
+
         Gate::define('potato', function (User $user) {
             return $user->email === 'allow';
         });
@@ -40,6 +42,8 @@ class GateWatcherTest extends FeatureTestCase
 
         $this->assertTrue($check);
         $this->assertSame(EntryType::GATE, $entry->type);
+        $this->assertSame(__FILE__, $entry->content['file']);
+        $this->assertSame(39, $entry->content['line']);
         $this->assertSame('potato', $entry->content['ability']);
         $this->assertSame('allowed', $entry->content['result']);
         $this->assertEmpty($entry->content['arguments']);
@@ -53,6 +57,8 @@ class GateWatcherTest extends FeatureTestCase
 
         $this->assertFalse($check);
         $this->assertSame(EntryType::GATE, $entry->type);
+        $this->assertSame(__FILE__, $entry->content['file']);
+        $this->assertSame(54, $entry->content['line']);
         $this->assertSame('potato', $entry->content['ability']);
         $this->assertSame('denied', $entry->content['result']);
         $this->assertSame(['banana'], $entry->content['arguments']);
@@ -66,6 +72,8 @@ class GateWatcherTest extends FeatureTestCase
 
         $this->assertTrue($check);
         $this->assertSame(EntryType::GATE, $entry->type);
+        $this->assertSame(__FILE__, $entry->content['file']);
+        $this->assertSame(69, $entry->content['line']);
         $this->assertSame('guest potato', $entry->content['ability']);
         $this->assertSame('allowed', $entry->content['result']);
         $this->assertEmpty($entry->content['arguments']);
@@ -79,6 +87,8 @@ class GateWatcherTest extends FeatureTestCase
 
         $this->assertFalse($check);
         $this->assertSame(EntryType::GATE, $entry->type);
+        $this->assertSame(__FILE__, $entry->content['file']);
+        $this->assertSame(84, $entry->content['line']);
         $this->assertSame('deny potato', $entry->content['ability']);
         $this->assertSame('denied', $entry->content['result']);
         $this->assertSame(['gelato'], $entry->content['arguments']);

--- a/tests/Watchers/GateWatcherTest.php
+++ b/tests/Watchers/GateWatcherTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Laravel\Telescope\Tests\Watchers;
+
+use Laravel\Telescope\EntryType;
+use Laravel\Telescope\Telescope;
+use Illuminate\Support\Facades\Gate;
+use Laravel\Telescope\Watchers\GateWatcher;
+use Laravel\Telescope\Tests\FeatureTestCase;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class GateWatcherTest extends FeatureTestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app->get('config')->set('telescope.watchers', [
+            GateWatcher::class => true,
+        ]);
+
+        Gate::define('potato', function (User $user) {
+            return $user->email === 'allow';
+        });
+
+        Gate::define('guest potato', function (?User $user) {
+            return true;
+        });
+
+        Gate::define('deny potato', function (?User $user) {
+            return false;
+        });
+    }
+
+    public function test_gate_watcher_registers_allowed_entries()
+    {
+        $check = Gate::forUser(new User('allow'))->check('potato');
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertTrue($check);
+        $this->assertSame(EntryType::GATE, $entry->type);
+        $this->assertSame('potato', $entry->content['ability']);
+        $this->assertSame('allowed', $entry->content['result']);
+        $this->assertEmpty($entry->content['arguments']);
+    }
+
+    public function test_gate_watcher_registers_denied_entries()
+    {
+        $check = Gate::forUser(new User('deny'))->check('potato', ['banana']);
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertFalse($check);
+        $this->assertSame(EntryType::GATE, $entry->type);
+        $this->assertSame('potato', $entry->content['ability']);
+        $this->assertSame('denied', $entry->content['result']);
+        $this->assertSame(['banana'], $entry->content['arguments']);
+    }
+
+    public function test_gate_watcher_registers_allowed_guest_entries()
+    {
+        $check = Gate::check('guest potato');
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertTrue($check);
+        $this->assertSame(EntryType::GATE, $entry->type);
+        $this->assertSame('guest potato', $entry->content['ability']);
+        $this->assertSame('allowed', $entry->content['result']);
+        $this->assertEmpty($entry->content['arguments']);
+    }
+
+    public function test_gate_watcher_registers_denied_guest_entries()
+    {
+        $check = Gate::check('deny potato', ['gelato']);
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertFalse($check);
+        $this->assertSame(EntryType::GATE, $entry->type);
+        $this->assertSame('deny potato', $entry->content['ability']);
+        $this->assertSame('denied', $entry->content['result']);
+        $this->assertSame(['gelato'], $entry->content['arguments']);
+    }
+}
+
+class User implements Authenticatable
+{
+    public $email;
+
+    public function __construct($email)
+    {
+        $this->email = $email;
+    }
+
+    public function getAuthIdentifierName()
+    {
+        return 'Telescope Test';
+    }
+
+    public function getAuthIdentifier()
+    {
+        return 'telescope-test';
+    }
+
+    public function getAuthPassword()
+    {
+        return 'secret';
+    }
+
+    public function getRememberToken()
+    {
+        return 'i-am-telescope';
+    }
+
+    public function setRememberToken($value)
+    {
+        //
+    }
+
+    public function getRememberTokenName()
+    {
+        //
+    }
+}

--- a/tests/Watchers/GateWatcherTest.php
+++ b/tests/Watchers/GateWatcherTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Gate;
 use Laravel\Telescope\Watchers\GateWatcher;
 use Laravel\Telescope\Tests\FeatureTestCase;
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 class GateWatcherTest extends FeatureTestCase
 {
@@ -43,7 +44,7 @@ class GateWatcherTest extends FeatureTestCase
         $this->assertTrue($check);
         $this->assertSame(EntryType::GATE, $entry->type);
         $this->assertSame(__FILE__, $entry->content['file']);
-        $this->assertSame(39, $entry->content['line']);
+        $this->assertSame(40, $entry->content['line']);
         $this->assertSame('potato', $entry->content['ability']);
         $this->assertSame('allowed', $entry->content['result']);
         $this->assertEmpty($entry->content['arguments']);
@@ -58,7 +59,7 @@ class GateWatcherTest extends FeatureTestCase
         $this->assertFalse($check);
         $this->assertSame(EntryType::GATE, $entry->type);
         $this->assertSame(__FILE__, $entry->content['file']);
-        $this->assertSame(54, $entry->content['line']);
+        $this->assertSame(55, $entry->content['line']);
         $this->assertSame('potato', $entry->content['ability']);
         $this->assertSame('denied', $entry->content['result']);
         $this->assertSame(['banana'], $entry->content['arguments']);
@@ -73,7 +74,7 @@ class GateWatcherTest extends FeatureTestCase
         $this->assertTrue($check);
         $this->assertSame(EntryType::GATE, $entry->type);
         $this->assertSame(__FILE__, $entry->content['file']);
-        $this->assertSame(69, $entry->content['line']);
+        $this->assertSame(70, $entry->content['line']);
         $this->assertSame('guest potato', $entry->content['ability']);
         $this->assertSame('allowed', $entry->content['result']);
         $this->assertEmpty($entry->content['arguments']);
@@ -88,10 +89,46 @@ class GateWatcherTest extends FeatureTestCase
         $this->assertFalse($check);
         $this->assertSame(EntryType::GATE, $entry->type);
         $this->assertSame(__FILE__, $entry->content['file']);
-        $this->assertSame(84, $entry->content['line']);
+        $this->assertSame(85, $entry->content['line']);
         $this->assertSame('deny potato', $entry->content['ability']);
         $this->assertSame('denied', $entry->content['result']);
         $this->assertSame(['gelato'], $entry->content['arguments']);
+    }
+
+    public function test_gate_watcher_registers_allowed_policy_entries()
+    {
+        Gate::policy(TestResource::class, TestPolicy::class);
+
+        (new TestController())->create(new TestResource());
+        
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::GATE, $entry->type);
+        $this->assertSame(__FILE__, $entry->content['file']);
+        $this->assertSame(186, $entry->content['line']);
+        $this->assertSame('create', $entry->content['ability']);
+        $this->assertSame('allowed', $entry->content['result']);
+        $this->assertSame([[]], $entry->content['arguments']);
+    }
+
+    public function test_gate_watcher_registers_denied_policy_entries()
+    {
+        Gate::policy(TestResource::class, TestPolicy::class);
+
+        try {
+            (new TestController())->update(new TestResource());
+        } catch(\Exception $ex) {
+            // ignore
+        }
+        
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::GATE, $entry->type);
+        $this->assertSame(__FILE__, $entry->content['file']);
+        $this->assertSame(191, $entry->content['line']);
+        $this->assertSame('update', $entry->content['ability']);
+        $this->assertSame('denied', $entry->content['result']);
+        $this->assertSame([[]], $entry->content['arguments']);
     }
 }
 
@@ -132,5 +169,38 @@ class User implements Authenticatable
     public function getRememberTokenName()
     {
         //
+    }
+}
+
+class TestResource
+{
+    //
+}
+
+class TestController
+{
+	use AuthorizesRequests;
+
+	public function create($object)
+	{
+		$this->authorize($object);
+    }
+
+    public function update($object)
+    {
+        $this->authorize($object);
+    }
+}
+
+class TestPolicy
+{
+    public function create(?User $user)
+    {
+        return true;
+    }
+
+    public function update(?User $user)
+    {
+        return false;
     }
 }


### PR DESCRIPTION
This PR adds a Gate Watcher that allows us to record and monitor gate checks. I think this would be really helpful to understand which gate/permission checks are performed on requests and the result of those checks. The Gate Watcher is disabled by default to avoid breaking changes. Closes #472.

Screenshots below:

**Index Screen**

<img width="1193" alt="screen shot 2018-12-06 at 3 02 07 am" src="https://user-images.githubusercontent.com/16099046/49545366-689ae580-f903-11e8-8997-b47fca6a90c5.png">

**Preview Screen (1/2)**

<img width="1168" alt="screen shot 2018-12-06 at 3 03 08 am" src="https://user-images.githubusercontent.com/16099046/49545438-a3048280-f903-11e8-926f-f13d731ffbdf.png">

**Preview Screen (2/2)**

<img width="1130" alt="screen shot 2018-12-06 at 3 05 16 am" src="https://user-images.githubusercontent.com/16099046/49545486-d0513080-f903-11e8-9c7b-b58a58d56b50.png">

**Related Entries on Request Screen**

<img width="1143" alt="screen shot 2018-12-06 at 3 06 19 am" src="https://user-images.githubusercontent.com/16099046/49545543-fd9dde80-f903-11e8-8b3f-ec8d8b63a755.png">
