### PR TITLE
Only load header once

### DIFF
--- a/resources/js/screens/dumps/index.vue
+++ b/resources/js/screens/dumps/index.vue
@@ -7,6 +7,7 @@
          */
         data() {
             return {
+                dump: null,
                 entries: [],
                 ready: false,
                 newEntriesTimeout: null,
@@ -39,6 +40,7 @@
             loadEntries(){
                 axios.post(Telescope.basePath + '/telescope-api/dumps').then(response => {
                     this.ready = true;
+                    this.dump = response.data.dump;
                     this.entries = response.data.entries;
                     this.recordingStatus = response.data.status;
 
@@ -102,8 +104,13 @@
             <span>We didn't find anything - just empty space.</span>
         </div>
 
+        <div style="display: none;" v-if="dump">
+            <div v-html="dump"></div>
+        </div>
+
         <div v-if="ready && entries.length > 0" class="code-bg px-3 pt-3">
             <transition-group tag="div" name="list">
+                
                 <div v-for="entry in entries" :key="entry.id" class="mb-4">
                     <div class="entryPointDescription d-flex justify-content-between align-items-center">
                         <router-link :to="{name:'request-preview', params:{id: entry.content.entry_point_uuid}}" class="control-action" v-if="entry.content.entry_point_type == 'request'">

--- a/src/Http/Controllers/DumpController.php
+++ b/src/Http/Controllers/DumpController.php
@@ -6,6 +6,9 @@ use Illuminate\Http\Request;
 use Illuminate\Cache\ArrayStore;
 use Laravel\Telescope\EntryType;
 use Laravel\Telescope\Watchers\DumpWatcher;
+use Laravel\Telescope\Storage\EntryQueryOptions;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 use Laravel\Telescope\Contracts\EntriesRepository;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 
@@ -40,7 +43,14 @@ class DumpController extends EntryController
     {
         $this->cache->put('telescope:dump-watcher', true, now()->addSeconds(4));
 
-        return parent::index($request, $storage);
+        return response()->json([
+            'dump' => (new HtmlDumper())->dump((new VarCloner)->cloneVar(true), true),
+            'entries' => $storage->get(
+                $this->entryType(),
+                EntryQueryOptions::fromRequest($request)
+            ),
+            'status' => $this->status(),
+        ]);
     }
 
     /**

--- a/src/Watchers/DumpWatcher.php
+++ b/src/Watchers/DumpWatcher.php
@@ -44,8 +44,11 @@ class DumpWatcher extends Watcher
             return;
         }
 
-        VarDumper::setHandler(function ($var) {
-            $this->recordDump((new HtmlDumper)->dump(
+        $htmlDumper = new HtmlDumper();
+        $htmlDumper->setDumpHeader('');
+
+        VarDumper::setHandler(function ($var) use($htmlDumper) {
+            $this->recordDump($htmlDumper->dump(
                 (new VarCloner)->cloneVar($var), true
             ));
         });


### PR DESCRIPTION
The script/style tags are added to all dumps, which make them big (eg. 15 kB per entry). You only need the header once (when rendering). This doesn't store them, but generates a single header on the fly.

I don't think we need al Javascript even, because that's not rendered (because of the v-html, which doesn't run inline scripts, which is why the collapse isn't working (see https://github.com/laravel/telescope/issues/636). But not sure if there is a different way to do that in Vue.

