### PR TITLE
Conditional branching in array case

### DIFF
--- a/src/Http/Controllers/EntryController.php
+++ b/src/Http/Controllers/EntryController.php
@@ -73,7 +73,10 @@ abstract class EntryController extends Controller
             return 'paused';
         }
 
-        if (! config('telescope.watchers.'.$this->watcher(), false)) {
+        $watcher = config('telescope.watchers.'.$this->watcher(), false);
+
+        if ((is_bool($watcher) && $watcher === false) ||
+            (is_array($watcher) && $watcher['enabled'] === false)) {
             return 'off';
         }
 


### PR DESCRIPTION
This PR Fixes the following bugs.

## **.env**

> ```ini
> TELESCOPE_QUERY_WATCHER=false
> ```

## Expected
> ![image](https://user-images.githubusercontent.com/1296540/49598059-2801a180-f9c1-11e8-8ea1-9f2d7e692337.png)

## Current Behavior
> ![image](https://user-images.githubusercontent.com/1296540/49597999-04d6f200-f9c1-11e8-97b9-1143cbf80f46.png)

## Reason
If config is an Array, **always** `false` condition.
Then return `'enabled'` status.

```php
$ artisan tinker
>>> config('telescope.watchers.Laravel\Telescope\Watchers\QueryWatcher', false)
=> [
     "enabled" => false,
     "ignore_packages" => true,
     "slow" => 100,
   ]
>>> ! config('telescope.watchers.Laravel\Telescope\Watchers\QueryWatcher', false)
=> false
```

https://github.com/laravel/telescope/blob/54ccd6ac175f081ed2a491c48592d1ad9f1332d9/config/telescope.php#L100-L104
https://github.com/laravel/telescope/blob/54ccd6ac175f081ed2a491c48592d1ad9f1332d9/src/Http/Controllers/EntryController.php#L76-L80