### PR TITLE
Fix abandoned math package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "require": {
         "php": "^7.1.3",
         "ext-json": "*",
+        "brick/math": "^0.8.8",
         "laravel/framework": "~5.8.0|^6.0|^7.0",
-        "moontoast/math": "^1.1",
         "symfony/var-dumper": "^4.1|^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
Require the ``brick/math`` package instead of the ``moontoast/math`` abandoned package.

The tests will still fail since ``Ramsey/uuid`` doesn't support ``brick/math`` as of now. So this PR can be merged as soon as https://github.com/ramsey/uuid/issues/286 is solved. 

This will fix #807.