### PR TITLE
[3.x] Add request IP address to RequestWatcher

### DIFF
--- a/resources/js/screens/requests/preview.vue
+++ b/resources/js/screens/requests/preview.vue
@@ -58,6 +58,13 @@
         </tr>
 
         <tr>
+            <td class="table-fit font-weight-bold">IP Address</td>
+            <td>
+                {{slotProps.entry.content.ip_address || '-'}}
+            </td>
+        </tr>
+
+        <tr>
             <td class="table-fit font-weight-bold">Memory usage</td>
             <td>
                 {{slotProps.entry.content.memory || '-'}} MB

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -53,6 +53,7 @@ class RequestWatcher extends Watcher
             'response_status' => $event->response->getStatusCode(),
             'response' => $this->response($event->response),
             'duration' => $startTime ? floor((microtime(true) - $startTime) * 1000) : null,
+            'ip_address' => $event->request->ip(),
             'memory' => round(memory_get_peak_usage(true) / 1024 / 1025, 1),
         ]));
     }


### PR DESCRIPTION
Addresses #629 and #812 

**Feature**
Adds the request IP Address to request details, did not think it should be added to the index view.

<img width="549" alt="Screen Shot 2020-05-12 at 11 52 31 PM" src="https://user-images.githubusercontent.com/10642932/81769695-48823500-94ac-11ea-9abb-0593818e3537.png">
