### PR TITLE
Enable redis events by default if the watcher is enabled

### DIFF
--- a/src/Watchers/RedisWatcher.php
+++ b/src/Watchers/RedisWatcher.php
@@ -17,6 +17,12 @@ class RedisWatcher extends Watcher
     public function register($app)
     {
         $app['events']->listen(CommandExecuted::class, [$this, 'recordCommand']);
+
+        foreach ((array) $app['redis']->connections() as $connection) {
+            $connection->setEventDispatcher($app['events']);
+        }
+
+        $app['redis']->enableEvents();
     }
 
     /**


### PR DESCRIPTION
This fixes the case where a redis connection is already set before calling Redis::enableEvents() in a service provider and also doesn't require people to add Redis::enableEvents() manually.