### PR TITLE
Make ignoring Laravel Nova paths configurable so Nova apps are debuggable

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -92,7 +92,7 @@ return [
     */
 
     'ignore_paths' => [
-        //
+        'nova-api*',
     ],
 
     'ignore_commands' => [

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -183,7 +183,6 @@ class Telescope
                 'vendor/telescope*',
                 'horizon*',
                 'vendor/horizon*',
-                'nova-api*',
             ], config('telescope.ignore_paths', []))
         );
     }


### PR DESCRIPTION
Make ignoring Laravel Nova paths configurable so Nova apps are debuggable.

Moved 'nova-api*' path from Telescope.php (vendor folder) to telescope.php (user config). This will allow Nova users like me to debug & profile their app via Telescope.
