### PR TITLE
[3.x] Add explicit base font family fallback

### DIFF
--- a/resources/sass/app-dark.scss
+++ b/resources/sass/app-dark.scss
@@ -1,4 +1,5 @@
-$font-family-base: Nunito;
+$font-family-base: Nunito, sans-serif;
+
 $font-size-base: 0.95rem;
 $badge-font-size: 0.95rem;
 

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -1,4 +1,4 @@
-$font-family-base: Nunito;
+$font-family-base: Nunito, sans-serif;
 
 $font-size-base: 0.95rem;
 $badge-font-size: 0.95rem;


### PR DESCRIPTION
On a network/browser that blocks Google Fonts (for any reason), custom base font `Nunito` will fail to load and the dashboard may end up looking ugly. Screesnhot:

![Screenshot from 2020-07-25 02-33-26](https://user-images.githubusercontent.com/6129517/88451806-79250a00-ce1f-11ea-92fd-0787ce5ffa5b.png)

With the fallback to `sans-serif`: 

![Screenshot from 2020-07-25 02-34-00](https://user-images.githubusercontent.com/6129517/88451825-8fcb6100-ce1f-11ea-9929-109c86af0d6a.png)

