### PR TITLE
created a config item to enable or disable the dark/night theme

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -9,6 +9,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Telescope Dark Mode
+    |--------------------------------------------------------------------------
+    |
+    | This configuration options determines if telescope will load its dark theme
+    | as default theme to use on its UI
+    |
+    */
+
+    'dark_mode' => env('TELESCOPE_DARK_MODE', false),
+    
+    /*
+    |--------------------------------------------------------------------------
     | Telescope Storage Driver
     |--------------------------------------------------------------------------
     |

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -9,7 +9,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Telescope Dark Mode
+    | Telescope Dark Theme
     |--------------------------------------------------------------------------
     |
     | This configuration options determines if telescope will load its dark theme
@@ -17,8 +17,8 @@ return [
     |
     */
 
-    'dark_mode' => env('TELESCOPE_DARK_MODE', false),
-    
+    'dark_theme' => env('TELESCOPE_DARK_THEME', false),
+
     /*
     |--------------------------------------------------------------------------
     | Telescope Storage Driver

--- a/stubs/TelescopeServiceProvider.stub
+++ b/stubs/TelescopeServiceProvider.stub
@@ -16,7 +16,7 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
      */
     public function register()
     {
-        if (config('telescope.dark_mode')) {
+        if (config('telescope.dark_theme')) {
             Telescope::night();
         }
 

--- a/stubs/TelescopeServiceProvider.stub
+++ b/stubs/TelescopeServiceProvider.stub
@@ -16,7 +16,9 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
      */
     public function register()
     {
-        // Telescope::night();
+        if (config('telescope.dark_mode')) {
+            Telescope::night();
+        }
 
         $this->hideSensitiveRequestDetails();
 


### PR DESCRIPTION
First of all, sorry if this isn't the best way to do that.
I didn't saw any guide on how to contribute to the project.

I work on a team with many developers, some of them prefer the light theme and some (like me) prefer the dark/night theme.

I made this change in our project and I tought that could be a nice-to-have config on the project, this way, when working on a team, each dev can have telescope loading their preferred theme.