### PR TITLE
[3.x] changed truncate from 75 chars to 50

### DIFF
--- a/resources/js/screens/logs/index.vue
+++ b/resources/js/screens/logs/index.vue
@@ -18,7 +18,7 @@
         </tr>
 
         <template slot="row" slot-scope="slotProps">
-            <td :title="slotProps.entry.content.message">{{truncate(slotProps.entry.content.message, 75)}}</td>
+            <td :title="slotProps.entry.content.message">{{truncate(slotProps.entry.content.message, 50)}}</td>
 
             <td class="table-fit">
                 <span class="badge font-weight-light" :class="'badge-'+logLevelClass(slotProps.entry.content.level)">


### PR DESCRIPTION
This should fit better on screen and fix Issue #886 which I reported.
As shown in the screenshot below, this alters the layout slightly when something goes to the 75 chars set on the `truncate` method.

<img width="1048" alt="Screenshot 2020-05-05 at 08 46 09" src="https://user-images.githubusercontent.com/1168291/81045038-4f59e800-8ead-11ea-98da-4facec0797db.png">


