### PR TITLE
Avoid error exception if currenty entry has empty content

### DIFF
--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -190,8 +190,13 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
                 continue;
             }
 
+            $currentEntryContent = json_decode($entry->content, true);
+            if (!is_array($currentEntryContent)) {
+                $currentEntryContent = [];
+            }
+            
             $content = json_encode(array_merge(
-                json_decode($entry->content, true), $update->changes
+                $currentEntryContent, $update->changes
             ));
 
             $this->table('telescope_entries')

--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -191,10 +191,10 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
             }
 
             $currentEntryContent = json_decode($entry->content, true);
-            if (!is_array($currentEntryContent)) {
+            if (! is_array($currentEntryContent)) {
                 $currentEntryContent = [];
             }
-            
+
             $content = json_encode(array_merge(
                 $currentEntryContent, $update->changes
             ));


### PR DESCRIPTION
Small update to avoid strange, but possible error when for some reason the current entry content is null
`array_merge(): Argument #1 is not an array`