### PR TITLE
Minimum Log Level for LogWatcher

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -97,7 +97,10 @@ return [
         Watchers\EventWatcher::class => env('TELESCOPE_EVENT_WATCHER', true),
         Watchers\ExceptionWatcher::class => env('TELESCOPE_EXCEPTION_WATCHER', true),
         Watchers\JobWatcher::class => env('TELESCOPE_JOB_WATCHER', true),
-        Watchers\LogWatcher::class => env('TELESCOPE_LOG_WATCHER', true),
+        Watchers\LogWatcher::class => env('TELESCOPE_LOG_WATCHER', [
+            'enabled' => true,
+            'level'   => 'error',
+        ]),
         Watchers\MailWatcher::class => env('TELESCOPE_MAIL_WATCHER', true),
 
         Watchers\ModelWatcher::class => [

--- a/src/Watchers/LogWatcher.php
+++ b/src/Watchers/LogWatcher.php
@@ -72,6 +72,6 @@ class LogWatcher extends Watcher
      */
     private function shouldIgnore(MessageLogged $event)
     {
-        return $this->level(['level' => $event->level]) < $this->level(['level' => ($this->options['level'] ?? 'info')]);
+        return $this->level(['level' => $event->level]) < $this->level(['level' => ($this->options['level'] ?? 'debug')]);
     }
 }

--- a/src/Watchers/LogWatcher.php
+++ b/src/Watchers/LogWatcher.php
@@ -11,6 +11,7 @@ use Illuminate\Log\ParsesLogConfiguration;
 class LogWatcher extends Watcher
 {
     use ParsesLogConfiguration;
+
     /**
      * Register the watcher.
      *

--- a/src/Watchers/LogWatcher.php
+++ b/src/Watchers/LogWatcher.php
@@ -4,9 +4,9 @@ namespace Laravel\Telescope\Watchers;
 
 use Illuminate\Support\Arr;
 use Laravel\Telescope\Telescope;
-use Illuminate\Log\ParsesLogConfiguration;
 use Laravel\Telescope\IncomingEntry;
 use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Log\ParsesLogConfiguration;
 
 class LogWatcher extends Watcher
 {
@@ -55,17 +55,16 @@ class LogWatcher extends Watcher
     }
 
     /**
-     * Abstract function getFallbackChannelName(); must be defined to use the ParsesLogConfiguration Trait
+     * Abstract function getFallbackChannelName(); must be defined to use the ParsesLogConfiguration Trait.
      *
      * @return void
      */
     protected function getFallbackChannelName()
     {
-        return;
     }
 
     /**
-     * Determine if the event should be ignored. Checks if log level too low
+     * Determine if the event should be ignored. Checks if log level too low.
      *
      * @param  \Illuminate\Log\Events\MessageLogged $event
      * @return bool


### PR DESCRIPTION
It would be useful to be able to set a log level config option for the LogWatcher to make the LogWatcher only log messages greater than a certain log level. In many cases, one may want to have a separate log level for Telescope than for their core application. This PR creates a "level" config option for LogWatcher and uses core Laravel's ParsesLogConfiguration trait to compare log levels. Only log messages with a log level greater than or equal to the passed in level would be logged in Telescope.

There probably needs to be some testing written around this, but I'm having a little trouble figuring out the best way to test that an entry is _not_ written into the database. 