### PR TITLE
[2.0] Allow for multi-tenancy

### DIFF
--- a/src/Http/Controllers/EntryController.php
+++ b/src/Http/Controllers/EntryController.php
@@ -44,13 +44,14 @@ abstract class EntryController extends Controller
     /**
      * Get an entry with the given ID.
      *
+     * @param  \Illuninate\Http\Request  $request
      * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
      * @param  int  $id
      * @return \Illuminate\Http\JsonResponse
      */
-    public function show(EntriesRepository $storage, $id)
+    public function show(Request $request, EntriesRepository $storage, $id)
     {
-        $entry = $storage->find($id);
+        $entry = $storage->find($request->telescopeEntryId);
 
         return response()->json([
             'entry' => $entry,

--- a/src/Http/Controllers/QueueController.php
+++ b/src/Http/Controllers/QueueController.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Telescope\Http\Controllers;
 
+use Illuminate\Http\Request;
 use Laravel\Telescope\Contracts\EntriesRepository;
 use Laravel\Telescope\EntryType;
 use Laravel\Telescope\Storage\EntryQueryOptions;
@@ -22,13 +23,14 @@ class QueueController extends EntryController
     /**
      * Get an entry with the given ID.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
      * @param  int  $id
      * @return \Illuminate\Http\JsonResponse
      */
-    public function show(EntriesRepository $storage, $id)
+    public function show(Request $request, EntriesRepository $storage, $id)
     {
-        $entry = $storage->find($id);
+        $entry = $storage->find($request->telescopeEntryId);
 
         return response()->json([
             'entry' => $entry,


### PR DESCRIPTION
Change finding of entry through using passed ```id``` to use ```telescopeEntryId``` from the request. This allows for multi-tenant applications which use route model binding for the sub-domain to still use this package on a tenant-by-tenant basis.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
