### PR TITLE
[4.x] Determine if the incoming entry is a request, added isRequest() filter

### DIFF
--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -182,6 +182,16 @@ class IncomingEntry
     }
 
     /**
+     * Determine if the incoming entry is a request.
+     *
+     * @return bool
+     */
+    public function isRequest()
+    {
+        return $this->type === EntryType::REQUEST;
+    }
+
+    /**
      * Determine if the incoming entry is a failed request.
      *
      * @return bool
@@ -190,16 +200,6 @@ class IncomingEntry
     {
         return $this->type === EntryType::REQUEST &&
             ($this->content['response_status'] ?? 200) >= 500;
-    }
-
-    /**
-     * Determine if the incoming entry is a request.
-     *
-     * @return bool
-     */
-    public function isRequest()
-    {
-        return $this->type === EntryType::REQUEST;
     }
 
     /**

--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -193,6 +193,16 @@ class IncomingEntry
     }
 
     /**
+     * Determine if the incoming entry is a request.
+     *
+     * @return bool
+     */
+    public function isRequest()
+    {
+        return $this->type === EntryType::REQUEST;
+    }
+
+    /**
      * Determine if the incoming entry is a query.
      *
      * @return bool


### PR DESCRIPTION
This will allow us to filter the entries of type 'request' in the register method in TelescopeServiceProvider