### PR TITLE
[2.0] Fall back to database.default when telescope.storage.database.connection is null

### DIFF
--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -157,7 +157,7 @@ class TelescopeServiceProvider extends ServiceProvider
 
         $this->app->when(DatabaseEntriesRepository::class)
             ->needs('$connection')
-            ->give(config('telescope.storage.database.connection'));
+            ->give(config('telescope.storage.database.connection') ?? config('database.default'));
 
         $this->app->when(DatabaseEntriesRepository::class)
             ->needs('$chunkSize')


### PR DESCRIPTION
This makes Telescope more flexible when dynamically changing the default DB connection, such as with multi-tenant setups.