### PR TITLE
[2.x] Handle all eval() failures from Laravel Tinker

### DIFF
--- a/src/ExceptionContext.php
+++ b/src/ExceptionContext.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Telescope;
 
+use Illuminate\Support\Str;
 use Throwable;
 
 class ExceptionContext
@@ -13,6 +14,33 @@ class ExceptionContext
      * @return array
      */
     public static function get(Throwable $exception)
+    {
+        return static::getEvalContext($exception) ??
+            static::getFileContext($exception);
+    }
+
+    /**
+     * Get the exception code context when eval() failed.
+     *
+     * @param  \Throwable  $exception
+     * @return array|null
+     */
+    protected static function getEvalContext(Throwable $exception)
+    {
+        if (Str::contains($exception->getFile(), "eval()'d code")) {
+            return [
+                $exception->getLine() => "eval()'d code",
+            ];
+        }
+    }
+
+    /**
+     * Get the exception code context from a file.
+     *
+     * @param  \Throwable  $exception
+     * @return array
+     */
+    protected static function getFileContext(Throwable $exception)
     {
         return collect(explode("\n", file_get_contents($exception->getFile())))
             ->slice($exception->getLine() - 10, 20)

--- a/tests/Watchers/ExceptionWatcherTest.php
+++ b/tests/Watchers/ExceptionWatcherTest.php
@@ -2,11 +2,13 @@
 
 namespace Laravel\Telescope\Tests\Watchers;
 
+use ErrorException;
 use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Laravel\Telescope\EntryType;
 use Laravel\Telescope\Tests\FeatureTestCase;
 use Laravel\Telescope\Watchers\ExceptionWatcher;
+use ParseError;
 
 class ExceptionWatcherTest extends FeatureTestCase
 {
@@ -34,8 +36,35 @@ class ExceptionWatcherTest extends FeatureTestCase
         $this->assertSame(EntryType::EXCEPTION, $entry->type);
         $this->assertSame(BananaException::class, $entry->content['class']);
         $this->assertSame(__FILE__, $entry->content['file']);
-        $this->assertSame(28, $entry->content['line']);
+        $this->assertSame(30, $entry->content['line']);
         $this->assertSame('Something went bananas.', $entry->content['message']);
+        $this->assertArrayHasKey('trace', $entry->content);
+    }
+
+    public function test_exception_watcher_register_entries_when_eval_failed()
+    {
+        $handler = $this->app->get(ExceptionHandler::class);
+
+        $exception = null;
+
+        try {
+            eval('if (');
+
+            $this->fail('eval() was expected to throw "syntax error, unexpected end of file"');
+        } catch (ParseError $e) {
+            // PsySH class ExecutionLoopClosure wraps ParseError in an exception.
+            $exception = new ErrorException($e->getMessage(), $e->getCode(), 1, $e->getFile(), $e->getLine(), $e);
+        }
+
+        $handler->report($exception);
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::EXCEPTION, $entry->type);
+        $this->assertSame(ErrorException::class, $entry->content['class']);
+        $this->assertStringContainsString("eval()'d code", $entry->content['file']);
+        $this->assertSame(1, $entry->content['line']);
+        $this->assertSame('syntax error, unexpected end of file', $entry->content['message']);
         $this->assertArrayHasKey('trace', $entry->content);
     }
 }


### PR DESCRIPTION
With Laravel Telescope and Laravel Tinker enabled in a project, `php artisan tinker` and attempt an expression that _fatally_ fails PHP parsing.

Instead of:

```php
$foo[] = 'bar'`
```

Try typing:

```
foo[] = 'bar'
```

The desired output would be the below exception about the `foo` symbol missing `$`.

> In ExecutionLoopClosure.php(55) : eval()'d code line 1:
> 
> Cannot use temporary expression in write context

Instead the developer is shown an unrelated Laravel Telescope-related stacktrace:

> PHP Warning:  file_get_contents(/home/dev/project/vendor/psy/psysh/src/ExecutionLoopClosure.php(55) : eval()'d code): failed to open stream: No such file or directory in
/home/dev/project/vendor/laravel/telescope/src/ExceptionContext.php on line 45

because the watched `$exception->getFile()` is a human readable string instead of an actual PHP script file path.

This change will show better output by looking for the `eval()` message string: https://github.com/php/php-src/blob/ac0853eb265784c4238af652de9c54c883ffa99f/Zend/zend_execute.c#L4157

Trying the above example in an automated test won't work since the PHPUnit script exits immediately from the `eval()` failure. So I've added a case that best mimics how Laravel Tinker / PsySH treat `eval()` raising `ParseError`.