### PR TITLE
[3.x] Remove thousands separator in time records (#876)

### DIFF
--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -40,7 +40,7 @@ class QueryWatcher extends Watcher
                 'connection' => $event->connectionName,
                 'bindings' => [],
                 'sql' => $this->replaceBindings($event),
-                'time' => number_format($time, 2),
+                'time' => number_format($time, 2, '.', ''),
                 'slow' => isset($this->options['slow']) && $time >= $this->options['slow'],
                 'file' => $caller['file'],
                 'line' => $caller['line'],

--- a/src/Watchers/RedisWatcher.php
+++ b/src/Watchers/RedisWatcher.php
@@ -40,7 +40,7 @@ class RedisWatcher extends Watcher
         Telescope::recordRedis(IncomingEntry::make([
             'connection' => $event->connectionName,
             'command' => $this->formatCommand($event->command, $event->parameters),
-            'time' => number_format($event->time, 2),
+            'time' => number_format($event->time, 2, '.', ''),
         ]));
     }
 


### PR DESCRIPTION
This overrides the default thousands separator in the PHP `number_format` function used to format the time entries. This allows requests that take over 1s/1000ms to be summed up correctly.

For a query with a running time of 1.2s, the current time entry in the database will be `1,200.00`. When this is passed to `parseFloat` in the front end it will be parsed as `1`.
With the change, the value will be stored as `1200.00` and correctly parsed as `1200`.
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
