### PR TITLE
Show warning when manifest is outdated

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -192,7 +192,7 @@
             </div>
 
             <div class="col-10">
-                @if (! $assetsUpdated)
+                @if (! $assetsAreCurrent)
                     <div class="alert alert-warning">
                         The published Telescope assets are not up-to-date with the installed version. To update, run:<br/><code>php artisan telescope:publish</code>
                     </div>

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -192,11 +192,12 @@
             </div>
 
             <div class="col-10">
-                @if(!$assetsUpdated)
+                @if (! $assetsUpdated)
                     <div class="alert alert-warning">
                         The published Telescope assets are not up-to-date with the installed version. To update, run:<br/><code>php artisan telescope:publish</code>
                     </div>
                 @endif
+
                 <router-view></router-view>
             </div>
         </div>

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -192,6 +192,11 @@
             </div>
 
             <div class="col-10">
+                @if(!$assetsUpdated)
+                    <div class="alert alert-warning">
+                        The published Telescope assets are not up-to-date with the installed version. To update, run:<br/><code>php artisan telescope:publish</code>
+                    </div>
+                @endif
                 <router-view></router-view>
             </div>
         </div>

--- a/src/Http/Controllers/HomeController.php
+++ b/src/Http/Controllers/HomeController.php
@@ -17,6 +17,7 @@ class HomeController extends Controller
         return view('telescope::layout', [
             'cssFile' => Telescope::$useDarkTheme ? 'app-dark.css' : 'app.css',
             'telescopeScriptVariables' => Telescope::scriptVariables(),
+            'assetsUpdated' => Telescope::assetsUpdated(),
         ]);
     }
 }

--- a/src/Http/Controllers/HomeController.php
+++ b/src/Http/Controllers/HomeController.php
@@ -17,7 +17,7 @@ class HomeController extends Controller
         return view('telescope::layout', [
             'cssFile' => Telescope::$useDarkTheme ? 'app-dark.css' : 'app.css',
             'telescopeScriptVariables' => Telescope::scriptVariables(),
-            'assetsUpdated' => Telescope::assetsUpdated(),
+            'assetsAreCurrent' => Telescope::assetsAreCurrent(),
         ]);
     }
 }

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -709,7 +709,7 @@ class Telescope
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      * @return bool
      */
-    public static function assetsUpdated()
+    public static function assetsAreCurrent()
     {
         $publishedPath = public_path('vendor/telescope/mix-manifest.json');
 

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -7,6 +7,7 @@ use Exception;
 use Throwable;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\File;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Laravel\Telescope\Contracts\EntriesRepository;
@@ -700,5 +701,21 @@ class Telescope
         static::$runsMigrations = false;
 
         return new static;
+    }
+
+    /**
+     * Check if assets are up-to-date
+     *
+     * @return bool
+     */
+    public static function assetsUpdated()
+    {
+        $publishedPath = public_path('vendor/telescope/mix-manifest.json');
+
+        if (!File::exists($publishedPath)) {
+            throw new \RuntimeException('The Telescope assets are not published. Please run: php artisan telescope:publish');
+        }
+
+        return File::get($publishedPath) === File::get(__DIR__ .'/../public/mix-manifest.json');
     }
 }

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -704,18 +704,19 @@ class Telescope
     }
 
     /**
-     * Check if assets are up-to-date
+     * Check if assets are up-to-date.
      *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      * @return bool
      */
     public static function assetsUpdated()
     {
         $publishedPath = public_path('vendor/telescope/mix-manifest.json');
 
-        if (!File::exists($publishedPath)) {
+        if (! File::exists($publishedPath)) {
             throw new \RuntimeException('The Telescope assets are not published. Please run: php artisan telescope:publish');
         }
 
-        return File::get($publishedPath) === File::get(__DIR__ .'/../public/mix-manifest.json');
+        return File::get($publishedPath) === File::get(__DIR__.'/../public/mix-manifest.json');
     }
 }


### PR DESCRIPTION
This adds a check to the base view to show a warning when the manifest file in the public folder is different from the one in the vendor dir. This prevents broken components or missing updates.

![image](https://user-images.githubusercontent.com/973269/64521968-46eae680-d2f9-11e9-8b9f-ee535e7735f9.png)

The exception is also updated to make it more clear.
Related: #594