### PR TITLE
Adding meta for disavowing robots

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -6,6 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <link rel="shortcut icon" href="{{ asset('/vendor/telescope/favicon.ico') }}">
+    
+    <!-- Disavowing all robots "access" -->
+    <meta name="robots" content="noindex, nofollow">
 
     <title>Telescope{{ config('app.name') ? ' - ' . config('app.name') : '' }}</title>
 

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -7,7 +7,6 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <link rel="shortcut icon" href="{{ asset('/vendor/telescope/favicon.ico') }}">
     
-    <!-- Disavowing all robots "access" -->
     <meta name="robots" content="noindex, nofollow">
 
     <title>Telescope{{ config('app.name') ? ' - ' . config('app.name') : '' }}</title>


### PR DESCRIPTION
Adding this meta tag may disavow regular indexing robots (google, yahoo, bing, etc.), to index the contents inside Telescope URLs.
Take into account that this is not a barrier to get access to the Telescope components, but at least may avoid those sensitive sections to get index by mistake (there are some indexed already).
Additionally, adding this to robots.txt may disavow robots for indexing, but will expose your Telescope URL to the public so you may want to avoid this and using this meta tag instead.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
