### PR TITLE
Add ability to configure route domain setting

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -5,6 +5,30 @@ use Laravel\Telescope\Http\Middleware\Authorize;
 
 return [
 
+    /*
+    |--------------------------------------------------------------------------
+    | Telescope Domain
+    |--------------------------------------------------------------------------
+    |
+    | This is the domain of where Telescope will be accessible from. Do not
+    | change this setting if you'd want Telescope to live under the same
+    | domain as your app. Change this if you'd want to use sub-domain.
+    |
+    */
+
+    'domain' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Telescope Path
+    |--------------------------------------------------------------------------
+    |
+    | This is the URI path where Telescope will be accessible from. Feel free
+    | to change this path to anything you like. Note that the URI will not
+    | affect the paths of its internal API which aren't exposed to users.
+    |
+    */
+
     'path' => 'telescope',
 
     /*

--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -52,6 +52,7 @@ class TelescopeServiceProvider extends ServiceProvider
     private function routeConfiguration()
     {
         return [
+            'domain' => config('telescope.domain', null),
             'namespace' => 'Laravel\Telescope\Http\Controllers',
             'prefix' => config('telescope.path'),
             'middleware' => 'telescope',


### PR DESCRIPTION
Currently there's no way to specify the domain of Telescope, and we only have the `path` option, I wanted Telescope to have its dedicated sub-domain like `telescope.myapp.com`.
Also added notes in the config comment blocks