### PR TITLE
[3.x] Change text for Marking Exceptions as Resolved

### DIFF
--- a/resources/js/screens/exceptions/preview.vue
+++ b/resources/js/screens/exceptions/preview.vue
@@ -21,8 +21,8 @@
                     && this.entry.content.context !== null;
             },
 
-            resolveException(entry) {
-                this.alertConfirm('Are you sure you want to resolve this exception?', () => {
+            markExceptionAsResolved(entry) {
+                this.alertConfirm('Are you sure you want to mark this exception as resolved?', () => {
 
                     axios.put(Telescope.basePath + '/telescope-api/exceptions/' + entry.id, {
                         'resolved_at': 'now',
@@ -69,7 +69,7 @@
                         {{localTime(entry.content.resolved_at)}} ({{timeAgo(entry.content.resolved_at)}})
                     </span>
                     <span v-if="!entry.content.resolved_at">
-                        <a href="#" class="badge badge-success mr-1 font-weight-light" v-on:click.prevent="resolveException(entry)">Resolve now</a>
+                        <a href="#" class="badge badge-success mr-1 font-weight-light" v-on:click.prevent="markExceptionAsResolved(entry)">Mark As Resolved</a>
                     </span>
                 </td>
             </tr>


### PR DESCRIPTION
Following up on pull request #710. I think although exceptions are marked as resolved the message isn't clear to the user. For once I thought Laravel Telescope would itself 'automagically' resolve the exception for me since that's what the message suggested (Resolve now). This change is to indicate to users that exceptions aren't resolved by Laravel Telescope but marked as resolved, so they have to go resolve the exception themselves and mark as resolved on Laravel Telescope which is the intention of pull request #710