### PR TITLE
Dump queued items when die'ing

### DIFF
--- a/src/Watchers/DumpWatcher.php
+++ b/src/Watchers/DumpWatcher.php
@@ -49,6 +49,15 @@ class DumpWatcher extends Watcher
                 (new VarCloner)->cloneVar($var), true
             ));
         });
+        
+        // When we die without storing the entries, show the dumps (eg. for `dd()`)
+        register_shutdown_function(function() {
+            foreach (Telescope::$entriesQueue as $entry) {
+                if ($entry instanceof IncomingDumpEntry) {
+                    echo $entry->content['dump'];
+                }
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
This is a potential fix for `dd($something)` which kills the script when the dump's are not persisted yet. It dumps the existing entries on screen, just like a regular `dd()`.

Not sure what the impact would be, but usually it wouldn't change anything (only happens when you are watching the dumps + when you die with something in the queue)