### PR TITLE
[3.x] Testing fixes

### DIFF
--- a/resources/js/base.js
+++ b/resources/js/base.js
@@ -17,7 +17,7 @@ export default {
                 relativeTime: {
                     future: 'in %s',
                     past: '%s ago',
-                    s: number => number + 's ago',
+                    s: (number) => number + 's ago',
                     ss: '%ds ago',
                     m: '1m ago',
                     mm: '%dm ago',
@@ -68,7 +68,7 @@ export default {
         /**
          * Creates a debounced function that delays invoking a callback.
          */
-        debouncer: _.debounce(callback => callback(), 500),
+        debouncer: _.debounce((callback) => callback(), 500),
 
         /**
          * Show an error message.

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
+use Illuminate\Support\Testing\Fakes\EventFake;
 use Laravel\Telescope\Contracts\EntriesRepository;
 use Laravel\Telescope\Contracts\TerminableRepository;
 use RuntimeException;
@@ -235,7 +236,7 @@ class Telescope
      */
     public static function isRecording()
     {
-        return static::$shouldRecord;
+        return static::$shouldRecord && ! app('events') instanceof EventFake;
     }
 
     /**

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -35,18 +35,18 @@ class QueryWatcher extends Watcher
 
         $time = $event->time;
 
-        $caller = $this->getCallerFromStackTrace();
-
-        Telescope::recordQuery(IncomingEntry::make([
-            'connection' => $event->connectionName,
-            'bindings' => [],
-            'sql' => $this->replaceBindings($event),
-            'time' => number_format($time, 2),
-            'slow' => isset($this->options['slow']) && $time >= $this->options['slow'],
-            'file' => $caller['file'],
-            'line' => $caller['line'],
-            'hash' => $this->familyHash($event),
-        ])->tags($this->tags($event)));
+        if ($caller = $this->getCallerFromStackTrace()) {
+            Telescope::recordQuery(IncomingEntry::make([
+                'connection' => $event->connectionName,
+                'bindings' => [],
+                'sql' => $this->replaceBindings($event),
+                'time' => number_format($time, 2),
+                'slow' => isset($this->options['slow']) && $time >= $this->options['slow'],
+                'file' => $caller['file'],
+                'line' => $caller['line'],
+                'hash' => $this->familyHash($event),
+            ])->tags($this->tags($event)));
+        }
     }
 
     /**


### PR DESCRIPTION
This PR provides some fixes when running Telescope during testing.

For example, it's not always certain that the debug backtrace will send back a result so we should check for a value before recording it.

And Telescope should be disabled when a test is faking events since Telescope heavily relies on the usage of events.

Fixes https://github.com/laravel/telescope/issues/573