### PR TITLE
Enable chunking on delete to prevent errors on large result sets

### DIFF
--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -321,9 +321,17 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
      */
     public function prune(DateTimeInterface $before)
     {
-        return $this->table('telescope_entries')
-                ->where('created_at', '<', $before)
-                ->delete();
+        $query = $this->table('telescope_entries')
+                ->where('created_at', '<', $before);
+
+         $deleted = 0;
+
+         do {
+            $newDeleted = $query->take($this->chunkSize)->delete();
+            $deleted += $newDeleted;
+        } while ($newDeleted !== 0);
+
+        return $deleted;
     }
 
     /**

--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -324,9 +324,9 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
         $query = $this->table('telescope_entries')
                 ->where('created_at', '<', $before);
 
-         $deleted = 0;
+        $deleted = 0;
 
-         do {
+        do {
             $newDeleted = $query->take($this->chunkSize)->delete();
             $deleted += $newDeleted;
         } while ($newDeleted !== 0);


### PR DESCRIPTION
This is to fix #536 

Actual metrics (including better math than napkin math):
(03:54 PM) ./artisan telescope:prune
2651547 entries pruned.
(04:04 PM)