### PR TITLE
wrap service provider boot code in telescope.enabled conditional

### DIFF
--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -18,18 +18,20 @@ class TelescopeServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Route::middlewareGroup('telescope', config('telescope.middleware', []));
+        if (config('telescope.enabled') === true) {
+            Route::middlewareGroup('telescope', config('telescope.middleware', []));
 
-        $this->registerRoutes();
-        $this->registerMigrations();
-        $this->registerPublishing();
+            $this->registerRoutes();
+            $this->registerMigrations();
+            $this->registerPublishing();
 
-        Telescope::start($this->app);
-        Telescope::listenForStorageOpportunities($this->app);
+            Telescope::start($this->app);
+            Telescope::listenForStorageOpportunities($this->app);
 
-        $this->loadViewsFrom(
-            __DIR__.'/../resources/views', 'telescope'
-        );
+            $this->loadViewsFrom(
+                __DIR__ . '/../resources/views', 'telescope'
+            );
+        }
     }
 
     /**

--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -29,7 +29,7 @@ class TelescopeServiceProvider extends ServiceProvider
             Telescope::listenForStorageOpportunities($this->app);
 
             $this->loadViewsFrom(
-                __DIR__ . '/../resources/views', 'telescope'
+                __DIR__.'/../resources/views', 'telescope'
             );
         }
     }


### PR DESCRIPTION
Currently, disabling telescope through the `TELESCOPE_ENABLED` environment variable will prevent `Telescope::start` from running but does not prevent telescope from registering routes, migrations, views etc. in the `TelescopeServiceProvider->boot` method.  

This can cause unexpected errors and problems in situations like a testing environment where telescope is disabled and the migrations are not expected to be registered.