### PR TITLE
Use time instead of duplicated to show global queries duration

### DIFF
--- a/resources/js/components/RelatedEntries.vue
+++ b/resources/js/components/RelatedEntries.vue
@@ -254,7 +254,7 @@
                 <thead>
                 <tr>
                     <th>Query<br/><small>{{ queries.length }} queries, {{ queriesSummary.duplicated }} of which are duplicated.</small></th>
-                    <th>Duration<br/><small>{{ queriesSummary.duplicated }} ms</small></th>
+                    <th>Duration<br/><small>{{ queriesSummary.time }} ms</small></th>
                     <th></th>
                 </tr>
                 </thead>


### PR DESCRIPTION
This patch is pretty simple. The duration shown on the screen below is wrong because it shows the number of duplicated queries instead of sum of queries duration.

![image](https://user-images.githubusercontent.com/340143/64945244-6f7e5d80-d870-11e9-8876-c52285ae8588.png)