### PR TITLE
Convert e-mail for gravatar to lower case

### DIFF
--- a/resources/js/components/PreviewScreen.vue
+++ b/resources/js/components/PreviewScreen.vue
@@ -67,7 +67,7 @@
             gravatarUrl() {
                 if (this.entry.content.user.email) {
                     const md5 = require('md5')
-                    return 'https://www.gravatar.com/avatar/' + md5(this.entry.content.user.email) + '?s=200'
+                    return 'https://www.gravatar.com/avatar/' + md5(this.entry.content.user.email.toLowerCase()) + '?s=200'
                 }
             }
         },


### PR DESCRIPTION
Gravatar by default convert e-mail to lower case
Gravatar [examples](https://gravatar.com/site/implement/images/php/)
```php
md5('Igor@Finag.in') != md5('igor@finag.in')
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->