### PR TITLE
Use getConnection method in Migrations

### DIFF
--- a/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -9,7 +9,7 @@ class CreateTelescopeEntriesTable extends Migration
     /**
      * The database schema.
      *
-     * @var \lluminate\Support\Facades\Schema
+     * @var \Illuminate\Database\Schema\Builder
      */
     protected $schema;
 

--- a/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -9,7 +9,7 @@ class CreateTelescopeEntriesTable extends Migration
     /**
      * The database schema.
      *
-     * @var Schema
+     * @var \lluminate\Support\Facades\Schema
      */
     protected $schema;
 
@@ -20,9 +20,17 @@ class CreateTelescopeEntriesTable extends Migration
      */
     public function __construct()
     {
-        $this->schema = Schema::connection(
-            config('telescope.storage.database.connection')
-        );
+        $this->schema = Schema::connection($this->getConnection());
+    }
+
+    /**
+     * Get the migration connection name.
+     *
+     * @return string|null
+     */
+    public function getConnection()
+    {
+        return config('telescope.storage.database.connection');
     }
 
     /**


### PR DESCRIPTION
Related to https://github.com/laravel/framework/pull/29983

Migration has `getConnection()` method which used inside of the Migrator class to determine if schema transactions are supported. Without this PR Migrator will check default database connection, but migrations could be executed on custom connection.