### PR TITLE
Check for null values in query bindings

### DIFF
--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -96,7 +96,9 @@ class QueryWatcher extends Watcher
                 ? "/\?(?=(?:[^'\\\']*'[^'\\\']*')*[^'\\\']*$)/"
                 : "/:{$key}(?=(?:[^'\\\']*'[^'\\\']*')*[^'\\\']*$)/";
 
-            if (! is_int($binding) && ! is_float($binding)) {
+            if ($binding === null) {
+                $binding = 'null';
+            } elseif (! is_int($binding) && ! is_float($binding)) {
                 $binding = $event->connection->getPdo()->quote($binding);
             }
 

--- a/tests/Watchers/QueryWatcherTest.php
+++ b/tests/Watchers/QueryWatcherTest.php
@@ -68,7 +68,7 @@ class QueryWatcherTest extends FeatureTestCase
         $entry = $this->loadTelescopeEntries()->first();
 
         $this->assertSame(EntryType::QUERY, $entry->type);
-        $this->assertSame(<<<SQL
+        $this->assertSame(<<<'SQL'
 update "telescope_entries" set "content" = null, "should_display_on_index" = 0 where "type" = 'query' and "should_display_on_index" = 1 and "family_hash" is null and "created_at" < '2019-01-01 00:00:00'
 SQL
             , $entry->content['sql']);

--- a/tests/Watchers/QueryWatcherTest.php
+++ b/tests/Watchers/QueryWatcherTest.php
@@ -59,6 +59,7 @@ class QueryWatcherTest extends FeatureTestCase
             ->where('type', 'query')
             ->where('should_display_on_index', true)
             ->whereNull('family_hash')
+            ->where('sequence', '>', 100)
             ->where('created_at', '<', Carbon::parse('2019-01-01'))
             ->update([
                 'content' => null,
@@ -69,7 +70,32 @@ class QueryWatcherTest extends FeatureTestCase
 
         $this->assertSame(EntryType::QUERY, $entry->type);
         $this->assertSame(<<<'SQL'
-update "telescope_entries" set "content" = null, "should_display_on_index" = 0 where "type" = 'query' and "should_display_on_index" = 1 and "family_hash" is null and "created_at" < '2019-01-01 00:00:00'
+update "telescope_entries" set "content" = null, "should_display_on_index" = 0 where "type" = 'query' and "should_display_on_index" = 1 and "family_hash" is null and "sequence" > 100 and "created_at" < '2019-01-01 00:00:00'
+SQL
+            , $entry->content['sql']);
+
+        $this->assertSame('testbench', $entry->content['connection']);
+    }
+
+    public function test_query_watcher_can_prepare_named_bindings()
+    {
+        $this->app->get('db')->statement(<<<'SQL'
+update "telescope_entries" set "content" = :content, "should_display_on_index" = :index_new where "type" = :type and "should_display_on_index" = :index_old and "family_hash" is null and "sequence" > :sequence and "created_at" < :created_at
+SQL
+            , [
+                'sequence' => 100,
+                'index_old' => 1,
+                'type' => 'query',
+                'created_at' => Carbon::parse('2019-01-01'),
+                'index_new' => 0,
+                'content' => null,
+            ]);
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::QUERY, $entry->type);
+        $this->assertSame(<<<'SQL'
+update "telescope_entries" set "content" = null, "should_display_on_index" = 0 where "type" = 'query' and "should_display_on_index" = 1 and "family_hash" is null and "sequence" > 100 and "created_at" < '2019-01-01 00:00:00'
 SQL
             , $entry->content['sql']);
 

--- a/tests/Watchers/QueryWatcherTest.php
+++ b/tests/Watchers/QueryWatcherTest.php
@@ -60,12 +60,19 @@ class QueryWatcherTest extends FeatureTestCase
             ->where('should_display_on_index', true)
             ->whereNull('family_hash')
             ->where('created_at', '<', Carbon::parse('2019-01-01'))
-            ->count();
+            ->update([
+                'content' => null,
+                'should_display_on_index' => false,
+            ]);
 
         $entry = $this->loadTelescopeEntries()->first();
 
         $this->assertSame(EntryType::QUERY, $entry->type);
-        $this->assertSame('select count(*) as aggregate from "telescope_entries" where "type" = \'query\' and "should_display_on_index" = 1 and "family_hash" is null and "created_at" < \'2019-01-01 00:00:00\'', $entry->content['sql']);
+        $this->assertSame(<<<SQL
+update "telescope_entries" set "content" = null, "should_display_on_index" = 0 where "type" = 'query' and "should_display_on_index" = 1 and "family_hash" is null and "created_at" < '2019-01-01 00:00:00'
+SQL
+            , $entry->content['sql']);
+
         $this->assertSame('testbench', $entry->content['connection']);
     }
 }


### PR DESCRIPTION
Checks for `null` values in queryies. Fixes https://github.com/laravel/telescope/issues/726