### PR TITLE
Prevent resuming recording when processing sync job

### DIFF
--- a/src/ListensForStorageOpportunities.php
+++ b/src/ListensForStorageOpportunities.php
@@ -53,10 +53,12 @@ trait ListensForStorageOpportunities
      */
     protected static function storeEntriesAfterWorkerLoop($app)
     {
-        $app['events']->listen(JobProcessing::class, function () {
-            static::startRecording();
+        $app['events']->listen(JobProcessing::class, function ($event) {
+            if ($event->connectionName !== 'sync') {
+                static::startRecording();
 
-            static::$processingJobs[] = true;
+                static::$processingJobs[] = true;
+            }
         });
 
         $app['events']->listen(JobProcessed::class, function ($event) use ($app) {

--- a/tests/Telescope/TelescopeTest.php
+++ b/tests/Telescope/TelescopeTest.php
@@ -3,6 +3,8 @@
 namespace Laravel\Telescope\Tests\Telescope;
 
 use Laravel\Telescope\Telescope;
+use Illuminate\Contracts\Bus\Dispatcher;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Laravel\Telescope\Tests\FeatureTestCase;
 use Laravel\Telescope\Watchers\QueryWatcher;
 use Laravel\Telescope\Contracts\EntriesRepository;
@@ -69,5 +71,38 @@ class TelescopeTest extends FeatureTestCase
         $this->app->get('db')->table('telescope_entries')->count();
 
         $this->assertCount(1, Telescope::$entriesQueue);
+    }
+
+    /**
+     * @test
+     */
+    public function dont_start_recording_when_dispatching_job_synchronously()
+    {
+        Telescope::stopRecording();
+
+        $this->assertFalse(Telescope::isRecording());
+
+        $this->app->get(Dispatcher::class)->dispatch(
+            new MySyncJob('Awesome Laravel')
+        );
+
+        $this->assertFalse(Telescope::isRecording());
+    }
+}
+
+class MySyncJob implements ShouldQueue
+{
+    public $connection = 'sync';
+
+    private $payload;
+
+    public function __construct($payload)
+    {
+        $this->payload = $payload;
+    }
+
+    public function handle()
+    {
+        //
     }
 }


### PR DESCRIPTION
This PR attempts to resolve the bug report made in https://github.com/laravel/telescope/issues/719.

The `storeIfDoneProcessingJob` method already contained a condition for checking if `$connectionName !== 'sync'`, so it seemed reasonable that this condition was also checked when _starting_ recording.

https://github.com/laravel/telescope/blob/fedd672e3c8570e3d4b4e96dd7014a9a7bec8800/src/ListensForStorageOpportunities.php#L86-L89

This fixed the regression test that I added.