### PR TITLE
[BUGFIX] Don't check TELESCOPE_ENABLED while booting

### DIFF
--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -18,10 +18,6 @@ class TelescopeServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if (! config('telescope.enabled')) {
-            return;
-        }
-
         Route::middlewareGroup('telescope', config('telescope.middleware', []));
 
         $this->registerRoutes();


### PR DESCRIPTION
This small fix will allow installation of Telescope again. Before, installing always existed before doing anything because of this statement.
The `TELESCOPE_ENABLED ` check is also implemented in [`Telescope::start`](https://github.com/laravel/telescope/blob/ee9f9b2/src/Telescope.php#L129-L131), so there shouldn't be any downsides.
It will also likely fix #732.