### PR TITLE
fix: ReflectionException when used with debugbar.

### DIFF
--- a/src/Watchers/ViewWatcher.php
+++ b/src/Watchers/ViewWatcher.php
@@ -121,6 +121,10 @@ class ViewWatcher extends Watcher
 
                 return ! $variables['listener'] instanceof Closure;
             })->map(function ($variables) {
+                if (is_array($variables['listener'])) {
+                    return;
+                }
+
                 $closure = new ReflectionFunction($listener = $variables['listener']);
 
                 if ($this->isWildcardViewComposer($variables, $closure)) {


### PR DESCRIPTION

I'm not familiar enough to know if there would be any further implications here, though given that a string is expected I can't imagine so... This resolves #824 and all existing tests are still passing.
