### PR TITLE
Log failed requests

### DIFF
--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -168,17 +168,6 @@ class IncomingEntry
     }
 
     /**
-     * Determine if the incoming entry is a failed job.
-     *
-     * @return bool
-     */
-    public function isFailedJob()
-    {
-        return $this->type === EntryType::JOB &&
-               ($this->content['status'] ?? null) === 'failed';
-    }
-
-    /**
      * Determine if the incoming entry is a failed request.
      *
      * @return bool
@@ -187,6 +176,17 @@ class IncomingEntry
     {
         return $this->type === EntryType::REQUEST &&
             ($this->content['response_status'] ?? 200) >= 500;
+    }
+    
+    /**
+     * Determine if the incoming entry is a failed job.
+     *
+     * @return bool
+     */
+    public function isFailedJob()
+    {
+        return $this->type === EntryType::JOB &&
+               ($this->content['status'] ?? null) === 'failed';
     }
 
     /**

--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -179,6 +179,17 @@ class IncomingEntry
     }
 
     /**
+     * Determine if the incoming entry is a failed request.
+     *
+     * @return bool
+     */
+    public function isFailedRequest()
+    {
+        return $this->type === EntryType::REQUEST &&
+            ($this->content['response_status'] ?? 200) >= 500;
+    }
+
+    /**
      * Determine if the incoming entry is a reportable exception.
      *
      * @return bool

--- a/stubs/TelescopeServiceProvider.stub
+++ b/stubs/TelescopeServiceProvider.stub
@@ -26,8 +26,8 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
             }
 
             return $entry->isReportableException() ||
-                   $entry->isFailedJob() ||
                    $entry->isFailedRequest() ||
+                   $entry->isFailedJob() ||
                    $entry->isScheduledTask() ||
                    $entry->hasMonitoredTag();
         });

--- a/stubs/TelescopeServiceProvider.stub
+++ b/stubs/TelescopeServiceProvider.stub
@@ -27,6 +27,7 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
 
             return $entry->isReportableException() ||
                    $entry->isFailedJob() ||
+                   $entry->isFailedRequest() ||
                    $entry->isScheduledTask() ||
                    $entry->hasMonitoredTag();
         });


### PR DESCRIPTION
Check if an IncomingEntry is a failed (5xx) Request and log that. Useful to log request info with the Exceptions etc.