### PR TITLE
[1.0] Add primary keys to database tables

### DIFF
--- a/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -48,9 +48,11 @@ class CreateTelescopeEntriesTable extends Migration
         });
 
         $this->schema->create('telescope_entries_tags', function (Blueprint $table) {
+            $table->uuid('uuid');
             $table->uuid('entry_uuid');
             $table->string('tag');
 
+            $table->primary('uuid');
             $table->index(['entry_uuid', 'tag']);
             $table->index('tag');
 

--- a/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -42,7 +42,7 @@ class CreateTelescopeEntriesTable extends Migration
             $table->text('content');
             $table->dateTime('created_at')->nullable();
 
-            $table->unique('uuid');
+            $table->primary('uuid');
             $table->index('batch_id');
             $table->index(['type', 'should_display_on_index']);
         });


### PR DESCRIPTION
Added missing primary keys to `telescope_entries` table.
Also added a new primary key column to `telescope_entries_tags` table.

Fixing #534 Issue