### PR TITLE
[2.0] Allow for multi-tenancy

### DIFF
--- a/src/Http/Controllers/EntryController.php
+++ b/src/Http/Controllers/EntryController.php
@@ -44,13 +44,14 @@ abstract class EntryController extends Controller
     /**
      * Get an entry with the given ID.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
      * @param  int  $id
      * @return \Illuminate\Http\JsonResponse
      */
-    public function show(EntriesRepository $storage, $id)
-    {
-        $entry = $storage->find($id);
+    public function show(Request $request, EntriesRepository $storage, $id)
+    {   
+        $entry = $storage->find($request->telescopeEntryId);
 
         return response()->json([
             'entry' => $entry,


### PR DESCRIPTION
Changed the "show" method to allow for multi-tenancy applications to still utilise the package. Applications which use Route Model Binding for subdomains aren't taken into account by this method and instead the $id would return the tenant model. By getting the entry id from the request, it retains the functionality and allows for multi-tenant applications to use this package per tenant.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
