### PR TITLE
Env for slow limit on query watcher

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -135,7 +135,7 @@ return [
         Watchers\QueryWatcher::class => [
             'enabled' => env('TELESCOPE_QUERY_WATCHER', true),
             'ignore_packages' => true,
-            'slow' => 100,
+            'slow' => env('TELESCOPE_QUERY_WATCHER_SLOW_LIMIT', 100),
         ],
 
         Watchers\RedisWatcher::class => env('TELESCOPE_REDIS_WATCHER', true),


### PR DESCRIPTION
Adds an environment, with a default of 100, to the query watcher to easily override the slow limit on `telescope.php` config file. 

Not a breaking change.
