### PR TITLE
[3.0] Change $tagUsing to array

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "2.0-dev"
         },
         "laravel": {
             "providers": [

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -248,7 +248,7 @@ class Telescope
         }
 
         $entry->type($type)->tags(array_map(function ($tagCallback) use ($entry) {
-            $tagCallback($entry);
+            return $tagCallback($entry);
         }, static::$tagUsing));
 
         try {

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -42,11 +42,11 @@ class Telescope
     public static $afterRecordingHook;
 
     /**
-     * The callback that adds tags to the record.
+     * The callbacks that add tags to the record.
      *
-     * @var \Closure
+     * @var \Closure[]
      */
-    public static $tagUsing;
+    public static $tagUsing = [];
 
     /**
      * The list of queued entries to be stored.
@@ -247,9 +247,9 @@ class Telescope
             return;
         }
 
-        $entry->type($type)->tags(
-            static::$tagUsing ? call_user_func(static::$tagUsing, $entry) : []
-        );
+        $entry->type($type)->tags(array_map(function ($tagCallback) use ($entry) {
+            $tagCallback($entry);
+        }, static::$tagUsing));
 
         try {
             if (Auth::hasUser()) {
@@ -519,14 +519,14 @@ class Telescope
     }
 
     /**
-     * Set the callback that adds tags to the record.
+     * Add a callback that adds tags to the record.
      *
      * @param  \Closure  $callback
      * @return static
      */
     public static function tag(Closure $callback)
     {
-        static::$tagUsing = $callback;
+        static::$tagUsing[] = $callback;
 
         return new static;
     }
@@ -605,7 +605,8 @@ class Telescope
     public static function hideRequestHeaders(array $headers)
     {
         static::$hiddenRequestHeaders = array_merge(
-            static::$hiddenRequestHeaders, $headers
+            static::$hiddenRequestHeaders,
+            $headers
         );
 
         return new static;
@@ -620,7 +621,8 @@ class Telescope
     public static function hideRequestParameters(array $attributes)
     {
         static::$hiddenRequestParameters = array_merge(
-            static::$hiddenRequestParameters, $attributes
+            static::$hiddenRequestParameters,
+            $attributes
         );
 
         return new static;
@@ -635,7 +637,8 @@ class Telescope
     public static function hideResponseParameters(array $attributes)
     {
         static::$hiddenResponseParameters = array_merge(
-            static::$hiddenResponseParameters, $attributes
+            static::$hiddenResponseParameters,
+            $attributes
         );
 
         return new static;


### PR DESCRIPTION
Resolves #673.

There can now be multiple tag-setting callbacks. This is useful if a package wants to set tags without overriding tags set by the user.

This could be done in v2 in an ugly way:
```php
$originalCallback = Telescope::$tagUsing;

Telescope::tag(function ($entry) use($originalCallback) {
    $originalTags = [];
    if (! is_null($originalCallback) {
        $originalTags = $originalCallback($entry);
    } 

    $tags = // custom logic

    return array_merge($originalTags, $tags);
});
```

And it would work only with two tags, unless all callbacks did this logic.

This PR makes this much nicer.

I would have added tests, but not sure how to do that (related to #691).

<sub>(sorry for the slightly messy PR, made this from 2.0)</sub>