### PR TITLE
Simplify dump error screen

### DIFF
--- a/resources/js/screens/dumps/index.vue
+++ b/resources/js/screens/dumps/index.vue
@@ -9,7 +9,6 @@
             return {
                 entries: [],
                 ready: false,
-                error: null,
                 newEntriesTimeout: null,
                 newEntriesTimer: 2000,
                 recordingStatus: 'enabled'
@@ -39,19 +38,11 @@
         methods: {
             loadEntries(){
                 axios.post(Telescope.basePath + '/telescope-api/dumps').then(response => {
-                    this.error = null;
+                    this.ready = true;
                     this.entries = response.data.entries;
                     this.recordingStatus = response.data.status;
 
                     this.checkForNewEntries();
-                }).catch(error => {
-                    if (error.response && error.response.data.message) {
-                        this.error = error.response.data.message;
-                    } else {
-                        this.error = 'Something went wrong';
-                    }
-                }).finally(() => {
-                    this.ready = true;
                 });
             },
 
@@ -91,6 +82,7 @@
             <span class="ml-1" v-if="recordingStatus == 'disabled'">Telescope is currently disabled.</span>
             <span class="ml-1" v-if="recordingStatus == 'paused'">Telescope recording is paused.</span>
             <span class="ml-1" v-if="recordingStatus == 'off'">This watcher is turned off.</span>
+            <span class="ml-1" v-if="recordingStatus == 'wrong-cache'">The 'array' cache cannot be used. Please use a persistent cache.</span>
         </p>
 
         <div v-if="!ready" class="d-flex align-items-center justify-content-center card-bg-secondary p-5 bottom-radius">
@@ -102,20 +94,12 @@
         </div>
 
 
-        <div v-if="ready && entries.length == 0 && !error" class="d-flex flex-column align-items-center justify-content-center card-bg-secondary p-5 bottom-radius">
+        <div v-if="ready && entries.length == 0" class="d-flex flex-column align-items-center justify-content-center card-bg-secondary p-5 bottom-radius">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" class="fill-text-color" style="width: 200px;">
                 <path fill-rule="evenodd" d="M7 10h41a11 11 0 0 1 0 22h-8a3 3 0 0 0 0 6h6a6 6 0 1 1 0 12H10a4 4 0 1 1 0-8h2a2 2 0 1 0 0-4H7a5 5 0 0 1 0-10h3a3 3 0 0 0 0-6H7a6 6 0 1 1 0-12zm14 19a1 1 0 0 1-1-1 1 1 0 0 0-2 0 1 1 0 0 1-1 1 1 1 0 0 0 0 2 1 1 0 0 1 1 1 1 1 0 0 0 2 0 1 1 0 0 1 1-1 1 1 0 0 0 0-2zm-5.5-11a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm24 10a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm1 18a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm-14-3a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm22-23a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM33 18a1 1 0 0 1-1-1v-1a1 1 0 0 0-2 0v1a1 1 0 0 1-1 1h-1a1 1 0 0 0 0 2h1a1 1 0 0 1 1 1v1a1 1 0 0 0 2 0v-1a1 1 0 0 1 1-1h1a1 1 0 0 0 0-2h-1z"></path>
             </svg>
 
             <span>We didn't find anything - just empty space.</span>
-        </div>
-
-        <div v-if="error" class="d-flex flex-column align-items-center justify-content-center card-bg-secondary p-5 bottom-radius">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" class="fill-text-color" style="width: 200px;">
-                <path fill-rule="evenodd" d="M7 10h41a11 11 0 0 1 0 22h-8a3 3 0 0 0 0 6h6a6 6 0 1 1 0 12H10a4 4 0 1 1 0-8h2a2 2 0 1 0 0-4H7a5 5 0 0 1 0-10h3a3 3 0 0 0 0-6H7a6 6 0 1 1 0-12zm14 19a1 1 0 0 1-1-1 1 1 0 0 0-2 0 1 1 0 0 1-1 1 1 1 0 0 0 0 2 1 1 0 0 1 1 1 1 1 0 0 0 2 0 1 1 0 0 1 1-1 1 1 0 0 0 0-2zm-5.5-11a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm24 10a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm1 18a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm-14-3a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm22-23a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM33 18a1 1 0 0 1-1-1v-1a1 1 0 0 0-2 0v1a1 1 0 0 1-1 1h-1a1 1 0 0 0 0 2h1a1 1 0 0 1 1 1v1a1 1 0 0 0 2 0v-1a1 1 0 0 1 1-1h1a1 1 0 0 0 0-2h-1z"></path>
-            </svg>
-
-            <span>Whoops: {{ error }}</span>
         </div>
 
         <div v-if="ready && entries.length > 0" class="code-bg px-3 pt-3">

--- a/src/Http/Controllers/DumpController.php
+++ b/src/Http/Controllers/DumpController.php
@@ -38,15 +38,23 @@ class DumpController extends EntryController
      */
     public function index(Request $request, EntriesRepository $storage)
     {
-        if ($this->cache->getStore() instanceof ArrayStore) {
-            return response()->json([
-                'message' => 'The Array cache driver cannot be used for Dumps. Please use a persistent cache.',
-            ], 400);
-        }
-
         $this->cache->put('telescope:dump-watcher', true, now()->addSeconds(4));
 
         return parent::index($request, $storage);
+    }
+
+    /**
+     * Determine the watcher recording status.
+     *
+     * @return string
+     */
+    protected function status()
+    {
+        if ($this->cache->getStore() instanceof ArrayStore) {
+            return 'wrong-cache';
+        }
+
+        return parent::status();
     }
 
     /**


### PR DESCRIPTION
This simplifies the error handler for the Dump messages and brings it in-line with the existing error messages:
![image](https://user-images.githubusercontent.com/973269/63155963-f80ca280-c013-11e9-8a89-13889ef08a42.png)
