### PR TITLE
[2.x] Only log file/line for exception trace

### DIFF
--- a/src/Watchers/ExceptionWatcher.php
+++ b/src/Watchers/ExceptionWatcher.php
@@ -35,7 +35,6 @@ class ExceptionWatcher extends Watcher
             return;
         }
 
-        /** @var \Throwable $exception */
         $exception = $event->context['exception'];
 
         $trace = collect($exception->getTrace())->map(function ($item) {

--- a/src/Watchers/ExceptionWatcher.php
+++ b/src/Watchers/ExceptionWatcher.php
@@ -4,6 +4,7 @@ namespace Laravel\Telescope\Watchers;
 
 use Exception;
 use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Support\Arr;
 use Laravel\Telescope\ExceptionContext;
 use Laravel\Telescope\ExtractTags;
 use Laravel\Telescope\IncomingExceptionEntry;
@@ -34,7 +35,12 @@ class ExceptionWatcher extends Watcher
             return;
         }
 
+        /** @var \Throwable $exception */
         $exception = $event->context['exception'];
+
+        $trace = collect($exception->getTrace())->map(function($item) {
+            return Arr::only($item, ['file', 'line']);
+        })->toArray();
 
         Telescope::recordException(
             IncomingExceptionEntry::make($exception, [
@@ -42,7 +48,7 @@ class ExceptionWatcher extends Watcher
                 'file' => $exception->getFile(),
                 'line' => $exception->getLine(),
                 'message' => $exception->getMessage(),
-                'trace' => $exception->getTrace(),
+                'trace' => $trace,
                 'line_preview' => ExceptionContext::get($exception),
             ])->tags($this->tags($event))
         );

--- a/src/Watchers/ExceptionWatcher.php
+++ b/src/Watchers/ExceptionWatcher.php
@@ -38,7 +38,7 @@ class ExceptionWatcher extends Watcher
         /** @var \Throwable $exception */
         $exception = $event->context['exception'];
 
-        $trace = collect($exception->getTrace())->map(function($item) {
+        $trace = collect($exception->getTrace())->map(function ($item) {
             return Arr::only($item, ['file', 'line']);
         })->toArray();
 


### PR DESCRIPTION
The Stacktrace contains a lot of data sometimes, especially in the `args` part of the Trace. As far as I can tell, these values are not actually used, only `file` and `line` are rendered.
This commit filters the stacktrace to reduce the size of the entries. I've encountered some issues with larger datasets that surpassed the max_allowed_packer from MySQL and thus crashing (the already crashed) app.