### PR TITLE
[2.x] Fix Round queries duration to 2 decimal places

### DIFF
--- a/resources/js/components/RelatedEntries.vue
+++ b/resources/js/components/RelatedEntries.vue
@@ -254,7 +254,7 @@
                 <thead>
                 <tr>
                     <th>Query<br/><small>{{ queries.length }} queries, {{ queriesSummary.duplicated }} of which are duplicated.</small></th>
-                    <th>Duration<br/><small>{{ queriesSummary.time }} ms</small></th>
+                    <th>Duration<br/><small>{{ queriesSummary.time }}ms</small></th>
                     <th></th>
                 </tr>
                 </thead>

--- a/resources/js/components/RelatedEntries.vue
+++ b/resources/js/components/RelatedEntries.vue
@@ -137,7 +137,7 @@
 
             queriesSummary() {
                 return {
-                    time: _.reduce(this.queries, (time, q) => { return time + parseFloat(q.content.time) }, 0.00),
+                    time: _.reduce(this.queries, (time, q) => { return time + parseFloat(q.content.time) }, 0.00).toFixed(2),
                     duplicated: this.queries.length - _.size(_.groupBy(this.queries, (q) => { return q.content.hash })),
                 };
             },


### PR DESCRIPTION
Round the queries duration to 2 decimal places.

### Before
![before](https://user-images.githubusercontent.com/11543163/70670027-e52b7700-1c6f-11ea-98df-0fe004483743.png)

### After
![after](https://user-images.githubusercontent.com/11543163/70670026-e52b7700-1c6f-11ea-82be-8ac62cb7e3fa.png)
