### PR TITLE
Change telescope connection default

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -46,7 +46,7 @@ return [
 
     'storage' => [
         'database' => [
-            'connection' => env('DB_CONNECTION', 'mysql'),
+            'connection' => config('database.default'),
         ],
     ],
 


### PR DESCRIPTION
Hi, 
The default database connection of telescope is a copy of initial database.php one.

However, if a developer changes the default connection in database.php config file, telescope will be wrong. With this modification, Telescope will always use by default the default connection of the project.

Thanks.
Matt'