### PR TITLE
[3.x] Add entry to afterRecording hook

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -270,7 +270,7 @@ class Telescope
             }
 
             if (static::$afterRecordingHook) {
-                call_user_func(static::$afterRecordingHook, new static);
+                call_user_func(static::$afterRecordingHook, new static, $entry);
             }
         });
     }


### PR DESCRIPTION
As stated in https://github.com/laravel/telescope/pull/867
The entry is not always available in the queue, because it's not always recorded (due to filters).

When adding it as a new param, it shouldn't break BC and you can access the Entry.