### PR TITLE
Fix config newline

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -69,8 +69,8 @@ class InstallCommand extends Command
         $eol = array_keys($lineEndingCount, max($lineEndingCount))[0];
 
         file_put_contents(config_path('app.php'), str_replace(
-            "{$namespace}\\Providers\EventServiceProvider::class,".PHP_EOL,
-            "{$namespace}\\Providers\EventServiceProvider::class,".PHP_EOL."        {$namespace}\Providers\TelescopeServiceProvider::class,".PHP_EOL,
+            "{$namespace}\\Providers\EventServiceProvider::class,".$eol,
+            "{$namespace}\\Providers\EventServiceProvider::class,".$eol."        {$namespace}\Providers\TelescopeServiceProvider::class,".$eol,
             $appConfig
         ));
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -60,6 +60,14 @@ class InstallCommand extends Command
             return;
         }
 
+        $lineEndingCount = [
+            "\r\n" => substr_count($appConfig, "\r\n"),
+            "\r" => substr_count($appConfig, "\r"),
+            "\n" => substr_count($appConfig, "\n")
+        ];
+
+        $eol = array_keys($lineEndingCount, max($lineEndingCount))[0];
+
         file_put_contents(config_path('app.php'), str_replace(
             "{$namespace}\\Providers\EventServiceProvider::class,".PHP_EOL,
             "{$namespace}\\Providers\EventServiceProvider::class,".PHP_EOL."        {$namespace}\Providers\TelescopeServiceProvider::class,".PHP_EOL,


### PR DESCRIPTION
Fixes a bug introduced after #558.

When registering the Telescope service provider the install command attempts to find and replace code with a needle that contains the platform's native end of line symbol, rather than what's currently being used in the file. This can result in the needle not being found on operating systems like Windows, if using Unix LF (like for PSR-2).

Fixes #271, Fixes #470, Fixes #500, Fixes #555