### PR TITLE
Make longer content entries possible

### DIFF
--- a/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -39,7 +39,7 @@ class CreateTelescopeEntriesTable extends Migration
             $table->string('family_hash')->nullable()->index();
             $table->boolean('should_display_on_index')->default(true);
             $table->string('type', 20);
-            $table->text('content');
+            $table->longText('content');
             $table->dateTime('created_at')->nullable();
 
             $table->unique('uuid');


### PR DESCRIPTION
I encountered an issue with Telescope when logging requests with large `Cache` payloads. The requests would not show up in the dashboard. When using a longer field-type for the content the request was logged as it should.