### PR TITLE
[2.x] Use Illuminate\Foundation\Application instead of contract

### DIFF
--- a/src/TelescopeApplicationServiceProvider.php
+++ b/src/TelescopeApplicationServiceProvider.php
@@ -8,6 +8,13 @@ use Illuminate\Support\ServiceProvider;
 class TelescopeApplicationServiceProvider extends ServiceProvider
 {
     /**
+     * The application instance.
+     *
+     * @var \Illuminate\Foundation\Application
+     */
+    protected $app;
+
+    /**
      * Bootstrap any application services.
      *
      * @return void


### PR DESCRIPTION
The stub service provider uses `$this->app->isLocal()` and that method exists only on `Illuminate\Foundation\Application`, not the contract.

![Screenshot from 2020-02-01 13-07-55](https://user-images.githubusercontent.com/33033094/73591829-e3559580-44f3-11ea-82a7-ede49ff71738.png)
