### PR TITLE
[2.x] Don't use familyHash for queries

### DIFF
--- a/resources/js/components/RelatedEntries.vue
+++ b/resources/js/components/RelatedEntries.vue
@@ -138,7 +138,7 @@
             queriesSummary() {
                 return {
                     time: _.reduce(this.queries, (time, q) => { return time + parseFloat(q.content.time) }, 0.00),
-                    duplicated: this.queries.length - _.size(_.groupBy(this.queries, 'family_hash')),
+                    duplicated: this.queries.length - _.size(_.groupBy(this.queries, (q) => { return q.content.hash })),
                 };
             },
 

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -45,7 +45,8 @@ class QueryWatcher extends Watcher
             'slow' => isset($this->options['slow']) && $time >= $this->options['slow'],
             'file' => $caller['file'],
             'line' => $caller['line'],
-        ])->tags($this->tags($event))->withFamilyHash($this->familyHash($event)));
+            'hash' => $this->familyHash($event),
+        ])->tags($this->tags($event)));
     }
 
     /**


### PR DESCRIPTION
Setting the familyHash had the unintended side-effect of grouping the Query entries on the Index page (not on the related pages). This keeps the logic, but uses a property in the `content`, instead of `familyHash`.
The method is kept because of strict BC compatibility (it's public, so technically breaking to rename). But I can change it if you want.
Fixes https://github.com/laravel/telescope/issues/603#issuecomment-535840401

This needs a rebuild for production.