### PR TITLE
Full timestamp on hover

### DIFF
--- a/resources/js/screens/cache/index.vue
+++ b/resources/js/screens/cache/index.vue
@@ -27,7 +27,9 @@
                 </span>
             </td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td class="table-fit" :data-timeago="slotProps.entry.created_at" :title="slotProps.entry.created_at">
+                {{timeAgo(slotProps.entry.created_at)}}
+            </td>
 
             <td class="table-fit">
                 <router-link :to="{name:'cache-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/commands/index.vue
+++ b/resources/js/screens/commands/index.vue
@@ -16,7 +16,9 @@
 
             <td class="table-fit">{{slotProps.entry.content.exit_code}}</td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td class="table-fit" :data-timeago="slotProps.entry.created_at" :title="slotProps.entry.created_at">
+                {{timeAgo(slotProps.entry.created_at)}}
+            </td>
 
             <td class="table-fit">
                 <router-link :to="{name:'command-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/events/index.vue
+++ b/resources/js/screens/events/index.vue
@@ -23,7 +23,9 @@
 
             <td class="table-fit">{{slotProps.entry.content.listeners.length}}</td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td class="table-fit" :data-timeago="slotProps.entry.created_at" :title="slotProps.entry.created_at">
+                {{timeAgo(slotProps.entry.created_at)}}
+            </td>
 
             <td class="table-fit">
                 <router-link :to="{name:'event-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/exceptions/index.vue
+++ b/resources/js/screens/exceptions/index.vue
@@ -37,7 +37,9 @@
                 </small>
             </td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td class="table-fit" :data-timeago="slotProps.entry.created_at" :title="slotProps.entry.created_at">
+                {{timeAgo(slotProps.entry.created_at)}}
+            </td>
 
             <td class="table-fit">
                 <router-link :to="{name:'exception-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/gates/index.vue
+++ b/resources/js/screens/gates/index.vue
@@ -27,7 +27,9 @@
                 </span>
             </td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td class="table-fit" :data-timeago="slotProps.entry.created_at" :title="slotProps.entry.created_at">
+                {{timeAgo(slotProps.entry.created_at)}}
+            </td>
 
             <td class="table-fit">
                 <router-link :to="{name:'gate-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/jobs/index.vue
+++ b/resources/js/screens/jobs/index.vue
@@ -32,7 +32,9 @@
                 </span>
             </td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{ timeAgo(slotProps.entry.created_at) }}</td>
+            <td class="table-fit" :data-timeago="slotProps.entry.created_at" :title="slotProps.entry.created_at">
+                {{ timeAgo(slotProps.entry.created_at) }}
+            </td>
 
             <td class="table-fit">
                 <router-link :to="{name:'job-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/logs/index.vue
+++ b/resources/js/screens/logs/index.vue
@@ -26,7 +26,9 @@
                 </span>
             </td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td class="table-fit" :data-timeago="slotProps.entry.created_at" :title="slotProps.entry.created_at">
+                {{timeAgo(slotProps.entry.created_at)}}
+            </td>
 
             <td class="table-fit">
                 <router-link :to="{name:'log-preview', params: {id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/mail/index.vue
+++ b/resources/js/screens/mail/index.vue
@@ -38,7 +38,9 @@
 
             <td class="table-fit">{{recipientsCount(slotProps.entry)}}</td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td class="table-fit" :data-timeago="slotProps.entry.created_at" :title="slotProps.entry.created_at">
+                {{timeAgo(slotProps.entry.created_at)}}
+            </td>
 
             <td class="table-fit">
                 <router-link :to="{name:'mail-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/models/index.vue
+++ b/resources/js/screens/models/index.vue
@@ -27,7 +27,9 @@
                 </span>
             </td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td class="table-fit" :data-timeago="slotProps.entry.created_at" :title="slotProps.entry.created_at">
+                {{timeAgo(slotProps.entry.created_at)}}
+            </td>
 
             <td class="table-fit">
                 <router-link :to="{name:'model-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/notifications/index.vue
+++ b/resources/js/screens/notifications/index.vue
@@ -29,7 +29,9 @@
 
             <td class="table-fit">{{truncate(slotProps.entry.content.channel, 20)}}</td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td class="table-fit" :data-timeago="slotProps.entry.created_at" :title="slotProps.entry.created_at">
+                {{timeAgo(slotProps.entry.created_at)}}
+            </td>
 
             <td class="table-fit">
                 <router-link :to="{name:'notification-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/queries/index.vue
+++ b/resources/js/screens/queries/index.vue
@@ -25,7 +25,9 @@
                 </span>
             </td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td class="table-fit" :data-timeago="slotProps.entry.created_at" :title="slotProps.entry.created_at">
+                {{timeAgo(slotProps.entry.created_at)}}
+            </td>
 
             <td class="table-fit">
                 <router-link :to="{name:'query-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/redis/index.vue
+++ b/resources/js/screens/redis/index.vue
@@ -17,7 +17,9 @@
 
             <td class="table-fit">{{slotProps.entry.content.time}}ms</td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td class="table-fit" :data-timeago="slotProps.entry.created_at" :title="slotProps.entry.created_at">
+                {{timeAgo(slotProps.entry.created_at)}}
+            </td>
 
             <td class="table-fit">
                 <router-link :to="{name:'redis-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/requests/index.vue
+++ b/resources/js/screens/requests/index.vue
@@ -40,7 +40,9 @@
                 <span v-else>-</span>
             </td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td class="table-fit" :data-timeago="slotProps.entry.created_at" :title="slotProps.entry.created_at">
+                {{timeAgo(slotProps.entry.created_at)}}
+            </td>
 
             <td class="table-fit">
                 <router-link :to="{name:'request-preview', params:{id: slotProps.entry.id}}" class="control-action">

--- a/resources/js/screens/schedule/index.vue
+++ b/resources/js/screens/schedule/index.vue
@@ -16,7 +16,9 @@
 
             <td class="table-fit">{{slotProps.entry.content.expression}}</td>
 
-            <td class="table-fit" :data-timeago="slotProps.entry.created_at">{{timeAgo(slotProps.entry.created_at)}}</td>
+            <td class="table-fit" :data-timeago="slotProps.entry.created_at" :title="slotProps.entry.created_at">
+                {{timeAgo(slotProps.entry.created_at)}}
+            </td>
 
             <td class="table-fit">
                 <router-link :to="{name:'schedule-preview', params:{id: slotProps.entry.id}}" class="control-action">


### PR DESCRIPTION
Allows you to view the full timestamp of a resource on hover. This is useful if you're trying to figure out the exact time of a request and don't want to go into the full resource page or if you're trying to figure out the time between two requests that are old and dont want to go into the full resource page.

![image](https://user-images.githubusercontent.com/7674587/61591200-1646d480-ac07-11e9-9521-7ae0a159b2ff.png)
