### PR TITLE
Change model column content length

### DIFF
--- a/resources/js/screens/models/index.vue
+++ b/resources/js/screens/models/index.vue
@@ -19,7 +19,7 @@
 
 
         <template slot="row" slot-scope="slotProps">
-            <td>{{truncate(slotProps.entry.content.model, 80)}}</td>
+            <td>{{truncate(slotProps.entry.content.model, 70)}}</td>
 
             <td class="table-fit">
                 <span class="badge font-weight-light" :class="'badge-'+modelActionClass(slotProps.entry.content.action)">


### PR DESCRIPTION
Before this PR, Model column truncate content from 80th character in the model screen. And show icon moves out of table. 

With this PR fix this issue changing truncate content from 70th character.
