### PR TITLE
ExtractTags from multi-level Collections

### DIFF
--- a/src/ExtractTags.php
+++ b/src/ExtractTags.php
@@ -175,6 +175,7 @@ class ExtractTags
                 $flat_array = array_merge($flat_array, [$item]);
             }
         });
+
         return $flat_array;
     }
 

--- a/src/ExtractTags.php
+++ b/src/ExtractTags.php
@@ -151,12 +151,31 @@ class ExtractTags
                 if ($value instanceof Model) {
                     return [$value];
                 } elseif ($value instanceof EloquentCollection) {
-                    return $value->all();
+                    return static::flattenCollection($value);
                 }
             })->collapse()->filter()->all();
         }
 
         return collect(Arr::collapse($models))->unique();
+    }
+
+    /**
+     * Flatten a potentially multi-level Collection and return any Models found.
+     *
+     * @param EloquentCollection $collection
+     * @return array
+     */
+    protected static function flattenCollection(EloquentCollection $collection)
+    {
+        $flat_array = [];
+        $collection->each(function ($item, $key) use (&$flat_array) {
+            if ($item instanceof EloquentCollection) {
+                $flat_array = array_merge($flat_array, static::flattenCollection($item));
+            } elseif ($item instanceof Model) {
+                $flat_array = array_merge($flat_array, [$item]);
+            }
+        });
+        return $flat_array;
     }
 
     /**


### PR DESCRIPTION
Solution to Issue #504.

The problem arises when you take a simple Collection of Models, and execute a 'groupBy' or otherwise modify the Collection so it is no longer single-level. In the ExtractTags file, modelsFor() was assuming that if a property of the target class was an EloquentCollection that it was always a simple Collection of Models.

There are 'flatten' methods available to the Collection class, but I wasn't completely sure how they would handle variable depth Collections, or if you had a mixed Collection where only some elements were instances of the Model class.