### PR TITLE
Support duration calculation without constant LARAVEL_START

### DIFF
--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -40,6 +40,7 @@ class RequestWatcher extends Watcher
         }
 
         $startTime = defined('LARAVEL_START') ? LARAVEL_START : $event->request->server('REQUEST_TIME_FLOAT');
+
         Telescope::recordRequest(IncomingEntry::make([
             'uri' => str_replace($event->request->root(), '', $event->request->fullUrl()) ?: '/',
             'method' => $event->request->method(),

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -39,6 +39,7 @@ class RequestWatcher extends Watcher
             return;
         }
 
+        $startTime = defined('LARAVEL_START') ? LARAVEL_START : $event->request->server('REQUEST_TIME_FLOAT');
         Telescope::recordRequest(IncomingEntry::make([
             'uri' => str_replace($event->request->root(), '', $event->request->fullUrl()) ?: '/',
             'method' => $event->request->method(),
@@ -49,7 +50,7 @@ class RequestWatcher extends Watcher
             'session' => $this->payload($this->sessionVariables($event->request)),
             'response_status' => $event->response->getStatusCode(),
             'response' => $this->response($event->response),
-            'duration' => defined('LARAVEL_START') ? floor((microtime(true) - LARAVEL_START) * 1000) : null,
+            'duration' => $startTime ? floor((microtime(true) - $startTime) * 1000) : null,
         ]));
     }
 


### PR DESCRIPTION
In order to improve performance, we have customized the Laravel entry, our new entry is only initialized once at startup, not initialized in subsequent requests. 
And we used the variable [REQUEST_TIME_FLOAT](https://www.php.net/manual/en/reserved.variables.server.php) to record the start time of request. At this time, Telescope cannot calculate the time.