### PR TITLE
[3.x] Allow avatar path customization

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -82,6 +82,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Telescope Avatar Service
+    |--------------------------------------------------------------------------
+    |
+    | This option may be used to control how to show an avatar for authorized
+    | users. 'gravatar' will lookup an avatar by the user's email address.
+    | 'custom' requires registering a callback via Telescope::avatar().
+    |
+    */
+
+    'avatar_driver' => 'gravatar',
+
+    /*
+    |--------------------------------------------------------------------------
     | Ignored Paths & Commands
     |--------------------------------------------------------------------------
     |

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
         "jquery": "^3.5",
         "laravel-mix": "^4.0.7",
         "lodash": "^4.17.13",
-        "md5": "^2.2.1",
         "moment": "^2.10.6",
         "moment-timezone": "^0.5.21",
         "popper.js": "^1.12",

--- a/resources/js/components/PreviewScreen.vue
+++ b/resources/js/components/PreviewScreen.vue
@@ -63,13 +63,6 @@
             command() {
                 return _.find(this.batch, {type: 'command'})
             },
-
-            gravatarUrl() {
-                if (this.entry.content.user.email) {
-                    const md5 = require('md5')
-                    return 'https://www.gravatar.com/avatar/' + md5(this.entry.content.user.email.toLowerCase()) + '?s=200'
-                }
-            }
         },
 
 
@@ -242,7 +235,7 @@
                     <td class="table-fit font-weight-bold align-middle">Name</td>
 
                     <td class="align-middle">
-                        <img :src="gravatarUrl" class="mr-2 rounded-circle" height="40" width="40" v-if="gravatarUrl">
+                        <img :src="entry.content.user.avatar" :alt="entry.content.user.name" class="mr-2 rounded-circle" height="40" width="40" v-if="entry.content.user.avatar">
                         {{entry.content.user.name}}
                     </td>
                 </tr>

--- a/src/Avatar.php
+++ b/src/Avatar.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Laravel\Telescope;
+
+use Closure;
+use Illuminate\Support\Str;
+
+class Avatar
+{
+    /**
+     * The callback that should be used to get the Telescope user avatar.
+     *
+     * @var \Closure
+     */
+    protected static $callback;
+
+    /**
+     * Get an avatar URL for an entry user.
+     *
+     * @param  array       $user User payload from the EntryResult.
+     * @return string|null
+     */
+    public static function url(array $user)
+    {
+        if (empty($user['email'])) {
+            return;
+        }
+
+        switch (config('telescope.avatar_driver', 'gravatar')) {
+            case 'custom':
+                return static::resolve($user);
+            case 'gravatar':
+                $hash = md5(Str::lower($user['email']));
+
+                return "https://www.gravatar.com/avatar/{$hash}?s=200";
+            default:
+                break;
+        }
+    }
+
+    /**
+     * Register the Telescope user avatar callback.
+     *
+     * @param  \Closure  $callback
+     */
+    public static function register(Closure $callback)
+    {
+        static::$callback = $callback;
+    }
+
+    /**
+     * Find the custom avatar for a user.
+     *
+     * @param  array       $user
+     * @return string|null
+     */
+    protected static function resolve($user)
+    {
+        if (static::$callback !== null) {
+            return call_user_func(static::$callback, $user['id'], $user['email']);
+        }
+    }
+}

--- a/src/EntryResult.php
+++ b/src/EntryResult.php
@@ -63,6 +63,13 @@ class EntryResult implements JsonSerializable
     private $tags;
 
     /**
+     * The generated URL to the entry user's avatar.
+     *
+     * @var string
+     */
+    protected $avatar;
+
+    /**
      * Create a new entry result instance.
      *
      * @param  mixed  $id
@@ -87,13 +94,25 @@ class EntryResult implements JsonSerializable
     }
 
     /**
+     * Set the URL to the entry user's avatar.
+     *
+     * @return $this
+     */
+    public function generateAvatar()
+    {
+        $this->avatar = Avatar::url($this->content['user'] ?? []);
+
+        return $this;
+    }
+
+    /**
      * Get the array representation of the entry.
      *
      * @return array
      */
     public function jsonSerialize()
     {
-        return [
+        return collect([
             'id' => $this->id,
             'sequence' => $this->sequence,
             'batch_id' => $this->batchId,
@@ -102,6 +121,14 @@ class EntryResult implements JsonSerializable
             'tags' => $this->tags,
             'family_hash' => $this->familyHash,
             'created_at' => $this->createdAt->toDateTimeString(),
-        ];
+        ])->when($this->avatar, function ($items) {
+            return $items->mergeRecursive([
+                'content' => [
+                    'user' => [
+                        'avatar' => $this->avatar,
+                    ],
+                ],
+            ]);
+        })->all();
     }
 }

--- a/src/Http/Controllers/EntryController.php
+++ b/src/Http/Controllers/EntryController.php
@@ -50,7 +50,7 @@ abstract class EntryController extends Controller
      */
     public function show(EntriesRepository $storage, $id)
     {
-        $entry = $storage->find($id);
+        $entry = $storage->find($id)->generateAvatar();
 
         return response()->json([
             'entry' => $entry,

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -685,6 +685,18 @@ class Telescope
     }
 
     /**
+     * Register the Telescope user avatar callback.
+     *
+     * @param  \Closure  $callback
+     */
+    public static function avatar(Closure $callback)
+    {
+        if (config('telescope.avatar_driver') === 'custom') {
+            Avatar::register($callback);
+        }
+    }
+
+    /**
      * Get the default JavaScript variables for Telescope.
      *
      * @return array

--- a/stubs/TelescopeServiceProvider.stub
+++ b/stubs/TelescopeServiceProvider.stub
@@ -31,6 +31,10 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
                    $entry->isScheduledTask() ||
                    $entry->hasMonitoredTag();
         });
+
+        Telescope::avatar(function ($id, $email) {
+            //
+        });
     }
 
     /**

--- a/tests/Http/AvatarTest.php
+++ b/tests/Http/AvatarTest.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace Laravel\Telescope\Tests\Http;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Telescope\Http\Middleware\Authorize;
+use Laravel\Telescope\Telescope;
+use Laravel\Telescope\Tests\FeatureTestCase;
+use Laravel\Telescope\Watchers\LogWatcher;
+use Psr\Log\LoggerInterface;
+
+class AvatarTest extends FeatureTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutMiddleware(Authorize::class);
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app->get('config')->set('logging.default', 'syslog');
+
+        $app->get('config')->set('telescope.watchers', [
+            LogWatcher::class => true,
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_register_custom_avatar_path()
+    {
+        $user = null;
+
+        Telescope::withoutRecording(function () use (&$user) {
+            $this->loadLaravelMigrations();
+
+            $user = UserEloquent::create([
+                'id' => 1,
+                'name' => 'Telescope',
+                'email' => 'telescope@laravel.com',
+                'password' => 'secret',
+            ]);
+        });
+
+        $this->app->get('config')->set('telescope.avatar_driver', 'custom');
+
+        Telescope::avatar(function ($id) {
+            return "/images/{$id}.jpg";
+        });
+
+        $this->actingAs($user);
+
+        $this->app->get(LoggerInterface::class)->error('Avatar path will be generated.', [
+            'exception' => 'Some error message',
+        ]);
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->get("/telescope/telescope-api/logs/{$entry->uuid}")
+            ->assertOk()
+            ->assertJson([
+                'entry' => [
+                    'content' => [
+                        'user' => [
+                            'avatar' => '/images/1.jpg',
+                        ],
+                    ],
+                ],
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_not_register_custom_avatar_path_when_not_configured()
+    {
+        $user = null;
+
+        Telescope::withoutRecording(function () use (&$user) {
+            $this->loadLaravelMigrations();
+
+            $user = UserEloquent::create([
+                'id' => 1,
+                'name' => 'Telescope',
+                'email' => 'telescope@laravel.com',
+                'password' => 'secret',
+            ]);
+        });
+
+        Telescope::avatar(function ($id) {
+            return "/images/{$id}.jpg";
+        });
+
+        $this->actingAs($user);
+
+        $this->app->get(LoggerInterface::class)->error('Avatar path will default to Gravatar.', [
+            'exception' => 'Some error message',
+        ]);
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->get("/telescope/telescope-api/logs/{$entry->uuid}")
+            ->assertOk()
+            ->assertJson([
+                'entry' => [
+                    'content' => [
+                        'user' => [
+                            'avatar' => 'https://www.gravatar.com/avatar/dac001a0dfeebe3b320cefa9f3a7d813?s=200',
+                        ],
+                    ],
+                ],
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_not_set_avatar_path_when_the_configuration_is_empty()
+    {
+        $user = null;
+
+        Telescope::withoutRecording(function () use (&$user) {
+            $this->loadLaravelMigrations();
+
+            $user = UserEloquent::create([
+                'id' => 1,
+                'name' => 'Telescope',
+                'email' => 'telescope@laravel.com',
+                'password' => 'secret',
+            ]);
+        });
+
+        $this->app->get('config')->set('telescope.avatar_driver', '');
+
+        Telescope::avatar(function ($id) {
+            return "/images/{$id}.jpg";
+        });
+
+        $this->actingAs($user);
+
+        $this->app->get(LoggerInterface::class)->error('Avatar path will not be generated.', [
+            'exception' => 'Some error message',
+        ]);
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $json = $this->get("/telescope/telescope-api/logs/{$entry->uuid}")
+            ->assertOk()
+            ->json();
+
+        $this->assertArrayNotHasKey('avatar', $json['entry']['content']['user']);
+    }
+}
+
+class UserEloquent extends Model implements Authenticatable
+{
+    protected $table = 'users';
+
+    protected $guarded = [];
+
+    public function getAuthIdentifierName()
+    {
+        return $this->email;
+    }
+
+    public function getAuthIdentifier()
+    {
+        return $this->id;
+    }
+
+    public function getAuthPassword()
+    {
+        return $this->password;
+    }
+
+    public function getRememberToken()
+    {
+        return 'i-am-telescope';
+    }
+
+    public function setRememberToken($value)
+    {
+        //
+    }
+
+    public function getRememberTokenName()
+    {
+        //
+    }
+}


### PR DESCRIPTION
Covers: https://github.com/laravel/telescope/issues/742

### Features

✔️ Apps can disable Gravatar and stop telling its parent Automattic about user activity on /telescope requests.
✔️ Existing apps still use Gravatar when the new `config('telescope.avatar_driver')` key is not defined so this a non-breaking change for a point release.
✔️ Apps can now show local avatars taken from your own image hosting rather than using a remote service.

### Configuration

```php
namespace App\Providers;

// ...

class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
{
    public function register()
    {
        // ...

        Telescope::avatar(function ($id) {
            $user = User::find($id);

            return url("/assets/images/users/{$user->avatar_path}");
        });
    }

    // ...
}
```
`config('telescope.avatar_driver')` options:

1. `'gravatar'` is the default
2. `'custom'` allows you to choose a URL path local to your application by registering a `Telescope::avatar()` callback.
3. Empty `''` (or any random string) will hide avatars in the UI and not call Gravatar's API.

### Remote Service Example

To switch from Gravatar to [Libravatar](https://wiki.libravatar.org/api/):

```php
Telescope::avatar(function ($id, $email) {
    $hash = md5(Str::lower($email));

    return vsprintf('https://seccdn.libravatar.org/avatar/%s?s=200&d=%s', [
        $hash,
        urlencode(url('/assets/image/avatar-placeholder.png')),
    ]);
});
```

### Implementation

The avatar URL is generated in PHP, only for JSON routes `GET /telescope/telescope-api/{type}/{telescopeEntryId}` for a preview of a single entry. i.e., this will not generate N+1 database queries when viewing a list of Telescope entries.