### PR TITLE
Typo in addSeconds

### DIFF
--- a/src/Http/Controllers/DumpController.php
+++ b/src/Http/Controllers/DumpController.php
@@ -37,7 +37,7 @@ class DumpController extends EntryController
      */
     public function index(Request $request, EntriesRepository $storage)
     {
-        $this->cache->put('telescope:dump-watcher', true, now()->addSecond(4));
+        $this->cache->put('telescope:dump-watcher', true, now()->addSeconds(4));
 
         return parent::index($request, $storage);
     }


### PR DESCRIPTION
I think both methods do the same actually, but according to the API/TypeHint `addSecond` doesn't take an argument.