### PR TITLE
[4.x] Make event watcher compatible with Laravel 8 subscriber syntax

### DIFF
--- a/src/Watchers/EventWatcher.php
+++ b/src/Watchers/EventWatcher.php
@@ -88,7 +88,9 @@ class EventWatcher extends Watcher
                 if (is_string($listener)) {
                     return Str::contains($listener, '@') ? $listener : $listener.'@handle';
                 } elseif (is_array($listener)) {
-                    return get_class($listener[0]).'@'.$listener[1];
+                    $class = is_object($listener[0]) ? get_class($listener[0]) : $listener[0];
+
+                    return $class.'@'.$listener[1];
                 }
 
                 return $this->formatClosureListener($listener);

--- a/tests/Watchers/EventWatcherTest.php
+++ b/tests/Watchers/EventWatcherTest.php
@@ -55,6 +55,39 @@ class EventWatcherTest extends FeatureTestCase
         $this->assertContains('PHP', $entry->content['payload']['data']);
     }
 
+
+    public function test_event_watcher_registers_events_and_stores_payloads_with_subscriber_methods()
+    {
+        Event::listen(DummyEvent::class, DummyEventSubscriber::class.'@handleDummyEvent');
+
+        event(new DummyEvent('Telescope', 'Laravel', 'PHP'));
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::EVENT, $entry->type);
+        $this->assertSame(DummyEvent::class, $entry->content['name']);
+        $this->assertArrayHasKey('data', $entry->content['payload']);
+        $this->assertContains('Telescope', $entry->content['payload']['data']);
+        $this->assertContains('Laravel', $entry->content['payload']['data']);
+        $this->assertContains('PHP', $entry->content['payload']['data']);
+    }
+    
+    public function test_event_watcher_registers_events_and_stores_payloads_with_subscriber_classes()
+    {
+        Event::listen(DummyEvent::class, [DummyEventSubscriber::class, 'handleDummyEvent']);
+
+        event(new DummyEvent('Telescope', 'Laravel', 'PHP'));
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::EVENT, $entry->type);
+        $this->assertSame(DummyEvent::class, $entry->content['name']);
+        $this->assertArrayHasKey('data', $entry->content['payload']);
+        $this->assertContains('Telescope', $entry->content['payload']['data']);
+        $this->assertContains('Laravel', $entry->content['payload']['data']);
+        $this->assertContains('PHP', $entry->content['payload']['data']);
+    }
+
     public function test_event_watcher_ignore_event()
     {
         event(new IgnoredEvent());
@@ -75,6 +108,14 @@ class DummyEvent
     }
 
     public function handle()
+    {
+        //
+    }
+}
+
+class DummyEventSubscriber
+{
+    public function handleDummyEvent($event)
     {
         //
     }

--- a/tests/Watchers/EventWatcherTest.php
+++ b/tests/Watchers/EventWatcherTest.php
@@ -55,7 +55,6 @@ class EventWatcherTest extends FeatureTestCase
         $this->assertContains('PHP', $entry->content['payload']['data']);
     }
 
-
     public function test_event_watcher_registers_events_and_stores_payloads_with_subscriber_methods()
     {
         Event::listen(DummyEvent::class, DummyEventSubscriber::class.'@handleDummyEvent');
@@ -71,7 +70,7 @@ class EventWatcherTest extends FeatureTestCase
         $this->assertContains('Laravel', $entry->content['payload']['data']);
         $this->assertContains('PHP', $entry->content['payload']['data']);
     }
-    
+
     public function test_event_watcher_registers_events_and_stores_payloads_with_subscriber_classes()
     {
         Event::listen(DummyEvent::class, [DummyEventSubscriber::class, 'handleDummyEvent']);


### PR DESCRIPTION
Fixes https://github.com/laravel/telescope/issues/952