### PR TITLE
rm terrafrost/bcmath_compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
         "ext-json": "*",
         "laravel/framework": "~5.8.0|^6.0",
         "moontoast/math": "^1.1",
-        "symfony/var-dumper": "^4.1",
-        "phpseclib/bcmath_compat": ">=1.0.0"
+        "symfony/var-dumper": "^4.1"
     },
     "require-dev": {
         "orchestra/testbench": "~3.7"


### PR DESCRIPTION
Due to moontoast/math's use of `ini_set` and `ini_get` on BCMath specific settings a shim cannot be utilized. https://github.com/phpseclib/bcmath_compat/blob/master/README.md elaborates, in the Limitations section.

I've made a pull request to moontoast/math that updates that to make use of bcmath_compat, instead (and rewrites it to avoid the `ini_set` / `ini_get` calls). My PR also fixes compatibility issues that moontoast/math _currently_ has with PHP 7.0+ (PHP 7.0 changed how `bcscale` works and moontoast/math never updated itself accordingly), etc, but at this point, the ball is in their court:

https://github.com/ramsey/moontoast-math/pull/17

If moontoast/math doesn't merge that PR in then maybe it'd make sense for me to create a fork that could live at, say, phpseclib/moontoast-math or something, that laravel/telescope could use idk.