### PR TITLE
Optimize dump

### DIFF
--- a/resources/js/screens/dumps/index.vue
+++ b/resources/js/screens/dumps/index.vue
@@ -9,6 +9,7 @@
             return {
                 entries: [],
                 ready: false,
+                error: null,
                 newEntriesTimeout: null,
                 newEntriesTimeoutInSeconds: 2000,
                 recordingStatus: 'enabled'
@@ -38,14 +39,21 @@
         methods: {
             loadEntries(){
                 axios.post(Telescope.basePath + '/telescope-api/dumps').then(response => {
+                    this.error = null;
                     this.entries = response.data.entries;
                     this.recordingStatus = response.data.status;
-
-                    this.ready = true;
 
                     this.newEntriesTimeout = setTimeout(() => {
                         this.loadEntries();
                     }, this.newEntriesTimeoutInSeconds);
+                }).catch(error => {
+                    if (error.response && error.response.data.message) {
+                        this.error = error.response.data.message;
+                    } else {
+                        this.error = 'Something went wrong';
+                    }
+                }).finally(() => {
+                    this.ready = true;
                 });
             }
         }
@@ -76,12 +84,20 @@
         </div>
 
 
-        <div v-if="ready && entries.length == 0" class="d-flex flex-column align-items-center justify-content-center card-bg-secondary p-5 bottom-radius">
+        <div v-if="ready && entries.length == 0 && !error" class="d-flex flex-column align-items-center justify-content-center card-bg-secondary p-5 bottom-radius">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" class="fill-text-color" style="width: 200px;">
                 <path fill-rule="evenodd" d="M7 10h41a11 11 0 0 1 0 22h-8a3 3 0 0 0 0 6h6a6 6 0 1 1 0 12H10a4 4 0 1 1 0-8h2a2 2 0 1 0 0-4H7a5 5 0 0 1 0-10h3a3 3 0 0 0 0-6H7a6 6 0 1 1 0-12zm14 19a1 1 0 0 1-1-1 1 1 0 0 0-2 0 1 1 0 0 1-1 1 1 1 0 0 0 0 2 1 1 0 0 1 1 1 1 1 0 0 0 2 0 1 1 0 0 1 1-1 1 1 0 0 0 0-2zm-5.5-11a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm24 10a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm1 18a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm-14-3a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm22-23a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM33 18a1 1 0 0 1-1-1v-1a1 1 0 0 0-2 0v1a1 1 0 0 1-1 1h-1a1 1 0 0 0 0 2h1a1 1 0 0 1 1 1v1a1 1 0 0 0 2 0v-1a1 1 0 0 1 1-1h1a1 1 0 0 0 0-2h-1z"></path>
             </svg>
 
             <span>We didn't find anything - just empty space.</span>
+        </div>
+
+        <div v-if="error" class="d-flex flex-column align-items-center justify-content-center card-bg-secondary p-5 bottom-radius">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" class="fill-text-color" style="width: 200px;">
+                <path fill-rule="evenodd" d="M7 10h41a11 11 0 0 1 0 22h-8a3 3 0 0 0 0 6h6a6 6 0 1 1 0 12H10a4 4 0 1 1 0-8h2a2 2 0 1 0 0-4H7a5 5 0 0 1 0-10h3a3 3 0 0 0 0-6H7a6 6 0 1 1 0-12zm14 19a1 1 0 0 1-1-1 1 1 0 0 0-2 0 1 1 0 0 1-1 1 1 1 0 0 0 0 2 1 1 0 0 1 1 1 1 1 0 0 0 2 0 1 1 0 0 1 1-1 1 1 0 0 0 0-2zm-5.5-11a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm24 10a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm1 18a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm-14-3a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm22-23a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM33 18a1 1 0 0 1-1-1v-1a1 1 0 0 0-2 0v1a1 1 0 0 1-1 1h-1a1 1 0 0 0 0 2h1a1 1 0 0 1 1 1v1a1 1 0 0 0 2 0v-1a1 1 0 0 1 1-1h1a1 1 0 0 0 0-2h-1z"></path>
+            </svg>
+
+            <span>Whoops: {{ error }}</span>
         </div>
 
         <div v-if="ready && entries.length > 0" class="code-bg px-3 pt-3">

--- a/src/Http/Controllers/DumpController.php
+++ b/src/Http/Controllers/DumpController.php
@@ -43,6 +43,7 @@ class DumpController extends EntryController
                 'message' => 'The Array cache driver cannot be used for Dumps. Please use a persistent cache.',
             ], 400);
         }
+
         $this->cache->put('telescope:dump-watcher', true, now()->addSeconds(4));
 
         return parent::index($request, $storage);

--- a/src/Http/Controllers/DumpController.php
+++ b/src/Http/Controllers/DumpController.php
@@ -4,7 +4,6 @@ namespace Laravel\Telescope\Http\Controllers;
 
 use Illuminate\Cache\ArrayStore;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Cache;
 use Laravel\Telescope\EntryType;
 use Laravel\Telescope\Watchers\DumpWatcher;
 use Laravel\Telescope\Contracts\EntriesRepository;
@@ -39,8 +38,10 @@ class DumpController extends EntryController
      */
     public function index(Request $request, EntriesRepository $storage)
     {
-        if ($this->cache->getStore() instanceof  ArrayStore) {
-            abort(400, 'The Array cache driver cannot be used for Dumps. Please use a persistent cache.');
+        if ($this->cache->getStore() instanceof ArrayStore) {
+            return response()->json([
+                'message' => 'The Array cache driver cannot be used for Dumps. Please use a persistent cache.'
+            ], 400);
         }
         $this->cache->put('telescope:dump-watcher', true, now()->addSeconds(4));
 

--- a/src/Http/Controllers/DumpController.php
+++ b/src/Http/Controllers/DumpController.php
@@ -2,7 +2,9 @@
 
 namespace Laravel\Telescope\Http\Controllers;
 
+use Illuminate\Cache\ArrayStore;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Laravel\Telescope\EntryType;
 use Laravel\Telescope\Watchers\DumpWatcher;
 use Laravel\Telescope\Contracts\EntriesRepository;
@@ -37,6 +39,9 @@ class DumpController extends EntryController
      */
     public function index(Request $request, EntriesRepository $storage)
     {
+        if ($this->cache->getStore() instanceof  ArrayStore) {
+            abort(400, 'The Array cache driver cannot be used for Dumps. Please use a persistent cache.');
+        }
         $this->cache->put('telescope:dump-watcher', true, now()->addSeconds(4));
 
         return parent::index($request, $storage);

--- a/src/Http/Controllers/DumpController.php
+++ b/src/Http/Controllers/DumpController.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Telescope\Http\Controllers;
 
-use Illuminate\Cache\ArrayStore;
 use Illuminate\Http\Request;
+use Illuminate\Cache\ArrayStore;
 use Laravel\Telescope\EntryType;
 use Laravel\Telescope\Watchers\DumpWatcher;
 use Laravel\Telescope\Contracts\EntriesRepository;
@@ -40,7 +40,7 @@ class DumpController extends EntryController
     {
         if ($this->cache->getStore() instanceof ArrayStore) {
             return response()->json([
-                'message' => 'The Array cache driver cannot be used for Dumps. Please use a persistent cache.'
+                'message' => 'The Array cache driver cannot be used for Dumps. Please use a persistent cache.',
             ], 400);
         }
         $this->cache->put('telescope:dump-watcher', true, now()->addSeconds(4));


### PR DESCRIPTION
This shuld fix #682 and partially fix #611 (or at least give the user some information about it).
Addition could be to specify a cache driver in config/telescope, so that the Telescope driver could be different (eg. if you want to work with the array driver locally).

This shows an error when something goes wrong (eg. the wrong cache driver in this instance).
It also changes the loading of entries to check 1 entry and only load the rest when something changed (just like the rest of the Index screens).