### PR TITLE
Format SQL in watcher

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -136,7 +136,6 @@ return [
             'enabled' => env('TELESCOPE_QUERY_WATCHER', true),
             'ignore_packages' => true,
             'slow' => 100,
-            'format_sql' => true,
         ],
 
         Watchers\RedisWatcher::class => env('TELESCOPE_REDIS_WATCHER', true),

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -136,6 +136,7 @@ return [
             'enabled' => env('TELESCOPE_QUERY_WATCHER', true),
             'ignore_packages' => true,
             'slow' => 100,
+            'format_sql' => true,
         ],
 
         Watchers\RedisWatcher::class => env('TELESCOPE_REDIS_WATCHER', true),

--- a/resources/js/components/RelatedEntries.vue
+++ b/resources/js/components/RelatedEntries.vue
@@ -126,6 +126,13 @@
                 return _.filter(this.batch, {type: 'view'});
             },
 
+            queriesSummary() {
+                return {
+                    time: _.reduce(this.queries, (time, q) => { return time + parseFloat(q.content.time) }, 0.00),
+                    duplicated: this.queries.length - _.size(_.groupBy(this.queries, 'family_hash')),
+                };
+            },
+
             tabs(){
                 return _.filter([
                     {title: "Exceptions", type: "exceptions", count: this.exceptions.length},
@@ -237,12 +244,11 @@
             <table class="table table-hover table-sm mb-0" v-show="currentTab=='queries' && queries.length">
                 <thead>
                 <tr>
-                    <th>Query</th>
-                    <th>Duration</th>
+                    <th>Query<br/><small>{{ queries.length }} queries, {{ queriesSummary.duplicated }} of which are duplicated.</small></th>
+                    <th>Duration<br/><small>{{ queriesSummary.duplicated }} ms</small></th>
                     <th></th>
                 </tr>
                 </thead>
-
                 <tbody>
                 <tr v-for="entry in queries">
                     <td :title="entry.content.sql">{{truncate(entry.content.sql, 110)}}</td>

--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -118,6 +118,19 @@ class IncomingEntry
     }
 
     /**
+     * Assign the entry a family hash.
+     *
+     * @param  string  $familyHash
+     * @return $this
+     */
+    public function withFamilyHash(string $familyHash)
+    {
+        $this->familyHash = $familyHash;
+
+        return $this;
+    }
+
+    /**
      * Set the currently authenticated user.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
@@ -249,6 +262,7 @@ class IncomingEntry
         return [
             'uuid' => $this->uuid,
             'batch_id' => $this->batchId,
+            'family_hash' => $this->familyHash,
             'type' => $this->type,
             'content' => $this->content,
             'created_at' => $this->recordedAt->toDateTimeString(),

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -108,7 +108,7 @@ class QueryWatcher extends Watcher
                 : "/:{$key}(?=(?:[^'\\\']*'[^'\\\']*')*[^'\\\']*$)/";
 
             // Quote strings
-            if (!is_int($binding) && !is_float($binding)) {
+            if ( ! is_int($binding) && ! is_float($binding)) {
                 $binding = $event->connection->getPdo()->quote($binding);
             }
 

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -37,18 +37,10 @@ class QueryWatcher extends Watcher
 
         $caller = $this->getCallerFromStackTrace();
 
-        if (isset($this->options['format_sql']) && $this->options['format_sql']) {
-            $sql = $this->formatSql($event);
-            $bindings = [];
-        } else {
-            $sql = $event->sql;
-            $bindings = $this->formatBindings($event);
-        }
-
         Telescope::recordQuery(IncomingEntry::make([
             'connection' => $event->connectionName,
-            'bindings' => $bindings,
-            'sql' => $sql,
+            'bindings' => [],
+            'sql' => $this->replaceBindings($event),
             'time' => number_format($time, 2),
             'slow' => isset($this->options['slow']) && $time >= $this->options['slow'],
             'file' => $caller['file'],
@@ -95,7 +87,7 @@ class QueryWatcher extends Watcher
      * @param  \Illuminate\Database\Events\QueryExecuted  $event
      * @return string
      */
-    public function formatSql($event)
+    public function replaceBindings($event)
     {
         $sql = $event->sql;
 

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Telescope\Watchers;
 
-use Laravel\Telescope\EntryResult;
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\IncomingEntry;
 use Illuminate\Database\Events\QueryExecuted;

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -108,7 +108,7 @@ class QueryWatcher extends Watcher
                 : "/:{$key}(?=(?:[^'\\\']*'[^'\\\']*')*[^'\\\']*$)/";
 
             // Quote strings
-            if ( ! is_int($binding) && ! is_float($binding)) {
+            if (! is_int($binding) && ! is_float($binding)) {
                 $binding = $event->connection->getPdo()->quote($binding);
             }
 


### PR DESCRIPTION
This formats the SQL in PHP (instead of Javascript) so that they can be shown in the preview window (imho that makes it a lot more clear when looking at them, but might be preference, hence the config options).
It stores the familyHash to be able to check for duplicates (which isn't implemented anywhere yet, but would perhaps be useful).

The view of the Javascript should be the same, with/without pre-formatted SQL.