### PR TITLE
Update to ramsey/uuid ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.2",
         "ext-json": "*",
         "laravel/framework": "^6.0|^7.0",
-        "moontoast/math": "^1.1",
+        "ramsey/uuid": "^4.0",
         "symfony/var-dumper": "^4.4|^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Updated abandoned moontoast/math lib to ramsey/uuid ^4.0 (required in Laravel), since ^4.0 version now requires brick/math.