### PR TITLE
Fix PHPUnit 8 warnings

### DIFF
--- a/tests/Watchers/DumpWatcherTest.php
+++ b/tests/Watchers/DumpWatcherTest.php
@@ -28,6 +28,6 @@ class DumpWatcherTest extends FeatureTestCase
         $entry = $this->loadTelescopeEntries()->first();
 
         $this->assertSame(EntryType::DUMP, $entry->type);
-        $this->assertContains($var, $entry->content['dump']);
+        $this->assertStringContainsString($var, $entry->content['dump']);
     }
 }

--- a/tests/Watchers/EventWatcherTest.php
+++ b/tests/Watchers/EventWatcherTest.php
@@ -45,7 +45,9 @@ class EventWatcherTest extends FeatureTestCase
         $this->assertSame(EntryType::EVENT, $entry->type);
         $this->assertSame(DummyEvent::class, $entry->content['name']);
         $this->assertArrayHasKey('data', $entry->content['payload']);
-        $this->assertArraySubset(['Telescope', 'Laravel', 'PHP'], $entry->content['payload']['data']);
+        $this->assertContains('Telescope', $entry->content['payload']['data']);
+        $this->assertContains('Laravel', $entry->content['payload']['data']);
+        $this->assertContains('PHP', $entry->content['payload']['data']);
     }
 }
 

--- a/tests/Watchers/MailWatcherTest.php
+++ b/tests/Watchers/MailWatcherTest.php
@@ -41,7 +41,7 @@ class MailWatcherTest extends FeatureTestCase
         $this->assertSame(['bcc@laravel.com'], array_keys($entry->content['bcc']));
         $this->assertSame('Check this out!', $entry->content['subject']);
         $this->assertSame('Telescope is amazing!', $entry->content['html']);
-        $this->assertContains('Telescope is amazing!', $entry->content['raw']);
+        $this->assertStringContainsString('Telescope is amazing!', $entry->content['raw']);
         $this->assertEmpty($entry->content['replyTo']);
     }
 }

--- a/tests/Watchers/NotificationWatcherTest.php
+++ b/tests/Watchers/NotificationWatcherTest.php
@@ -32,7 +32,7 @@ class NotificationWatcherTest extends FeatureTestCase
         $this->assertSame(EntryType::NOTIFICATION, $entry->type);
         $this->assertSame(BoomerangNotification::class, $entry->content['notification']);
         $this->assertSame(false, $entry->content['queued']);
-        $this->assertContains('telescope@laravel.com', $entry->content['notifiable']);
+        $this->assertStringContainsString('telescope@laravel.com', $entry->content['notifiable']);
         $this->assertSame('mail', $entry->content['channel']);
         $this->assertNull($entry->content['response']);
     }


### PR DESCRIPTION
The `assertArraySubset` method has been deprecated and the `assertContains` method should no longer be used with strings.

This alternatives suppress those warnings.

Before:

<img width="1693" alt="Captura de pantalla 2019-04-10 a la(s) 10 46 01" src="https://user-images.githubusercontent.com/5356595/55894583-f1f74880-5b7f-11e9-85c5-8e09e72b6cec.png">

After:

<img width="889" alt="Captura de pantalla 2019-04-10 a la(s) 10 47 07" src="https://user-images.githubusercontent.com/5356595/55894595-f6bbfc80-5b7f-11e9-938f-0ffd8a0e0480.png">
