### PR TITLE
Don't run migrations when connection differs from configured connection

### DIFF
--- a/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -32,6 +32,10 @@ class CreateTelescopeEntriesTable extends Migration
      */
     public function up()
     {
+        if (!app()->environment('self-testing') && !$this->currentConnectionIsConfiguredTelescopeConnection()) {
+            return;
+        }
+
         $this->schema->create('telescope_entries', function (Blueprint $table) {
             $table->bigIncrements('sequence');
             $table->uuid('uuid');
@@ -75,5 +79,17 @@ class CreateTelescopeEntriesTable extends Migration
         $this->schema->dropIfExists('telescope_entries_tags');
         $this->schema->dropIfExists('telescope_entries');
         $this->schema->dropIfExists('telescope_monitoring');
+    }
+
+    /**
+     * Determine if the current connection is the configured Telescope connection.
+     *
+     * @return boolean
+     */
+    protected function currentConnectionIsConfiguredTelescopeConnection()
+    {
+        $currentConnection = resolve('migrator')->getConnection();
+
+        return $currentConnection == config('telescope.storage.database.connection');
     }
 }

--- a/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateTelescopeEntriesTable extends Migration
 {
@@ -32,7 +32,7 @@ class CreateTelescopeEntriesTable extends Migration
      */
     public function up()
     {
-        if (!app()->environment('self-testing') && !$this->currentConnectionIsConfiguredTelescopeConnection()) {
+        if (! app()->environment('self-testing') && ! $this->currentConnectionIsConfiguredTelescopeConnection()) {
             return;
         }
 
@@ -84,7 +84,7 @@ class CreateTelescopeEntriesTable extends Migration
     /**
      * Determine if the current connection is the configured Telescope connection.
      *
-     * @return boolean
+     * @return bool
      */
     protected function currentConnectionIsConfiguredTelescopeConnection()
     {

--- a/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
 class CreateTelescopeEntriesTable extends Migration
 {


### PR DESCRIPTION
This is my proposed fix to https://github.com/laravel/telescope/issues/540

When a user runs `php artisan migrate --database=mysql_testing` (or any other migrate command) whilst specifying the database connection to use through the --database option, Telescope ignores the specified database connection and attempts to migrate the database on the connection configured in config/telescope.php.

This PR checks the connection the Migrator is currently using and does not run Telescope's migrations if it differs from the connection configured in config/telescope.php.

Hope this helps!