### PR TITLE
3.x Feature: Be able to specify only allowed paths

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -82,6 +82,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Allowed Paths
+    |--------------------------------------------------------------------------
+    |
+    | The following array lists the URI paths be watched by Telescope.
+    | NOTE: Specifying any paths in this list
+    |       ignores all paths specified in 'ignore_paths' below.
+    |
+    */
+
+    'only_allow_paths' => [
+        // 'api/*'
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Ignored Paths & Commands
     |--------------------------------------------------------------------------
     |

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -186,7 +186,17 @@ class Telescope
      */
     protected static function handlingApprovedRequest($app)
     {
-        return ! $app->runningInConsole() && ! $app['request']->is(
+        if ($app->runningInConsole()) {
+            return false;
+        }
+
+        // Prioritize only_allow_paths if any are specified
+        $onlyAllowed = config('telescope.only_allow_paths', []);
+        if (! empty($onlyAllowed)) {
+            return $app['request']->is($onlyAllowed);
+        }
+
+        return ! $app['request']->is(
             array_merge([
                 config('telescope.path').'*',
                 'telescope-api*',


### PR DESCRIPTION
Non-breaking changes. (For version 3.x)

Only start recording on the given paths if any are specified
Reason: It is a hassel if you only want to monitor a single path.

Example: Great for only monitoring api requests in production eg.:

    'only_allow_paths' => [
        'api/*'
    ],
If none are specified then it falls back to checking ignore_paths which is still the default.