### PR TITLE
Use a custom model key

### DIFF
--- a/src/FormatModel.php
+++ b/src/FormatModel.php
@@ -15,6 +15,12 @@ class FormatModel
      */
     public static function given($model)
     {
-        return get_class($model).':'.implode('_', Arr::wrap($model->getKey()));
+        if (method_exists($model, 'getTelescopeKey')) {
+            $key = $model->getTelescopeKey();
+        } else {
+            $key = $model->getKey();
+        }
+
+        return get_class($model).':'.implode('_', Arr::wrap($key));
     }
 }


### PR DESCRIPTION
It would be nice to be able to customize the model key that will be displayed on the dasbhoard without having to change the getKey method.

I don't like much the idea of adding a method on the model, but it's optional . (I thought of adding this in the config, but it looks cleaner directly on the model)