### PR TITLE
[3.x] Checked query parameters before send to sqlFormatter. fixes #919

### DIFF
--- a/resources/js/screens/queries/preview.vue
+++ b/resources/js/screens/queries/preview.vue
@@ -14,9 +14,15 @@
 
         methods:{
             formatSQL(sql, params) {
-                return sqlFormatter.format(sql, {
-                    params: _.map(params, param => _.isString(param) ? '"'+param+'"' : param)
-                });
+                return sqlFormatter.format(sql, this.prepareParams(params));
+            },
+
+            prepareParams(params) {
+                if (!_.isEmpty(params)) {
+                    return {
+                        params: _.map(params, param => _.isString(param) ? '"'+param+'"' : param)
+                    };
+                }
             },
 
             highlightSQL() {

--- a/resources/js/screens/queries/preview.vue
+++ b/resources/js/screens/queries/preview.vue
@@ -1,5 +1,4 @@
 <script type="text/ecmascript-6">
-    import _ from 'lodash';
     import sqlFormatter from "sql-formatter";
     import hljs from 'highlight.js/lib/highlight';
     import sql from 'highlight.js/lib/languages/sql';
@@ -13,16 +12,8 @@
         },
 
         methods:{
-            formatSQL(sql, params) {
-                return sqlFormatter.format(sql, this.prepareParams(params));
-            },
-
-            prepareParams(params) {
-                if (!_.isEmpty(params)) {
-                    return {
-                        params: _.map(params, param => _.isString(param) ? '"'+param+'"' : param)
-                    };
-                }
+            formatSQL(sql) {
+                return sqlFormatter.format(sql);
             },
 
             highlightSQL() {
@@ -70,7 +61,7 @@
             <div class="card mt-5">
                 <div class="card-header"><h5>Query</h5></div>
 
-                <pre class="code-bg p-4 mb-0 text-white" ref="sqlcode">{{formatSQL(slotProps.entry.content.sql, slotProps.entry.content.bindings)}}</pre>
+                <pre class="code-bg p-4 mb-0 text-white" ref="sqlcode">{{formatSQL(slotProps.entry.content.sql)}}</pre>
             </div>
         </div>
     </preview-screen>


### PR DESCRIPTION
**This pull request fixes sql formatter that shows mysql variables as undefined.**

For this query `\DB::select('select @user_id := id as id from users');` telescope query page shows like this:

<img width="379" alt="image" src="https://user-images.githubusercontent.com/5646041/88549900-8b729400-d029-11ea-967f-fdcd2e90d49e.png">

With this pr you can see mysql variables like image below:
<img width="339" alt="image" src="https://user-images.githubusercontent.com/5646041/88550531-6af70980-d02a-11ea-8a8e-b8c53dbbdadd.png">

For fixing this issue i have checked if params exists before send to sqlFormatter.

You may see related conversation here. https://github.com/laravel/telescope/issues/919

Fixes #919