### PR TITLE
Update to 2.1 alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "2.1-dev"
         },
         "laravel": {
             "providers": [


### PR DESCRIPTION
The branch is 2.0, but the last version is 2.1 so I think this needs to be updated?
Otherwise you have to require `2.0-dev` which is a bit weird.

Perhaps a new tag would also be possible?