### PR TITLE
Hide response parameters

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -75,6 +75,13 @@ class Telescope
     ];
 
     /**
+     * The list of hidden response parameters.
+     *
+     * @var array
+     */
+    public static $hiddenResponseParameters = [];
+
+    /**
      * Indicates if Telescope should ignore events fired by Laravel.
      *
      * @var bool
@@ -559,6 +566,21 @@ class Telescope
     {
         static::$hiddenRequestParameters = array_merge(
             static::$hiddenRequestParameters, $attributes
+        );
+
+        return new static;
+    }
+
+    /**
+     * Hide the given response parameters.
+     *
+     * @param  array  $attributes
+     * @return static
+     */
+    public static function hideResponseParameters(array $attributes)
+    {
+        static::$hiddenResponseParameters = array_merge(
+            static::$hiddenResponseParameters, $attributes
         );
 
         return new static;

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -130,8 +130,14 @@ class RequestWatcher extends Watcher
         if (is_string($content) &&
             is_array(json_decode($content, true)) &&
             json_last_error() === JSON_ERROR_NONE) {
+            $all = json_decode($content, true);
+            foreach (Telescope::$hiddenResponseParameters as $parameter) {
+                if (Arr::get($all, $parameter)) {
+                    Arr::set($all, $parameter, '********');
+                }
+            }
             return $this->contentWithinLimits($content)
-                    ? json_decode($response->getContent(), true) : 'Purged By Telescope';
+                ? $all : 'Purged By Telescope';
         }
 
         if ($response instanceof RedirectResponse) {


### PR DESCRIPTION
Method to hide response parameters using Telescope:: hideResponseParameters([]) in TelescopeProvider.
Can be useful to hide "access_token" in API response, for example.