### PR TITLE
Configure telescope to use bootstrap's container-fluid class

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <link rel="shortcut icon" href="{{ asset('/vendor/telescope/favicon.ico') }}">
-    
+
     <meta name="robots" content="noindex, nofollow">
 
     <title>Telescope{{ config('app.name') ? ' - ' . config('app.name') : '' }}</title>
@@ -24,7 +24,7 @@
            :confirmation-cancel="alert.confirmationCancel"
            v-if="alert.type"></alert>
 
-    <div class="container mb-5">
+    <div class="{{ $containerClass }} mb-5">
         <div class="d-flex align-items-center py-4 header">
             <svg class="logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80">
                 <path class="fill-primary" d="M0 40a39.87 39.87 0 0 1 11.72-28.28A40 40 0 1 1 0 40zm34 10a4 4 0 0 1-4-4v-2a2 2 0 1 0-4 0v2a4 4 0 0 1-4 4h-2a2 2 0 1 0 0 4h2a4 4 0 0 1 4 4v2a2 2 0 1 0 4 0v-2a4 4 0 0 1 4-4h2a2 2 0 1 0 0-4h-2zm24-24a6 6 0 0 1-6-6v-3a3 3 0 0 0-6 0v3a6 6 0 0 1-6 6h-3a3 3 0 0 0 0 6h3a6 6 0 0 1 6 6v3a3 3 0 0 0 6 0v-3a6 6 0 0 1 6-6h3a3 3 0 0 0 0-6h-3zm-4 36a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM21 28a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"></path>

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -24,7 +24,7 @@
            :confirmation-cancel="alert.confirmationCancel"
            v-if="alert.type"></alert>
 
-    <div class="{{ $containerClass }} mb-5">
+    <div class="{{ $containerCssClass }} mb-5">
         <div class="d-flex align-items-center py-4 header">
             <svg class="logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80">
                 <path class="fill-primary" d="M0 40a39.87 39.87 0 0 1 11.72-28.28A40 40 0 1 1 0 40zm34 10a4 4 0 0 1-4-4v-2a2 2 0 1 0-4 0v2a4 4 0 0 1-4 4h-2a2 2 0 1 0 0 4h2a4 4 0 0 1 4 4v2a2 2 0 1 0 4 0v-2a4 4 0 0 1 4-4h2a2 2 0 1 0 0-4h-2zm24-24a6 6 0 0 1-6-6v-3a3 3 0 0 0-6 0v3a6 6 0 0 1-6 6h-3a3 3 0 0 0 0 6h3a6 6 0 0 1 6 6v3a3 3 0 0 0 6 0v-3a6 6 0 0 1 6-6h3a3 3 0 0 0 0-6h-3zm-4 36a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM21 28a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"></path>

--- a/src/Http/Controllers/HomeController.php
+++ b/src/Http/Controllers/HomeController.php
@@ -16,7 +16,7 @@ class HomeController extends Controller
     {
         return view('telescope::layout', [
             'cssFile' => Telescope::$useDarkTheme ? 'app-dark.css' : 'app.css',
-            'containerClass' => Telescope::$useFluidLayout ? 'container-fluid' : 'container',
+            'containerCssClass' => Telescope::$useFluidLayout ? 'container-fluid' : 'container',
             'telescopeScriptVariables' => Telescope::scriptVariables(),
             'assetsAreCurrent' => Telescope::assetsAreCurrent(),
         ]);

--- a/src/Http/Controllers/HomeController.php
+++ b/src/Http/Controllers/HomeController.php
@@ -16,6 +16,7 @@ class HomeController extends Controller
     {
         return view('telescope::layout', [
             'cssFile' => Telescope::$useDarkTheme ? 'app-dark.css' : 'app.css',
+            'containerClass' => Telescope::$useFluidLayout ? 'container-fluid' : 'container',
             'telescopeScriptVariables' => Telescope::scriptVariables(),
             'assetsAreCurrent' => Telescope::assetsAreCurrent(),
         ]);

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -105,6 +105,13 @@ class Telescope
     public static $useDarkTheme = false;
 
     /**
+     * Indicates if Telescope should use a fluid layout.
+     *
+     * @var bool
+     */
+    public static $useFluidLayout = false;
+
+    /**
      * Indicates if Telescope should record entries.
      *
      * @var bool
@@ -678,6 +685,18 @@ class Telescope
     public static function night()
     {
         static::$useDarkTheme = true;
+
+        return new static;
+    }
+
+    /**
+     * Specifies that Telescope should use a fluid layout.
+     *
+     * @return static
+     */
+    public static function fluid()
+    {
+        static::$useFluidLayout = true;
 
         return new static;
     }

--- a/stubs/TelescopeServiceProvider.stub
+++ b/stubs/TelescopeServiceProvider.stub
@@ -17,6 +17,7 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
     public function register()
     {
         // Telescope::night();
+        // Telescope::fluid();
 
         $this->hideSensitiveRequestDetails();
 


### PR DESCRIPTION
Telescope by default uses bootstrap's `container` class. This can sometimes cause items to flow out of  the table:

![image](https://user-images.githubusercontent.com/21232249/68793481-8c35d800-060a-11ea-8dd5-2154579e80b7.png)
 
This update allows telescope to use bootstrap's `container-fluid` class by simply using `Telescope::fluid();` .