### PR TITLE
Import Route facade in routes.php

### DIFF
--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Route;
+
 // Mail entries...
 Route::post('/telescope-api/mail', 'MailController@index');
 Route::get('/telescope-api/mail/{telescopeEntryId}', 'MailController@show');


### PR DESCRIPTION
Right now when anybody chooses to disband the usage of Class Aliases the package will break because the `Route` alias can't be found, this can be easily fixed by importing the facade properly.