### PR TITLE
Fix Log watcher with exception key

### DIFF
--- a/src/Watchers/LogWatcher.php
+++ b/src/Watchers/LogWatcher.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Telescope\Watchers;
 
+use Exception;
 use Illuminate\Support\Arr;
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\IncomingEntry;
@@ -28,7 +29,8 @@ class LogWatcher extends Watcher
      */
     public function recordLog(MessageLogged $event)
     {
-        if (! Telescope::isRecording() || isset($event->context['exception'])) {
+        if (! Telescope::isRecording()
+            || (isset($event->context['exception']) && $event->context['exception'] instanceof Exception)) {
             return;
         }
 

--- a/tests/Watchers/LogWatcherTest.php
+++ b/tests/Watchers/LogWatcherTest.php
@@ -68,7 +68,7 @@ class LogWatcherTest extends FeatureTestCase
 
         $this->assertSame(EntryType::LOG, $entry->type);
         $this->assertSame('error', $entry->content['level']);
-        $this->assertSame("Logging Level ['error'].", $entry->content['message']);
+        $this->assertSame('Some message', $entry->content['message']);
         $this->assertSame('Some error message', $entry->content['context']['exception']);
     }
 }

--- a/tests/Watchers/LogWatcherTest.php
+++ b/tests/Watchers/LogWatcherTest.php
@@ -61,7 +61,7 @@ class LogWatcherTest extends FeatureTestCase
         $logger = $this->app->get(LoggerInterface::class);
 
         $logger->error("Logging Level ['error'].", [
-            'exception' => 'Some error message'
+            'exception' => 'Some error message',
         ]);
 
         $entry = $this->loadTelescopeEntries()->first();

--- a/tests/Watchers/LogWatcherTest.php
+++ b/tests/Watchers/LogWatcherTest.php
@@ -60,7 +60,7 @@ class LogWatcherTest extends FeatureTestCase
     {
         $logger = $this->app->get(LoggerInterface::class);
 
-        $logger->error("Logging Level ['error'].", [
+        $logger->error("Some message", [
             'exception' => 'Some error message',
         ]);
 

--- a/tests/Watchers/LogWatcherTest.php
+++ b/tests/Watchers/LogWatcherTest.php
@@ -55,4 +55,20 @@ class LogWatcherTest extends FeatureTestCase
         $this->assertSame('Claire Redfield', $entry->content['context']['user']);
         $this->assertSame('Zombie Hunter', $entry->content['context']['role']);
     }
+
+    public function test_log_watcher_registers_entry_with_exception_key()
+    {
+        $logger = $this->app->get(LoggerInterface::class);
+
+        $logger->error("Logging Level ['error'].", [
+            'exception' => 'Some error message'
+        ]);
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::LOG, $entry->type);
+        $this->assertSame('error', $entry->content['level']);
+        $this->assertSame("Logging Level ['error'].", $entry->content['message']);
+        $this->assertSame('Some error message', $entry->content['context']['exception']);
+    }
 }

--- a/tests/Watchers/LogWatcherTest.php
+++ b/tests/Watchers/LogWatcherTest.php
@@ -60,7 +60,7 @@ class LogWatcherTest extends FeatureTestCase
     {
         $logger = $this->app->get(LoggerInterface::class);
 
-        $logger->error("Some message", [
+        $logger->error('Some message', [
             'exception' => 'Some error message',
         ]);
 


### PR DESCRIPTION
Currently if we log data that has the `exception` key it will throw an exception.
So this:
```
    $logger->error("Some message", [
            'exception' => 'Some error message'
    ]);
```
will throw an error: `get_class() expects parameter 1 to be object, string given`
at: `Watchers/ExceptionWatcher.php:40)`

I've added a test to prove the bug.
And the fix: also checking if the 'exception' key is an instance of Exception.