### PR TITLE
ExtractTags from multi-level Collections

### DIFF
--- a/src/ExtractTags.php
+++ b/src/ExtractTags.php
@@ -175,6 +175,7 @@ class ExtractTags
                 $flat_array = array_merge($flat_array, [$item]);
             }
         });
+
         return $flat_array;
     }
 

--- a/src/ExtractTags.php
+++ b/src/ExtractTags.php
@@ -60,7 +60,7 @@ class ExtractTags
             if ($value instanceof Model) {
                 return [$value];
             } elseif ($value instanceof EloquentCollection) {
-                return $value->all();
+                return static::flattenCollection($value);
             }
         })->collapse()->filter();
 

--- a/src/ExtractTags.php
+++ b/src/ExtractTags.php
@@ -151,12 +151,31 @@ class ExtractTags
                 if ($value instanceof Model) {
                     return [$value];
                 } elseif ($value instanceof EloquentCollection) {
-                    return $value->all();
+                    return static::flattenCollection($value);
                 }
             })->collapse()->filter()->all();
         }
 
         return collect(Arr::collapse($models))->unique();
+    }
+
+    /**
+     * Flatten a potentially multi-level Collection and return any Models found.
+     *
+     * @param EloquentCollection $collection
+     * @return array
+     */
+    protected static function flattenCollection(EloquentCollection $collection)
+    {
+        $flat_array = [];
+        $collection->each(function ($item, $key) use (&$flat_array) {
+            if ($item instanceof EloquentCollection) {
+                $flat_array = array_merge($flat_array, static::flattenCollection($item));
+            } elseif ($item instanceof Model) {
+                $flat_array = array_merge($flat_array, [$item]);
+            }
+        });
+        return $flat_array;
     }
 
     /**

--- a/tests/Telescope/ExtractTagTest.php
+++ b/tests/Telescope/ExtractTagTest.php
@@ -14,7 +14,6 @@ class ExtractTagTest extends FeatureTestCase
     public function test_extract_tag_from_array_containing_flat_collection()
     {
         $this->loadFactoriesUsing($this->app, __DIR__.'/../../src/Storage/factories');
-
         $flat_collection = factory(EntryModel::class, 1)->create();
 
         $tag = FormatModel::given($flat_collection->first());
@@ -29,12 +28,45 @@ class ExtractTagTest extends FeatureTestCase
     public function test_extract_tag_from array_containing_deep_collection()
     {
         $this->loadFactoriesUsing($this->app, __DIR__.'/../../src/Storage/factories');
-
         $deep_collection = factory(EntryModel::class, 1)->create()->groupBy('type');
 
         $tag = FormatModel::given($flat_collection->first()->first());
         $extracted_tag = ExtractTags::fromArray([$deep_collection]);
 
         $this->assertSame($tag, $extracted_tag);
+    }
+
+    /**
+     * @test
+     */
+    public function test_extract_tag_from_mailable()
+    {
+        $this->loadFactoriesUsing($this->app, __DIR__.'/../../src/Storage/factories');
+        $deep_collection = factory(EntryModel::class, 1)->create()->groupBy('type');
+        $mailable = new DummyMailableWithData($deep_collection);
+
+        $tag = FormatModel::given($flat_collection->first()->first());
+        $extracted_tag = ExtractTags::from($mailable);
+
+        $this->assertSame($tag, $extracted_tag);
+    }
+}
+
+class DummyMailableWithData extends Mailable
+{
+    private $mail_data;
+
+    public function __construct($mail_data) {
+        $this->mail_data = $mail_data;
+    }
+
+    public function build()
+    {
+        return $this->from('from@laravel.com')
+            ->to('to@laravel.com')
+            ->view(['raw' => 'simple text content'])
+            ->with([
+                'mail_data' => $this->mail_data,
+            ]);
     }
 }

--- a/tests/Telescope/ExtractTagTest.php
+++ b/tests/Telescope/ExtractTagTest.php
@@ -25,7 +25,7 @@ class ExtractTagTest extends FeatureTestCase
     /**
      * @test
      */
-    public function test_extract_tag_from array_containing_deep_collection()
+    public function test_extract_tag_from_array_containing_deep_collection()
     {
         $this->loadFactoriesUsing($this->app, __DIR__.'/../../src/Storage/factories');
         $deep_collection = factory(EntryModel::class, 1)->create()->groupBy('type');

--- a/tests/Telescope/ExtractTagTest.php
+++ b/tests/Telescope/ExtractTagTest.php
@@ -32,7 +32,7 @@ class ExtractTagTest extends FeatureTestCase
         $this->loadFactoriesUsing($this->app, __DIR__.'/../../src/Storage/factories');
         $deep_collection = factory(EntryModel::class, 1)->create()->groupBy('type');
 
-        $tag = FormatModel::given($flat_collection->first()->first());
+        $tag = FormatModel::given($deep_collection->first()->first());
         $extracted_tag = ExtractTags::fromArray([$deep_collection]);
 
         $this->assertSame($tag, $extracted_tag[0]);
@@ -47,7 +47,7 @@ class ExtractTagTest extends FeatureTestCase
         $deep_collection = factory(EntryModel::class, 1)->create()->groupBy('type');
         $mailable = new DummyMailableWithData($deep_collection);
 
-        $tag = FormatModel::given($flat_collection->first()->first());
+        $tag = FormatModel::given($deep_collection->first()->first());
         $extracted_tag = ExtractTags::from($mailable);
 
         $this->assertSame($tag, $extracted_tag[0]);

--- a/tests/Telescope/ExtractTagTest.php
+++ b/tests/Telescope/ExtractTagTest.php
@@ -56,7 +56,8 @@ class DummyMailableWithData extends Mailable
 {
     private $mail_data;
 
-    public function __construct($mail_data) {
+    public function __construct($mail_data)
+    {
         $this->mail_data = $mail_data;
     }
 

--- a/tests/Telescope/ExtractTagTest.php
+++ b/tests/Telescope/ExtractTagTest.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Telescope\Tests\Telescope;
 
+use Illuminate\Mail\Mailable;
+use Laravel\Telescope\ExtractTags;
 use Laravel\Telescope\FormatModel;
 use Laravel\Telescope\Storage\EntryModel;
 use Laravel\Telescope\Tests\FeatureTestCase;
@@ -19,7 +21,7 @@ class ExtractTagTest extends FeatureTestCase
         $tag = FormatModel::given($flat_collection->first());
         $extracted_tag = ExtractTags::fromArray([$flat_collection]);
 
-        $this->assertSame($tag, $extracted_tag);
+        $this->assertSame($tag, $extracted_tag[0]);
     }
 
     /**
@@ -33,7 +35,7 @@ class ExtractTagTest extends FeatureTestCase
         $tag = FormatModel::given($flat_collection->first()->first());
         $extracted_tag = ExtractTags::fromArray([$deep_collection]);
 
-        $this->assertSame($tag, $extracted_tag);
+        $this->assertSame($tag, $extracted_tag[0]);
     }
 
     /**
@@ -48,7 +50,7 @@ class ExtractTagTest extends FeatureTestCase
         $tag = FormatModel::given($flat_collection->first()->first());
         $extracted_tag = ExtractTags::from($mailable);
 
-        $this->assertSame($tag, $extracted_tag);
+        $this->assertSame($tag, $extracted_tag[0]);
     }
 }
 

--- a/tests/Telescope/ExtractTagTest.php
+++ b/tests/Telescope/ExtractTagTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Laravel\Telescope\Tests\Telescope;
+
+use Laravel\Telescope\FormatModel;
+use Laravel\Telescope\Storage\EntryModel;
+use Laravel\Telescope\Tests\FeatureTestCase;
+
+class ExtractTagTest extends FeatureTestCase
+{
+    /**
+     * @test
+     */
+    public function test_extract_tag_from_array_containing_flat_collection()
+    {
+        $this->loadFactoriesUsing($this->app, __DIR__.'/../../src/Storage/factories');
+
+        $flat_collection = factory(EntryModel::class, 1)->create();
+
+        $tag = FormatModel::given($flat_collection->first());
+        $extracted_tag = ExtractTags::fromArray([$flat_collection]);
+
+        $this->assertSame($tag, $extracted_tag);
+    }
+
+    /**
+     * @test
+     */
+    public function test_extract_tag_from array_containing_deep_collection()
+    {
+        $this->loadFactoriesUsing($this->app, __DIR__.'/../../src/Storage/factories');
+
+        $deep_collection = factory(EntryModel::class, 1)->create()->groupBy('type');
+
+        $tag = FormatModel::given($flat_collection->first()->first());
+        $extracted_tag = ExtractTags::fromArray([$deep_collection]);
+
+        $this->assertSame($tag, $extracted_tag);
+    }
+}


### PR DESCRIPTION
Solution to Issue #504.

**Problem:**
In _ExtractTags_, when calling the public `fromArray` method, or the private `modelsFor` method they are both looking for either instances of `Model` or `EloquentCollection`. If an `EloquentCollection` is detected, the assumption it is made that this is the result of a query and a Collection of `Model` classes.

If however you take the result of a query and issue a `groupBy` to the Collection, it becomes a Collection of Collections, and the assumption that _$value->all()_ will resolve into an array of `Model` classes falls apart resulting in an exception thrown when _FormatModel::given_ is called.

**Solution:**
Instead of simply calling _$value->all()_, call a new method that will recurse through the collection and return a flat array containing any instances of `Model` found.

**Impact to Experience:**
If querying data that needs to be grouped and sent in an email, you could end up with the following situation:

```
$mail_data = DummyModel::all()->groupBy('someKey');
Mail::send(new DummyMailableWithData($mail_data));

class DummyMailableWithData extends Mailable
{
    private $mail_data;

    public function __construct($mail_data) {
        $this->mail_data = $mail_data;
    }

    public function build()
    {
        return $this->from('from@laravel.com')
            ->to('to@laravel.com')
            ->view('bladeViewNeedingData')
            ->with([
                'mail_data' => $this->mail_data,
            ]);
    }
}
```
Because `static::registerMailableTagExtractor()` is called regardless regardless of whether the _MailWatcher_ is enabled, if you use this pattern anywhere in you Laravel application, Telescope must be completely disabled.

**Testing**
Rather then test indirectly throught the _MailWatcher_ hook, I made a  few tests in a new _ExtractTagTest_ file to more directly test the impacted methods. Writing the test from this angle is how I found that `fromArray` was impact in addition to the `modelsFor` method. The tests verify an extracted tag matches one generated by `FormatModel::given($model)` regardless of whether the `EloquentCollection` containing the `Model` we wanted to extract the tag from was grouped or not. For my `Model` class I used the factory to generate a random `EntryModel` to leverage existing code and not need to create a local DummyModel.