### PR TITLE
[4.x] Remove brick math

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "brick/math": "^0.8.14",
         "laravel/framework": "^7.0",
         "symfony/var-dumper": "^5.0"
     },


### PR DESCRIPTION
This dependency isn't actually needed and will come with ramsey/uuid v4