### PR TITLE
rm bcmath dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "ext-json": "*",
         "laravel/framework": "~5.8.0|~5.9.0",
         "moontoast/math": "^1.1",
-        "symfony/var-dumper": "^4.1"
+        "symfony/var-dumper": "^4.1",
+        "phpseclib/bcmath_compat": ">=1.0.0"
     },
     "require-dev": {
         "orchestra/testbench": "~3.7"


### PR DESCRIPTION
moontoast/math has bcmath as a dependency. Since phpseclib/bcmath_compat "provides" ext-bcmath, via it's composer.json, I believe this PR should eliminate bcmath as a dependency.

For good measure I've also submitted a PR to moontoast/math (https://github.com/moontoast/math/pull/11) but given that the last commit was over 5 years ago I'm not going to hold my breath on the PR even being looked at, let alone being merged in.