### PR TITLE
[3.0] Change Telescope::$tagUsing to an array

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -526,7 +526,7 @@ class Telescope
      */
     public static function tag(Closure $callback)
     {
-        static::$tagUsing = $callback;
+        static::$tagUsing[] = $callback;
 
         return new static;
     }

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -42,11 +42,11 @@ class Telescope
     public static $afterRecordingHook;
 
     /**
-     * The callback that adds tags to the record.
+     * The callbacks that add tags to the record.
      *
-     * @var \Closure
+     * @var \Closure[]
      */
-    public static $tagUsing;
+    public static $tagUsing = [];
 
     /**
      * The list of queued entries to be stored.
@@ -247,9 +247,9 @@ class Telescope
             return;
         }
 
-        $entry->type($type)->tags(
-            static::$tagUsing ? call_user_func(static::$tagUsing, $entry) : []
-        );
+        $entry->type($type)->tags(array_map(function ($tagCallback) use ($entry) {
+            return $tagCallback($entry);
+        }, static::$tagUsing));
 
         try {
             if (Auth::hasUser()) {
@@ -519,7 +519,7 @@ class Telescope
     }
 
     /**
-     * Set the callback that adds tags to the record.
+     * Add a callback that adds tags to the record.
      *
      * @param  \Closure  $callback
      * @return static


### PR DESCRIPTION
(Originally #692)

Resolves #673.

There can now be multiple tag-setting callbacks. This is useful if a package wants to set tags without overriding tags set by the user.

This could be done in v2 in an ugly way:
```php
$originalCallback = Telescope::$tagUsing;

Telescope::tag(function ($entry) use($originalCallback) {
    $originalTags = [];
    if (! is_null($originalCallback) {
        $originalTags = $originalCallback($entry);
    } 

    $tags = // custom logic

    return array_merge($originalTags, $tags);
});
```

And it would work only with two tags, unless all callbacks did this logic.

This PR makes this much nicer.

I would have added tests, but not sure how to do that (related to #691).