### PR TITLE
[4.x] Drop Laravel 6 support and replace moontoast/math

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.2, 7.3, 7.4]
-        laravel: [^6.0, ^7.0]
+        laravel: [^7.0]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "laravel/framework": "^6.0|^7.0",
+        "laravel/framework": "^7.0",
         "moontoast/math": "^1.1",
-        "symfony/var-dumper": "^4.4|^5.0"
+        "symfony/var-dumper": "^5.0"
     },
     "require-dev": {
         "ext-gd": "*",
-        "orchestra/testbench": "^4.0|^5.0"
+        "orchestra/testbench": "^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
+        "brick/math": "^0.8.14",
         "laravel/framework": "^7.0",
-        "moontoast/math": "^1.1",
         "symfony/var-dumper": "^5.0"
     },
     "require-dev": {

--- a/resources/js/base.js
+++ b/resources/js/base.js
@@ -17,7 +17,7 @@ export default {
                 relativeTime: {
                     future: 'in %s',
                     past: '%s ago',
-                    s: number => number + 's ago',
+                    s: (number) => number + 's ago',
                     ss: '%ds ago',
                     m: '1m ago',
                     mm: '%dm ago',
@@ -68,7 +68,7 @@ export default {
         /**
          * Creates a debounced function that delays invoking a callback.
          */
-        debouncer: _.debounce(callback => callback(), 500),
+        debouncer: _.debounce((callback) => callback(), 500),
 
         /**
          * Show an error message.


### PR DESCRIPTION
So we can finally get rid of the warnings in Composer.

Closes https://github.com/laravel/telescope/issues/815