### PR TITLE
[3.x] Remove problematic unused code when formatting SQL

### DIFF
--- a/resources/js/screens/queries/preview.vue
+++ b/resources/js/screens/queries/preview.vue
@@ -1,24 +1,16 @@
 <script type="text/ecmascript-6">
-    import _ from 'lodash';
-    import sqlFormatter from "sql-formatter";
     import hljs from 'highlight.js/lib/highlight';
     import sql from 'highlight.js/lib/languages/sql';
+    import StandardSqlFormatter from 'sql-formatter/src/languages/StandardSqlFormatter';
 
     export default {
         data(){
             return {
-                entry: null,
-                batch: [],
+                sqlFormatter: new StandardSqlFormatter({}),
             };
         },
 
         methods:{
-            formatSQL(sql, params) {
-                return sqlFormatter.format(sql, {
-                    params: _.map(params, param => _.isString(param) ? '"'+param+'"' : param)
-                });
-            },
-
             highlightSQL() {
                 this.$nextTick(() => {
                     hljs.registerLanguage('sql', sql);
@@ -64,7 +56,7 @@
             <div class="card mt-5">
                 <div class="card-header"><h5>Query</h5></div>
 
-                <pre class="code-bg p-4 mb-0 text-white" ref="sqlcode">{{formatSQL(slotProps.entry.content.sql, slotProps.entry.content.bindings)}}</pre>
+                <pre class="code-bg p-4 mb-0 text-white" ref="sqlcode">{{sqlFormatter.format(slotProps.entry.content.sql)}}</pre>
             </div>
         </div>
     </preview-screen>


### PR DESCRIPTION
Fixes: https://github.com/laravel/telescope/issues/919
Replaces pull request https://github.com/laravel/telescope/pull/923 as per [Dries' request](https://github.com/laravel/telescope/pull/923#discussion_r461064565)

Formatted SQL preview:

![before](https://user-images.githubusercontent.com/823566/88581033-8fe38080-d01a-11ea-9e43-b3dfe9dfae26.png)

which should be:

![after](https://user-images.githubusercontent.com/823566/88581045-92de7100-d01a-11ea-9213-f3cde44baa37.png)

Telescope's `QueryWatcher` always stores an empty array for query parameter bindings.

https://github.com/laravel/telescope/blob/f5dee9aa18f4ec426130676bd1e50dac79ec91e4/src/Watchers/QueryWatcher.php#L39-L41

This causes an issue in NPM package `sql-formatter` when the query has MySQL session variables referenced with an `'@'` character. Using the generic SQL:2011 dialect, it's treated like a named placeholder (e.g., for MS SQL Server.)

```javascript
sqlFormatter.format('select @user_id := id as id from users', {params: []});
// select
//   undefined: = id as id
// from
//   users
```

This expects a named options parameter as if `@user_id` is referenced within a `WHERE` clause, e.g., `{params: {user_id: 1}}` Missing a named binding value, JavaScript `undefined` is instead filled in.

Excluding the `params` option will stop the package from attempting to fill the placeholder.

```javascript
sqlFormatter.format('select @user_id := id as id from users');
// select
//   @user_id: = id as id
// from
//   users
```

### `<query-preview>` cleanup

1. stop passing the bindings empty array to the `.format()` method since the argument is _never_ used.
   * `slotProps.entry.content.bindings` returned by the API endpoint is always `[]`
   * should that QueryWatcher.php `'bindings' => []` line also be removed? Does the JSON payload need that when PDO parameters are replaced before database insertion?
     * The change was from https://github.com/laravel/telescope/pull/706/files#diff-fa8840834f665959fe3cfa98a78adadcR42 so I think that line has been redundant since Telescope v2.1 (Sept 3, 2019)
2. Instead of referencing the generic wrapper `sqlFormatter.format()` [public API](https://github.com/zeroturnaround/sql-formatter/blob/master/src/sqlFormatter.js#L29), pull in the exact `StandardSqlFormatter` implementation. ES6 classes `Db2Formatter`, `N1qlFormatter`, & `PlSqlFormatter` are also being unnecessarily bundled into Telescope's app.js. This shrinks the production file 813kb to 796kb. There's definitely more room for perf improvement here. e.g.,
   * remove `/**!` NPM package comments
   * remove bootstrap.js components Telescope doesn't use like Carousel
3. remove unused Vue component props `entry` & `batch` since query data is accessed via a slotted scope.