### PR TITLE
Switch to brick/math

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
+        "brick/math": "^0.8.14",
         "laravel/framework": "^6.0|^7.0",
-        "moontoast/math": "^1.1",
         "symfony/var-dumper": "^4.4|^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
Package `moontoast/math` is abandoned. This PR switched to suggested replacement `brick/math`.

