### PR TITLE
Add the Nova API to ignore paths array

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -183,7 +183,7 @@ class Telescope
                 'vendor/telescope*',
                 'horizon*',
                 'vendor/horizon*',
-                'nova-api*'
+                'nova-api*',
             ], config('telescope.ignore_paths', []))
         );
     }

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -183,6 +183,7 @@ class Telescope
                 'vendor/telescope*',
                 'horizon*',
                 'vendor/horizon*',
+                'nova-api*'
             ], config('telescope.ignore_paths', []))
         );
     }
@@ -618,7 +619,8 @@ class Telescope
     public static function hideRequestHeaders(array $headers)
     {
         static::$hiddenRequestHeaders = array_merge(
-            static::$hiddenRequestHeaders, $headers
+            static::$hiddenRequestHeaders,
+            $headers
         );
 
         return new static;
@@ -633,7 +635,8 @@ class Telescope
     public static function hideRequestParameters(array $attributes)
     {
         static::$hiddenRequestParameters = array_merge(
-            static::$hiddenRequestParameters, $attributes
+            static::$hiddenRequestParameters,
+            $attributes
         );
 
         return new static;
@@ -648,7 +651,8 @@ class Telescope
     public static function hideResponseParameters(array $attributes)
     {
         static::$hiddenResponseParameters = array_merge(
-            static::$hiddenResponseParameters, $attributes
+            static::$hiddenResponseParameters,
+            $attributes
         );
 
         return new static;


### PR DESCRIPTION
Hello, 

Would you be open to by default ignoring the nova API by default? You can do this individually by project via the config file but the Horizon API is ignored by default so I figured it's worth asking.

The Nova API creates a lot of requests that don't provide much value (in my case), if others get value from those request logs then disregard.

Cheers, Wyatt!