### PR TITLE
Hide php-auth-pw server variable by default

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -70,6 +70,7 @@ class Telescope
      */
     public static $hiddenRequestHeaders = [
         'authorization',
+        'php-auth-pw',
     ];
 
     /**

--- a/tests/Watchers/RequestWatchersTest.php
+++ b/tests/Watchers/RequestWatchersTest.php
@@ -91,6 +91,23 @@ class RequestWatchersTest extends FeatureTestCase
         $this->assertSame('********', $entry->content['headers']['authorization']);
     }
 
+    public function test_request_watcher_hides_php_auth_pw()
+    {
+        Route::post('/dashboard', function () {
+            return response('success');
+        });
+
+        $this->post('/dashboard', [], [
+            'php-auth-pw' => 'secret',
+        ]);
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::REQUEST, $entry->type);
+        $this->assertSame('POST', $entry->content['method']);
+        $this->assertSame('********', $entry->content['headers']['php-auth-pw']);
+    }
+
     public function test_request_watcher_handles_file_uploads()
     {
         $image = UploadedFile::fake()->image('avatar.jpg');


### PR DESCRIPTION
Following https://github.com/laravel/telescope/issues/730

"authorization" header is filtered out by default, but it's showing simple HTTP auth server variable "php-auth-pw" where plain password can be seen. This might be a security concern as HTTP auth plain passwords will be stored in DB. I added "php-auth-pw" to $hiddenRequestHeaders to be filtered out by default.
