### PR TITLE
Deletes `phpstan.neon.dist` as larastan is no longer included

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,8 +1,0 @@
-includes:
-    - ./vendor/nunomaduro/larastan/extension.neon
-parameters:
-    excludes_analyse:
-        - %rootDir%/../../../src/Storage/factories
-    level: 1
-    paths:
-        - src


### PR DESCRIPTION
This pull request deletes `phpstan.neon.dist` as larastan is no longer included.