### PR TITLE
improvement - Added isQuery() in IncomingEntry

### DIFF
--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -192,6 +192,16 @@ class IncomingEntry
     }
 
     /**
+     * Determine if the incoming entry is a query.
+     *
+     * @return bool
+     */
+    public function isQuery()
+    {
+        return $this->type === EntryType::QUERY;
+    }    
+
+    /**
      * Determine if the incoming entry is a failed job.
      *
      * @return bool
@@ -240,16 +250,6 @@ class IncomingEntry
     public function isScheduledTask()
     {
         return $this->type === EntryType::SCHEDULED_TASK;
-    }
-
-    /**
-     * Determine if the incoming entry is a query.
-     *
-     * @return bool
-     */
-    public function isQuery()
-    {
-        return $this->type === EntryType::QUERY;
     }
 
     /**

--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -243,6 +243,16 @@ class IncomingEntry
     }
 
     /**
+     * Determine if the incoming entry is a query.
+     *
+     * @return bool
+     */
+    public function isQuery()
+    {
+        return $this->type === EntryType::QUERY;
+    }
+
+    /**
      * Get the family look-up hash for the incoming entry.
      *
      * @return string|null


### PR DESCRIPTION
I've added a simple isQuery() function to the IncomingEntry class, in order to log all database queries in addition to the default (non-local env) checks in the Telescope filter:

- isReportableException()
- isFailedRequest()
- isFailedJob()
- isScheduledTask()
- hasMonitorTag()
