### PR TITLE
Add formatted output support for plain text responses

### DIFF
--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -154,7 +154,6 @@ class RequestWatcher extends Watcher
                         : 'Purged By Telescope';
             }
 
-            // return plain text responses
             if (Str::startsWith(strtolower($response->headers->get('Content-Type')), 'text/plain')) {
                 return $this->contentWithinLimits($content) ? $content : 'Purged By Telescope';
             }

--- a/tests/Watchers/RequestWatchersTest.php
+++ b/tests/Watchers/RequestWatchersTest.php
@@ -4,6 +4,7 @@ namespace Laravel\Telescope\Tests\Watchers;
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Response;
 use Laravel\Telescope\EntryType;
 use Laravel\Telescope\Tests\FeatureTestCase;
 use Laravel\Telescope\Watchers\RequestWatcher;
@@ -138,5 +139,22 @@ class RequestWatchersTest extends FeatureTestCase
         $this->assertSame($image->getClientOriginalName(), $uploadedImage['name']);
 
         $this->assertSame('0', $uploadedImage['size']);
+    }
+
+    public function test_request_watcher_plain_text_response()
+    {
+        Route::get('/fake-plain-text', function () {
+            return Response::make(
+                'plain telescope response', 200, ['Content-Type' => 'text/plain']
+            );
+        });
+
+        $this->get('/fake-plain-text')->assertSuccessful();
+
+        $entry = $this->loadTelescopeEntries()->first();
+        $this->assertSame(EntryType::REQUEST, $entry->type);
+        $this->assertSame('GET', $entry->content['method']);
+        $this->assertSame(200, $entry->content['response_status']);
+        $this->assertSame('plain telescope response', $entry->content['response']);
     }
 }

--- a/tests/Watchers/RequestWatchersTest.php
+++ b/tests/Watchers/RequestWatchersTest.php
@@ -3,8 +3,8 @@
 namespace Laravel\Telescope\Tests\Watchers;
 
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Response;
+use Illuminate\Support\Facades\Route;
 use Laravel\Telescope\EntryType;
 use Laravel\Telescope\Tests\FeatureTestCase;
 use Laravel\Telescope\Watchers\RequestWatcher;


### PR DESCRIPTION
In the case the response content-type is plain text (`text/plain`), the response output of the request details view contains the response content instead of the static content `HTML Response`.