### PR TITLE
[1.0] Fix job watcher crash

### DIFF
--- a/src/Watchers/JobWatcher.php
+++ b/src/Watchers/JobWatcher.php
@@ -42,7 +42,7 @@ class JobWatcher extends Watcher
     public function recordJob($connection, $queue, array $payload)
     {
         if (! Telescope::isRecording()) {
-            return null;
+            return;
         }
 
         $content = array_merge([

--- a/src/Watchers/JobWatcher.php
+++ b/src/Watchers/JobWatcher.php
@@ -24,7 +24,7 @@ class JobWatcher extends Watcher
     public function register($app)
     {
         Queue::createPayloadUsing(function ($connection, $queue, $payload) {
-            return ['telescope_uuid' => $this->recordJob($connection, $queue, $payload)->uuid];
+            return ['telescope_uuid' => optional($this->recordJob($connection, $queue, $payload))->uuid];
         });
 
         $app['events']->listen(JobProcessed::class, [$this, 'recordProcessedJob']);
@@ -37,12 +37,12 @@ class JobWatcher extends Watcher
      * @param  string  $connection
      * @param  string  $queue
      * @param  array  $payload
-     * @return \Laravel\Telescope\IncomingEntry
+     * @return \Laravel\Telescope\IncomingEntry|null
      */
     public function recordJob($connection, $queue, array $payload)
     {
         if (! Telescope::isRecording()) {
-            return;
+            return null;
         }
 
         $content = array_merge([


### PR DESCRIPTION
The recent optimization commit was causing the JobWatcher to crash when not recording. This PR fixes #475.