### PR TITLE
Database migrations customisation

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -110,6 +110,13 @@ class Telescope
     public static $shouldRecord = false;
 
     /**
+     * Indicates if Telescope migrations will be run.
+     *
+     * @var bool
+     */
+    public static $runsMigrations = true;
+
+    /**
      * Register the Telescope watchers and start recording if necessary.
      *
      * @param  \Illuminate\Foundation\Application  $app
@@ -670,5 +677,17 @@ class Telescope
             'timezone' => config('app.timezone'),
             'recording' => ! cache('telescope:pause-recording'),
         ];
+    }
+
+    /**
+     * Configure Telescope to not register it's migrations.
+     *
+     * @return static
+     */
+    public static function ignoreMigrations()
+    {
+        static::$runsMigrations = false;
+
+        return new static;
     }
 }

--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -162,6 +162,6 @@ class TelescopeServiceProvider extends ServiceProvider
      */
     protected function shouldMigrate()
     {
-        return config('telescope.driver') === 'database';
+        return Telescope::$runsMigrations && config('telescope.driver') === 'database';
     }
 }

--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -79,6 +79,10 @@ class TelescopeServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
+                __DIR__.'/Storage/migrations' => database_path('migrations'),
+            ], 'telescope-migrations');
+
+            $this->publishes([
                 __DIR__.'/../public' => public_path('vendor/telescope'),
             ], 'telescope-assets');
 


### PR DESCRIPTION
Before this Pull Request, it was not possible to publish the default migrations or easily ignore the migrations for the Laravel Telescope package.

If you consider these changes, users will be able to export the migrations using:

```
php artisan vendor:publish --tag=telescope-migrations
```

Users will also be able to ignore the running of these default migrations, should they wish to by calling the `Telescope::ignoreMigrations()` method in the register method of their AppServiceProvider.

These changes I have made, are only mimicking the behaviour of publishing and ignoring migrations, which is present in Laravel Passport.

Resolves https://github.com/laravel/telescope/issues/525

A pull request has also been made to the [Laravel Docs repository](https://github.com/laravel/docs/pull/4902)