### PR TITLE
Improve assertions

### DIFF
--- a/tests/Telescope/TelescopeTest.php
+++ b/tests/Telescope/TelescopeTest.php
@@ -98,7 +98,7 @@ class TelescopeTest extends FeatureTestCase
         Telescope::store($repository);
 
         $this->assertSame(2, $this->count);
-        $this->assertSame(2, count($storedEntries));
+        $this->assertCount(2, $storedEntries);
         $this->assertSame(36, strlen($storedBatchId));
         $this->assertInstanceOf(IncomingEntry::class, $storedEntries[0]);
     }

--- a/tests/Watchers/MailWatcherTest.php
+++ b/tests/Watchers/MailWatcherTest.php
@@ -34,7 +34,7 @@ class MailWatcherTest extends FeatureTestCase
 
         $this->assertSame(EntryType::MAIL, $entry->type);
         $this->assertEmpty($entry->content['mailable']);
-        $this->assertSame(false, $entry->content['queued']);
+        $this->assertFalse($entry->content['queued']);
         $this->assertSame(['from@laravel.com'], array_keys($entry->content['from']));
         $this->assertSame(['to@laravel.com'], array_keys($entry->content['to']));
         $this->assertSame(['cc1@laravel.com', 'cc2@laravel.com'], array_keys($entry->content['cc']));

--- a/tests/Watchers/NotificationWatcherTest.php
+++ b/tests/Watchers/NotificationWatcherTest.php
@@ -41,7 +41,7 @@ class NotificationWatcherTest extends FeatureTestCase
 
         $this->assertSame(EntryType::NOTIFICATION, $entry->type);
         $this->assertSame(BoomerangNotification::class, $entry->content['notification']);
-        $this->assertSame(false, $entry->content['queued']);
+        $this->assertFalse($entry->content['queued']);
         $this->assertStringContainsString(is_array($route) ? implode(',', $route) : $route, $entry->content['notifiable']);
         $this->assertSame($channel, $entry->content['channel']);
         $this->assertNull($entry->content['response']);


### PR DESCRIPTION
# Changed log

- Using the `assertFale` to assert expected and result are `false`.
- Using the `assertCount` to assert result length is same as expected count.