### PR TITLE
Fix view tab selection order

### DIFF
--- a/resources/js/components/RelatedEntries.vue
+++ b/resources/js/components/RelatedEntries.vue
@@ -42,6 +42,8 @@
                     this.currentTab = 'exceptions'
                 } else if (this.logs.length) {
                     this.currentTab = 'logs'
+                } else if (this.views.length) {
+                    this.currentTab = 'views'
                 } else if (this.queries.length) {
                     this.currentTab = 'queries'
                 } else if (this.models.length) {
@@ -60,8 +62,6 @@
                     this.currentTab = 'gates'
                 } else if (this.redis.length) {
                     this.currentTab = 'redis'
-                } else if (this.views.length) {
-                    this.currentTab = 'views'
                 }
             },
         },


### PR DESCRIPTION
The tab order was changed here: https://github.com/laravel/telescope/commit/459a11acb5070e649c15059aad67945d6525f622

Which puts the tab before queries, but queries is activated first, so it looks a bit weird that the second tab is activated by default.