### PR TITLE
[3.x] Pass IncomingEntry in AfterRecordingHook

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -270,7 +270,7 @@ class Telescope
             }
 
             if (static::$afterRecordingHook) {
-                call_user_func(static::$afterRecordingHook, new static);
+                call_user_func(static::$afterRecordingHook, $entry);
             }
         });
     }

--- a/tests/Telescope/TelescopeTest.php
+++ b/tests/Telescope/TelescopeTest.php
@@ -5,6 +5,7 @@ namespace Laravel\Telescope\Tests\Telescope;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Laravel\Telescope\Contracts\EntriesRepository;
+use Laravel\Telescope\IncomingEntry;
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\Tests\FeatureTestCase;
 use Laravel\Telescope\Watchers\QueryWatcher;
@@ -37,7 +38,7 @@ class TelescopeTest extends FeatureTestCase
      */
     public function run_after_recording_callback()
     {
-        Telescope::afterRecording(function () {
+        Telescope::afterRecording(function (IncomingEntry $entry) {
             $this->count++;
         });
 
@@ -53,10 +54,10 @@ class TelescopeTest extends FeatureTestCase
      */
     public function after_recording_callback_can_store_and_flush()
     {
-        Telescope::afterRecording(function (Telescope $telescope) {
-            if (count($telescope::$entriesQueue) > 1) {
+        Telescope::afterRecording(function (IncomingEntry $entry) {
+            if (count(Telescope::$entriesQueue) > 1) {
                 $repository = $this->app->make(EntriesRepository::class);
-                $telescope->store($repository);
+                Telescope::store($repository);
             }
         });
 


### PR DESCRIPTION
As discussed in #862, the wrong parameter is passed in this event, it should be the model itself, `IncomingEntry`.
I fixed it and fixed the test that used the previous implementation.

BTW, do you think this hook should be documented in the official [documentation](https://laravel.com/docs/7.x/telescope)?