### PR TITLE
Make chunk size of database storage driver configurable

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -47,6 +47,7 @@ return [
     'storage' => [
         'database' => [
             'connection' => env('DB_CONNECTION', 'mysql'),
+            'chunk_size' => 1000,
         ],
     ],
 

--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -22,6 +22,13 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
     protected $connection;
 
     /**
+     * Number of recorded entries that will be inserted at once into the database.
+     *
+     * @var int
+     */
+    protected $chunkSize = 1000;
+
+    /**
      * The tags currently being monitored.
      *
      * @var array|null
@@ -32,11 +39,16 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
      * Create a new database repository.
      *
      * @param  string  $connection
+     * @param  int     $chunkSize
      * @return void
      */
-    public function __construct(string $connection)
+    public function __construct(string $connection, int $chunkSize = null)
     {
         $this->connection = $connection;
+
+        if ($chunkSize) {
+            $this->chunkSize = $chunkSize;
+        }
     }
 
     /**
@@ -113,7 +125,7 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
 
         $table = $this->table('telescope_entries');
 
-        $entries->chunk(1000)->each(function ($chunked) use ($table) {
+        $entries->chunk($this->chunkSize)->each(function ($chunked) use ($table) {
             $table->insert($chunked->map(function ($entry) {
                 $entry->content = json_encode($entry->content);
 

--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -154,6 +154,9 @@ class TelescopeServiceProvider extends ServiceProvider
         $this->app->when(DatabaseEntriesRepository::class)
             ->needs('$connection')
             ->give(config('telescope.storage.database.connection'));
+        $this->app->when(DatabaseEntriesRepository::class)
+            ->needs('$chunkSize')
+            ->give(config('telescope.storage.database.chunk_size'));
     }
 
     /**


### PR DESCRIPTION
The PR introduces a new `chunk_size` configuration parameter for the `database` storage driver in order to fix the issue explained in #614.

In case someone created a custom version of the `TelescopeServiceProvider` which does not pass the new `$chunkSize` parameter to the database repository, the repository will still work due to the old default being used. Also users relying on the default service provider will have no issues as the old default is used if no configured chunk size is being found.

What I'm not sure about is how to properly document the setting. Personally, I'd prefer if there was a thorough explanation in `config/telescope.php`. There isn't really a common way to document nested configuration options though. Alternatively, we can also add it to the official documentation. Basically, I'm open to suggestions.