### PR TITLE
Clean up unused moontoast/math dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "php": "^7.2",
         "ext-json": "*",
         "laravel/framework": "^6.0|^7.0",
-        "moontoast/math": "^1.1",
         "symfony/var-dumper": "^4.4|^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
AFAICS, `moontoast/math` is not used anymore in this project.
This is confirmed by all tests passing.