### PR TITLE
Fix Dump test using file cache

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,5 +25,6 @@
     <php>
         <env name="APP_ENV" value="self-testing"/>
         <env name="APP_KEY" value="base64:yk+bUVuZa1p86Dqjk9OjVK2R1pm6XHxC6xEKFq8utH0="/>
+        <env name="CACHE_DRIVER" value="file"/>
     </php>
 </phpunit>


### PR DESCRIPTION
As dump relies on the cache working, changed the cache to `file`