### PR TITLE
[2.x] Fix ignore generic listeners as view composer

### DIFF
--- a/src/Watchers/ViewWatcher.php
+++ b/src/Watchers/ViewWatcher.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Telescope\Watchers;
 
+use Closure;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
@@ -118,7 +119,7 @@ class ViewWatcher extends Watcher
                     return Str::contains(get_class($variables['listener'][0]), 'Laravel\\Telescope');
                 }
 
-                return false;
+                return ! $variables['listener'] instanceof Closure;
             })->map(function ($variables) {
                 $closure = new ReflectionFunction($listener = $variables['listener']);
 

--- a/tests/Watchers/ViewWatcherTest.php
+++ b/tests/Watchers/ViewWatcherTest.php
@@ -78,6 +78,5 @@ class GenericListener
 
     public function handle()
     {
-
     }
 }

--- a/tests/Watchers/ViewWatcherTest.php
+++ b/tests/Watchers/ViewWatcherTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Telescope\Tests\Watchers;
 
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\View;
 use Laravel\Telescope\EntryType;
 use Laravel\Telescope\Tests\FeatureTestCase;
@@ -13,6 +14,8 @@ class ViewWatcherTest extends FeatureTestCase
     protected function getEnvironmentSetUp($app)
     {
         parent::getEnvironmentSetUp($app);
+
+        Event::subscribe(GenericListener::class);
 
         View::addNamespace('tests', $this->viewsDirectory);
 
@@ -31,6 +34,7 @@ class ViewWatcherTest extends FeatureTestCase
 
         $entries = $this->loadTelescopeEntries();
 
+        $this->assertCount(3, $entries);
         $this->assertSame(EntryType::VIEW, $entries[0]->type);
         $this->assertSame('tests::welcome', $entries[0]->content['name']);
         $this->assertSame($this->viewsDirectory.'/welcome.blade.php', $entries[0]->content['path']);
@@ -62,5 +66,18 @@ class ViewComposer
     public function compose(\Illuminate\View\View $view)
     {
         $view->with('bar', 'baz');
+    }
+}
+
+class GenericListener
+{
+    public function subscribe($events): void
+    {
+        $events->listen('*', static::class.'@handle');
+    }
+
+    public function handle()
+    {
+
     }
 }


### PR DESCRIPTION
This fixes #793 which would throw a ReflectionException when a non-closure listener is attached to the `composing: ...`, `creating: ...` or `*` event. 
This happens when a listener is attached like: `Event::listen('*', 'MyListener@handle')`

All view composers/creators are wrapped in a closure, see: `Illuminate\View\Concerns\ManagesEvents@addViewEvent`. That means that we can filter out all listeners that are not a closure when fetching the view composers. 

Technically it would be possible though to create a view composer like `Event::listen('composing: layouts.master', 'MyListener@compose')`. But since there is a dedicated `View::composer` method I assume that's the prefered and supported way to register view composers? If we would add support for those non-closure listeners that would also mean that all listeners for the `*` event will be seen as view composer.