### PR TITLE
Properly Implode Nested(Array) Notification Routes To Fix Array To String Conversion Exception

### DIFF
--- a/src/Watchers/NotificationWatcher.php
+++ b/src/Watchers/NotificationWatcher.php
@@ -69,7 +69,11 @@ class NotificationWatcher extends Watcher
         if ($notifiable instanceof Model) {
             return FormatModel::given($notifiable);
         } elseif ($notifiable instanceof AnonymousNotifiable) {
-            return 'Anonymous:'.implode(',', $notifiable->routes);
+            $routes = array_map(function ($route){
+                return is_array( $route ) ? implode(',', $route) : $route;
+            }, $notifiable->routes);
+
+            return 'Anonymous:'.implode(',', $routes);
         }
 
         return get_class($notifiable);

--- a/src/Watchers/NotificationWatcher.php
+++ b/src/Watchers/NotificationWatcher.php
@@ -69,8 +69,8 @@ class NotificationWatcher extends Watcher
         if ($notifiable instanceof Model) {
             return FormatModel::given($notifiable);
         } elseif ($notifiable instanceof AnonymousNotifiable) {
-            $routes = array_map(function ($route){
-                return is_array( $route ) ? implode(',', $route) : $route;
+            $routes = array_map(function ($route) {
+                return is_array($route) ? implode(',', $route) : $route;
             }, $notifiable->routes);
 
             return 'Anonymous:'.implode(',', $routes);

--- a/tests/Watchers/NotificationWatcherTest.php
+++ b/tests/Watchers/NotificationWatcherTest.php
@@ -24,16 +24,26 @@ class NotificationWatcherTest extends FeatureTestCase
 
     public function test_notification_watcher_registers_entry()
     {
-        Notification::route('mail', 'telescope@laravel.com')
-                    ->notify(new BoomerangNotification);
+        $this->performNotificationAssertions('mail', 'telescope@laravel.com');
+    }
+
+    public function test_notification_watcher_registers_array_routes()
+    {
+        $this->performNotificationAssertions('mail', ['telescope@laravel.com','nestedroute@laravel.com']);
+    }
+
+    private function performNotificationAssertions($channel, $route)
+    {
+        Notification::route($channel, $route)
+            ->notify(new BoomerangNotification);
 
         $entry = $this->loadTelescopeEntries()->first();
 
         $this->assertSame(EntryType::NOTIFICATION, $entry->type);
         $this->assertSame(BoomerangNotification::class, $entry->content['notification']);
         $this->assertSame(false, $entry->content['queued']);
-        $this->assertStringContainsString('telescope@laravel.com', $entry->content['notifiable']);
-        $this->assertSame('mail', $entry->content['channel']);
+        $this->assertStringContainsString(is_array($route) ? implode(',', $route) : $route, $entry->content['notifiable']);
+        $this->assertSame($channel, $entry->content['channel']);
         $this->assertNull($entry->content['response']);
     }
 }

--- a/tests/Watchers/NotificationWatcherTest.php
+++ b/tests/Watchers/NotificationWatcherTest.php
@@ -29,7 +29,7 @@ class NotificationWatcherTest extends FeatureTestCase
 
     public function test_notification_watcher_registers_array_routes()
     {
-        $this->performNotificationAssertions('mail', ['telescope@laravel.com','nestedroute@laravel.com']);
+        $this->performNotificationAssertions('mail', ['telescope@laravel.com', 'nestedroute@laravel.com']);
     }
 
     private function performNotificationAssertions($channel, $route)


### PR DESCRIPTION
When sending an anonymous notification with a string route, The entries are logged successfully. But when using an array of routes, There is an array to string conversion exception in the notification watcher.

```
// This works well
Notification::route('mail', 'telescope@laravel.com')->notify( new SomeNotification() );

```

```
// This throws an array to string conversion exception
Notification::route('mail', ['telescope@laravel.com'])->notify( new SomeNotification() );
```

![Screenshot from 2019-11-22 21-54-00](https://user-images.githubusercontent.com/10626045/69471942-a5f5be80-0d72-11ea-98e0-01994a6cff81.png)

![Screenshot from 2019-11-22 21-55-15](https://user-images.githubusercontent.com/10626045/69471959-d178a900-0d72-11ea-8a2d-c5339335169e.png)




I have added a test case which verifies working of the new change with array routes.

This is my first time contributing to an open source project. Please guide me in the right direction if i did not follow any standards.