### PR TITLE
Check if tables already exists

### DIFF
--- a/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -32,37 +32,43 @@ class CreateTelescopeEntriesTable extends Migration
      */
     public function up()
     {
-        $this->schema->create('telescope_entries', function (Blueprint $table) {
-            $table->bigIncrements('sequence');
-            $table->uuid('uuid');
-            $table->uuid('batch_id');
-            $table->string('family_hash')->nullable()->index();
-            $table->boolean('should_display_on_index')->default(true);
-            $table->string('type', 20);
-            $table->text('content');
-            $table->dateTime('created_at')->nullable();
+        if (! $this->schema->hasTable('telescope_entries')) {
+            $this->schema->create('telescope_entries', function (Blueprint $table) {
+                $table->bigIncrements('sequence');
+                $table->uuid('uuid');
+                $table->uuid('batch_id');
+                $table->string('family_hash')->nullable()->index();
+                $table->boolean('should_display_on_index')->default(true);
+                $table->string('type', 20);
+                $table->text('content');
+                $table->dateTime('created_at')->nullable();
 
-            $table->unique('uuid');
-            $table->index('batch_id');
-            $table->index(['type', 'should_display_on_index']);
-        });
+                $table->unique('uuid');
+                $table->index('batch_id');
+                $table->index(['type', 'should_display_on_index']);
+            });
+        }
 
-        $this->schema->create('telescope_entries_tags', function (Blueprint $table) {
-            $table->uuid('entry_uuid');
-            $table->string('tag');
+        if (! $this->schema->hasTable('telescope_entries_tags')) {
+            $this->schema->create('telescope_entries_tags', function (Blueprint $table) {
+                $table->uuid('entry_uuid');
+                $table->string('tag');
 
-            $table->index(['entry_uuid', 'tag']);
-            $table->index('tag');
+                $table->index(['entry_uuid', 'tag']);
+                $table->index('tag');
 
-            $table->foreign('entry_uuid')
-                  ->references('uuid')
-                  ->on('telescope_entries')
-                  ->onDelete('cascade');
-        });
+                $table->foreign('entry_uuid')
+                    ->references('uuid')
+                    ->on('telescope_entries')
+                    ->onDelete('cascade');
+            });
+        }
 
-        $this->schema->create('telescope_monitoring', function (Blueprint $table) {
-            $table->string('tag');
-        });
+        if (! $this->schema->hasTable('telescope_monitoring')) {
+            $this->schema->create('telescope_monitoring', function (Blueprint $table) {
+                $table->string('tag');
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
The Telescope migrations are always running for the same connection: 
`config('telescope.storage.database.connection')`

So when we run a migration for a different connection we get an error saying:
`Base table or view already exists: 1050 Table 'telescope_entries' already exists`

On this PR I've added a check if the table already exists that will prevent this error.
