### PR TITLE
Timing screen

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "3.0-dev"
         },
         "laravel": {
             "providers": [

--- a/resources/js/routes.js
+++ b/resources/js/routes.js
@@ -180,4 +180,10 @@ export default [
         name: 'gates',
         component: require('./screens/gates/index').default,
     },
+
+    {
+        path: '/timing/:id',
+        name: 'timing-preview',
+        component: require('./screens/timing/preview').default,
+    },
 ];

--- a/resources/js/screens/timing/preview.vue
+++ b/resources/js/screens/timing/preview.vue
@@ -1,0 +1,73 @@
+<script type="text/ecmascript-6">
+  export default {
+    data(){
+      return {
+        entry: null,
+        batch: [],
+        currentTab: 'data'
+      };
+    },
+
+    methods: {
+      entryTypeClass(method) {
+        return 'info';
+      },
+    }
+  }
+</script>
+
+<template>
+    <preview-screen title="Timing Details" resource="timing" :id="$route.params.id">
+        <template slot="table-parameters" slot-scope="slotProps">
+            <tr>
+                <td class="table-fit font-weight-bold">Total Duration</td>
+                <td>
+                    {{slotProps.entry.content.duration}} ms
+                </td>
+            </tr>
+        </template>
+
+        <div slot="after-attributes-card" slot-scope="slotProps">
+            <div class="card mt-5">
+                <ul class="nav nav-pills">
+                    <li class="nav-item">
+                        <a class="nav-link" :class="{active: currentTab=='data'}" href="#" v-on:click.prevent="currentTab='data'">Timing Data</a>
+                    </li>
+                </ul>
+                <div>
+                    <table  class="table mb-0">
+                        <tbody>
+                            <tr v-for="timing in batch" :key="timing.id">
+                                <td class="table-fit pr-0">
+                                <span class="badge font-weight-light" :class="'badge-'+entryTypeClass(timing.entryType)">
+                                    {{timing.entryType}}
+                                </span>
+                                </td>
+
+                                <td :title="timing.duration + 'ms: ' + timing.label" width="100%">
+                                    <div :class="'timing-event timing-'+entryTypeClass(timing.entryType)" :style="{ marginLeft: timing.left + '%', width: timing.width + '%' }"></div>
+                                </td>
+
+                                <td class="table-fit">
+                                    <router-link :to="{name: timing.entryType + '-preview', params:{id: timing.id}}" class="control-action">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 16">
+                                            <path d="M16.56 13.66a8 8 0 0 1-11.32 0L.3 8.7a1 1 0 0 1 0-1.42l4.95-4.95a8 8 0 0 1 11.32 0l4.95 4.95a1 1 0 0 1 0 1.42l-4.95 4.95-.01.01zm-9.9-1.42a6 6 0 0 0 8.48 0L19.38 8l-4.24-4.24a6 6 0 0 0-8.48 0L2.4 8l4.25 4.24h.01zM10.9 12a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"></path>
+                                        </svg>
+                                    </router-link>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </preview-screen>
+</template>
+
+<style>
+    .timing-event {
+        height: 20px;
+        background-color: grey;
+        padding: 0 1px;
+    }
+</style>

--- a/src/Http/Controllers/TimingController.php
+++ b/src/Http/Controllers/TimingController.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Laravel\Telescope\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+use Laravel\Telescope\EntryResult;
+use Laravel\Telescope\EntryType;
+use Laravel\Telescope\IncomingEntry;
+use Laravel\Telescope\Watchers\LogWatcher;
+use Laravel\Telescope\Storage\EntryQueryOptions;
+use Laravel\Telescope\Contracts\EntriesRepository;
+
+class TimingController extends Controller
+{
+    /**
+     * Get an entry with the given ID.
+     *
+     * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
+     * @param  int  $id
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function show(EntriesRepository $storage, $id)
+    {
+        $entry = $storage->find($id);
+
+        $start = 0;
+        $end = 0;
+        $batch = $storage->get(null, EntryQueryOptions::forBatchId($entry->batchId)->limit(-1))
+            ->map(function(EntryResult $entry) {
+
+                $timeEnd = $entry->content['timeEnd'] ?? null;
+                if ($entry->content['timeEnd'] === null) {
+                    return;
+                }
+
+                list($timeStart, $timeEnd) = $this->getTimesForEntry($entry);
+
+                return [
+                    'id' => $entry->id,
+                    'entryType' => $entry->type,
+                    'label' => $this->getLabelForEntry($entry),
+                    'timeStart' => $timeStart,
+                    'timeEnd' => $timeEnd,
+                    'duration' => round($timeEnd - $timeStart, 2),
+                ];
+            })
+            ->filter(function($data) {
+                return $data['timeStart'];
+            })
+            ->sortBy('timeStart', SORT_NUMERIC)
+            ->values();
+
+        $start = $batch->min('timeStart');
+        $end = $batch->max('timeEnd');
+
+        $duration = round($end - $start, 2);
+
+        $entry->content = [
+            'start' => $start,
+            'end' => $end,
+            'duration' => $duration,
+        ];
+
+        if ( ! $duration) {
+            return response()->json([
+                'entry' => $entry,
+                'batch' => [],
+            ]);
+        }
+
+        $batch = $batch->map(function(array $data) use($start, $duration) {
+
+            $data['left'] = ($data['timeStart'] - $start) / $duration * 100;
+            $data['width'] = $data['duration'] / $duration * 100;
+
+            return $data;
+        });
+
+        return response()->json([
+            'entry' => $entry,
+            'batch' => $batch,
+        ]);
+    }
+
+    private function getTimesForEntry(EntryResult $entry)
+    {
+        $end = $entry->content['timeEnd'] * 1000;
+        $start = $end;
+
+        if ($entry->type === EntryType::QUERY) {
+            $start -= $entry->content['time'] ?? 0;
+        }
+
+        if ($entry->type === EntryType::REQUEST) {
+            $start -= $entry->content['duration'] ?? 0;
+        }
+
+        return [round($start, 2), round($end, 2)];
+    }
+
+    private function getLabelForEntry(EntryResult $entry)
+    {
+        if ($entry->type === EntryType::QUERY) {
+            return $entry->content['sql'] ?? 'SQL Query';
+        }
+
+        if ($entry->type === EntryType::LOG) {
+            return $entry->content['message'] ?? 'LOG';
+        }
+
+        return $entry->type;
+    }
+}

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -63,6 +63,9 @@ Route::get('/telescope-api/schedule/{telescopeEntryId}', 'ScheduleController@sho
 Route::post('/telescope-api/redis', 'RedisController@index');
 Route::get('/telescope-api/redis/{telescopeEntryId}', 'RedisController@show');
 
+// Timing entries
+Route::get('/telescope-api/timing/{telescopeEntryId}', 'TimingController@show');
+
 // Monitored Tags...
 Route::get('/telescope-api/monitored-tags', 'MonitoredTagController@index');
 Route::post('/telescope-api/monitored-tags/', 'MonitoredTagController@store');

--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -75,7 +75,10 @@ class IncomingEntry
 
         $this->recordedAt = now();
 
-        $this->content = array_merge($content, ['hostname' => gethostname()]);
+        $this->content = array_merge($content, [
+            'hostname' => gethostname(),
+            'timeEnd' => microtime(true),
+        ]);
 
         // $this->tags = ['hostname:'.gethostname()];
     }


### PR DESCRIPTION
This is a Draft Pull Request to check if this is worth including, before too much time is spent on this.

- Adds timing information to entries
- Shows timing information
- Ability to start/stop timers

Fixes #674 

Example:
<img width="955" alt="Screen Shot 2019-08-15 at 22 19 56" src="https://user-images.githubusercontent.com/973269/63124416-8731a000-bfab-11e9-9bfa-c6db6b310a8f.png">

TODO
 - [ ] Fix layout to make it useful
 - [ ] Think about how to add timing (eg. sections? perhaps use https://symfony.com/doc/current/components/stopwatch.html ? )
 - [ ] Record the timing data together with the IncomingEntry, or create 1 timing entry with just all the events?
 - [ ] Add timing info for all appropriate watchers.
 - [ ] Add framework timing info (boot etc)

cc @christophmayrhofer