### PR TITLE
Mark exceptions as resolved

### DIFF
--- a/resources/js/screens/exceptions/index.vue
+++ b/resources/js/screens/exceptions/index.vue
@@ -6,9 +6,10 @@
     <index-screen title="Exceptions" resource="exceptions">
         <tr slot="table-header">
             <th scope="col" v-if="!$route.query.family_hash">Type</th>
-            <th scope="col" v-if="!$route.query.family_hash && !$route.query.tag">Occurrences</th>
+            <th scope="col" v-if="!$route.query.family_hash && !$route.query.tag">#</th>
             <th scope="col" v-if="$route.query.family_hash">Message</th>
             <th scope="col">Happened</th>
+            <th scope="col">Resolved</th>
             <th scope="col"></th>
         </tr>
 
@@ -39,6 +40,17 @@
 
             <td class="table-fit" :data-timeago="slotProps.entry.created_at" :title="slotProps.entry.created_at">
                 {{timeAgo(slotProps.entry.created_at)}}
+            </td>
+
+            <td class="table-fit">
+                <div v-if="slotProps.entry.content.resolved_at" :data-timeago="slotProps.entry.content.resolved_at" :title="slotProps.entry.content.resolved_at">
+                     {{timeAgo(slotProps.entry.content.resolved_at)}}
+                </div>
+                <div v-if="!slotProps.entry.content.resolved_at" class="control-action text-center">
+                     <svg viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                        <path fill="#ef5753"  d="M2.92893219,17.0710678 C6.83417511,20.9763107 13.1658249,20.9763107 17.0710678,17.0710678 C20.9763107,13.1658249 20.9763107,6.83417511 17.0710678,2.92893219 C13.1658249,-0.976310729 6.83417511,-0.976310729 2.92893219,2.92893219 C-0.976310729,6.83417511 -0.976310729,13.1658249 2.92893219,17.0710678 Z M9,5 L11,5 L11,11 L9,11 L9,5 Z M9,13 L11,13 L11,15 L9,15 L9,13 Z" id="Combined-Shape"></path>
+                    </svg>
+                </div>
             </td>
 
             <td class="table-fit">

--- a/resources/js/screens/exceptions/preview.vue
+++ b/resources/js/screens/exceptions/preview.vue
@@ -63,7 +63,7 @@
                         {{localTime(entry.content.resolved_at)}} ({{timeAgo(entry.content.resolved_at)}})
                     </span>
                     <span v-if="!entry.content.resolved_at">
-                        <a href="#" class="btn btn-sm btn-success" v-on:click.prevent="resolveException(entry)">Resolve now</a>
+                        <a href="#" class="badge badge-success mr-1 font-weight-light" v-on:click.prevent="resolveException(entry)">Resolve now</a>
                     </span>
                 </td>
             </tr>

--- a/resources/js/screens/exceptions/preview.vue
+++ b/resources/js/screens/exceptions/preview.vue
@@ -1,4 +1,6 @@
 <script type="text/ecmascript-6">
+    import axios from 'axios';
+
     export default {
         components: {
             'code-preview': require('./../../components/ExceptionCodePreview').default,
@@ -12,6 +14,19 @@
                 currentTab: 'message'
             };
         },
+
+        methods: {
+            resolveException(entry) {
+                this.alertConfirm('Are you sure you want to resolve this exception?', () => {
+
+                    axios.put(Telescope.basePath + '/telescope-api/exceptions/' + entry.id, {
+                        'resolved_at': 'now',
+                    }).then(response => {
+                        this.entry = response.data.entry;
+                    })
+                });
+            },
+        }
     }
 </script>
 
@@ -38,6 +53,18 @@
                     <router-link :to="{name:'exceptions', query: {family_hash: slotProps.entry.family_hash}}" class="control-action">
                         View Other Occurrences
                     </router-link>
+                </td>
+            </tr>
+
+            <tr>
+                <td class="table-fit font-weight-bold">Resolved at</td>
+                <td>
+                    <span v-if="entry.content.resolved_at">
+                        {{localTime(entry.content.resolved_at)}} ({{timeAgo(entry.content.resolved_at)}})
+                    </span>
+                    <span v-if="!entry.content.resolved_at">
+                        <a href="#" class="btn btn-sm btn-success" v-on:click.prevent="resolveException(entry)">Resolve now</a>
+                    </span>
                 </td>
             </tr>
         </template>

--- a/src/Http/Controllers/ExceptionController.php
+++ b/src/Http/Controllers/ExceptionController.php
@@ -4,11 +4,11 @@ namespace Laravel\Telescope\Http\Controllers;
 
 use Carbon\Carbon;
 use Illuminate\Http\Request;
-use Laravel\Telescope\Contracts\EntriesRepository;
 use Laravel\Telescope\EntryType;
 use Laravel\Telescope\EntryUpdate;
 use Laravel\Telescope\Storage\EntryQueryOptions;
 use Laravel\Telescope\Watchers\ExceptionWatcher;
+use Laravel\Telescope\Contracts\EntriesRepository;
 
 class ExceptionController extends EntryController
 {

--- a/src/Http/Controllers/ExceptionController.php
+++ b/src/Http/Controllers/ExceptionController.php
@@ -2,7 +2,12 @@
 
 namespace Laravel\Telescope\Http\Controllers;
 
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Laravel\Telescope\Contracts\EntriesRepository;
 use Laravel\Telescope\EntryType;
+use Laravel\Telescope\EntryUpdate;
+use Laravel\Telescope\Storage\EntryQueryOptions;
 use Laravel\Telescope\Watchers\ExceptionWatcher;
 
 class ExceptionController extends EntryController
@@ -25,5 +30,33 @@ class ExceptionController extends EntryController
     protected function watcher()
     {
         return ExceptionWatcher::class;
+    }
+
+    /**
+     * Update an entry with the given ID.
+     *
+     * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
+     * @param  int  $id
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function update(EntriesRepository $storage, Request $request, $id)
+    {
+        $entry = $storage->find($id);
+
+        if ($request->input('resolved_at') === 'now') {
+            $update = new EntryUpdate($entry->id, $entry->type, [
+                'resolved_at' => Carbon::now()->toDateTimeString(),
+            ]);
+
+            $storage->update(collect([$update]));
+
+            // Reload entry
+            $entry = $storage->find($id);
+        }
+
+        return response()->json([
+            'entry' => $entry,
+            'batch' => $storage->get(null, EntryQueryOptions::forBatchId($entry->batchId)->limit(-1)),
+        ]);
     }
 }

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -11,6 +11,7 @@ Route::get('/telescope-api/mail/{telescopeEntryId}/download', 'MailEmlController
 // Exception entries...
 Route::post('/telescope-api/exceptions', 'ExceptionController@index');
 Route::get('/telescope-api/exceptions/{telescopeEntryId}', 'ExceptionController@show');
+Route::put('/telescope-api/exceptions/{telescopeEntryId}', 'ExceptionController@update');
 
 // Dump entries...
 Route::post('/telescope-api/dumps', 'DumpController@index');


### PR DESCRIPTION
This allows to mark exceptions as resolved, and show warnings when not resolved.

![image](https://user-images.githubusercontent.com/973269/63591455-23ad0100-c5af-11e9-8db5-778dd7094dbd.png)

![image](https://user-images.githubusercontent.com/973269/63591471-3293b380-c5af-11e9-82c1-b89039444666.png)

If an Exception occurs again, it's shown as not-resolved again (because the last entry is shown, which is good).