### PR TITLE
Fixing display wrong timestamp

### DIFF
--- a/resources/js/base.js
+++ b/resources/js/base.js
@@ -50,7 +50,7 @@ export default {
          * Show the time in local time.
          */
         localTime(time){
-            return moment(time + ' Z').utc().local().format('MMMM Do YYYY, h:mm:ss A');
+            return moment(time + ' Z').utc().format('MMMM Do YYYY, h:mm:ss A');
         },
 
 


### PR DESCRIPTION
Timezone works perfectly when retrieving but it shows the wrong timezone when Vue render template using `localTime` function. It will fix #429 