### PR TITLE
Fixed frontend to work in subpath

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -20,7 +20,7 @@ window.Popper = require('popper.js').default;
 
 moment.tz.setDefault(Telescope.timezone);
 
-window.Telescope.basePath = '/' + window.Telescope.path;
+window.Telescope.basePath = window.Telescope.path;
 
 let routerBasePath = window.Telescope.basePath + '/';
 

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -729,7 +729,7 @@ class Telescope
     public static function scriptVariables()
     {
         return [
-            'path' => config('telescope.path'),
+            'path' => parse_url(route('telescope'), PHP_URL_PATH) ?? '/',
             'timezone' => config('app.timezone'),
             'recording' => ! cache('telescope:pause-recording'),
         ];


### PR DESCRIPTION
This pull request solve the route problem in frontend when is served in a subpath.
Currently, the frontend try call from root + `config('telescope.path')`, but the correct need respect current base_path.

Example: 
URL base: `http://localhost/laravel/test`
The original request try call `http://localhost/telescope-api/....`
With this path: call `localhost/laravel/test/telescope-api/....`