### PR TITLE
fix events with ShouldBroadcastNow

### DIFF
--- a/src/ListensForStorageOpportunities.php
+++ b/src/ListensForStorageOpportunities.php
@@ -83,12 +83,9 @@ trait ListensForStorageOpportunities
     {
         array_pop(static::$processingJobs);
 
-        if (empty(static::$processingJobs)) {
+        if (empty(static::$processingJobs) && $event->connectionName !== 'sync') {
             static::store($app[EntriesRepository::class]);
-
-            if ($event->connectionName !== 'sync') {
-                static::stopRecording();
-            }
+            static::stopRecording();
         }
     }
 }


### PR DESCRIPTION
[This fix](https://github.com/laravel/telescope/commit/9dfb1b08d3cf30adcfd44c79b5aaaa1f2fe34379) did not completely solve #412.

After dispatching an event with `ShouldBroadcastNow` the following entries are not correctly associated with the current request. 

This PR solves this and disables the premature storing if an event with the sync driver was emitted.