### PR TITLE
Update Cache to use seconds instead of minutes starting from Laravel 5.8

### DIFF
--- a/resources/js/screens/cache/preview.vue
+++ b/resources/js/screens/cache/preview.vue
@@ -16,11 +16,7 @@
 
         methods: {
             formatExpiration(expiration) {
-                if (expiration < 1) {
-                    return expiration * 60 + ' seconds';
-                }
-
-                return expiration + ' minutes';
+                return expiration + ' seconds';
             }
         }
     }

--- a/src/Watchers/CacheWatcher.php
+++ b/src/Watchers/CacheWatcher.php
@@ -80,7 +80,7 @@ class CacheWatcher extends Watcher
             'type' => 'set',
             'key' => $event->key,
             'value' => $event->value,
-            'expiration' => $event->minutes,
+            'expiration' => $event->seconds,
         ]));
     }
 


### PR DESCRIPTION
I'm not sure if it's a bug, so submitting it to `master`.