### PR TITLE
Fix config/app.php linendings

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -61,8 +61,8 @@ class InstallCommand extends Command
         }
 
         file_put_contents(config_path('app.php'), str_replace(
-            "{$namespace}\\Providers\EventServiceProvider::class,".PHP_EOL,
-            "{$namespace}\\Providers\EventServiceProvider::class,".PHP_EOL."        {$namespace}\Providers\TelescopeServiceProvider::class,".PHP_EOL,
+            "{$namespace}\\Providers\EventServiceProvider::class,",
+            "{$namespace}\\Providers\EventServiceProvider::class,".PHP_EOL."        {$namespace}\Providers\TelescopeServiceProvider::class,",
             $appConfig
         ));
 


### PR DESCRIPTION
If you checkout a new laravel project on windows your `config/app.php` might end up with linux lineendings.

If you then run `php artisan telescope:install` this string can't be found in the config: `"{$namespace}\\Providers\EventServiceProvider::class,".PHP_EOL`. And so the `TelescopeServiceProvider` is not added to it.



This caused https://github.com/laravel/telescope/issues/178, https://github.com/laravel/telescope/issues/271, https://github.com/laravel/telescope/issues/500 and probably some more issues like "darkmode not working", when the underlying problem was that the TelescopeServiceProvider wasn't registered.