### PR TITLE
telescope:prune support for cockroachdb

### DIFF
--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -338,12 +338,14 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
     public function prune(DateTimeInterface $before)
     {
         $query = $this->table('telescope_entries')
-                ->where('created_at', '<', $before);
+                ->select('uuid')
+                ->where('created_at', '<', $before)
+                ->take($this->chunkSize);
 
         $totalDeleted = 0;
 
         do {
-            $deleted = $query->take($this->chunkSize)->delete();
+            $deleted = DB::table('telescope_entries')->whereIn('uuid', $query)->delete();
 
             $totalDeleted += $deleted;
         } while ($deleted !== 0);


### PR DESCRIPTION
Hi guy,

postgresql using ctid as an internal column since https://github.com/laravel/framework/pull/29393

some other DB also using postgres wire but do not explicit have ctid column (internally).

when rewrite sql this way, we can also support cockroachdb and this should not cause much perf impact.
