### PR TITLE
fix:May be written to an empty log

### DIFF
--- a/src/Watchers/LogWatcher.php
+++ b/src/Watchers/LogWatcher.php
@@ -36,7 +36,7 @@ class LogWatcher extends Watcher
         Telescope::recordLog(
             IncomingEntry::make([
                 'level' => $event->level,
-                'message' => $event->message,
+                'message' => (string)$event->message,
                 'context' => Arr::except($event->context, ['telescope']),
             ])->tags($this->tags($event))
         );

--- a/src/Watchers/LogWatcher.php
+++ b/src/Watchers/LogWatcher.php
@@ -36,7 +36,7 @@ class LogWatcher extends Watcher
         Telescope::recordLog(
             IncomingEntry::make([
                 'level' => $event->level,
-                'message' => (string)$event->message,
+                'message' => (string) $event->message,
                 'context' => Arr::except($event->context, ['telescope']),
             ])->tags($this->tags($event))
         );


### PR DESCRIPTION
why ?
```
$th = new \Exception("test string log");
\Log::error($th);
```

This code can normally write to the laravel journal file.

But logs in telepope are null