### PR TITLE
[4.x] Determine if the incoming entry is a request, added isRequest() filter

### DIFF
--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -212,6 +212,16 @@ class IncomingEntry
         return $this->type === EntryType::JOB &&
                ($this->content['status'] ?? null) === 'failed';
     }
+    
+    /**
+     * Determine if the incoming entry is a request.
+     *
+     * @return bool
+     */
+    public function isRequest()
+    {
+        return $this->type === EntryType::REQUEST;
+    }
 
     /**
      * Determine if the incoming entry is a reportable exception.

--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -212,7 +212,7 @@ class IncomingEntry
         return $this->type === EntryType::JOB &&
                ($this->content['status'] ?? null) === 'failed';
     }
-    
+
     /**
      * Determine if the incoming entry is a request.
      *


### PR DESCRIPTION

This will allow us to filter the entries of type 'request' in the register method in TelescopeServiceProvider