### PR TITLE
[3.x] Add index to created_at

### DIFF
--- a/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -44,14 +44,16 @@ class CreateTelescopeEntriesTable extends Migration
             $table->bigIncrements('sequence');
             $table->uuid('uuid');
             $table->uuid('batch_id');
-            $table->string('family_hash')->nullable()->index();
+            $table->string('family_hash')->nullable();
             $table->boolean('should_display_on_index')->default(true);
             $table->string('type', 20);
             $table->longText('content');
-            $table->dateTime('created_at')->nullable()->index();
+            $table->dateTime('created_at')->nullable();
 
             $table->unique('uuid');
             $table->index('batch_id');
+            $table->index('family_hash');
+            $table->index('created_at');
             $table->index(['type', 'should_display_on_index']);
         });
 

--- a/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -48,7 +48,7 @@ class CreateTelescopeEntriesTable extends Migration
             $table->boolean('should_display_on_index')->default(true);
             $table->string('type', 20);
             $table->longText('content');
-            $table->dateTime('created_at')->nullable();
+            $table->dateTime('created_at')->nullable()->index();
 
             $table->unique('uuid');
             $table->index('batch_id');


### PR DESCRIPTION
When the `telescope_entries` table gets very large, `telescope:prune` will fail miserably, actually bringing an AWS db instance to its knees. This is because `telescope:prune` is using `created_at` in a where clause when there's no index on that column.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
