### PR TITLE
[3.x] Encode array for logging

### DIFF
--- a/src/Watchers/RedisWatcher.php
+++ b/src/Watchers/RedisWatcher.php
@@ -56,6 +56,10 @@ class RedisWatcher extends Watcher
         $parameters = collect($parameters)->map(function ($parameter) {
             if (is_array($parameter)) {
                 return collect($parameter)->map(function ($value, $key) {
+                    if (is_array($value)) {
+                        return json_encode($value);
+                    }
+
                     return is_int($key) ? $value : "{$key} {$value}";
                 })->implode(' ');
             }


### PR DESCRIPTION
Fixes an issue where the RedisWatcher crashed if it tried to log commands which have an array as value. It now properly formats the array to a string using `json_encode`:

<img width="975" alt="Screenshot 2020-04-14 at 15 10 00" src="https://user-images.githubusercontent.com/594614/79228659-1c9a7200-7e62-11ea-8618-71b51ca86f7f.png">

Fixes https://github.com/laravel/telescope/issues/845