### PR TITLE
Add primary keys to database tables

### DIFF
--- a/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -61,6 +61,7 @@ class CreateTelescopeEntriesTable extends Migration
             $table->uuid('entry_uuid');
             $table->string('tag');
 
+            $table->primary(['entry_uuid', 'tag']);
             $table->index(['entry_uuid', 'tag']);
             $table->index('tag');
 
@@ -72,6 +73,8 @@ class CreateTelescopeEntriesTable extends Migration
 
         $this->schema->create('telescope_monitoring', function (Blueprint $table) {
             $table->string('tag');
+
+            $table->primary('tag');
         });
     }
 


### PR DESCRIPTION
It is considered good practice to always set a primary key for improved performance. As such, some managed databases, like [DigitalOcean, requires the definition of a primary key](https://www.digitalocean.com/docs/databases/mysql/how-to/create-primary-keys/) on each table in every new MySQL database. However, Telescope doesn't have any primary key for the following tables:

- `telescope_entries_tags`
- `telescope_monitoring`

Thus using Telescope in projects using a managed database like DigitalOcean is impossible.

This pull request adds the missing primary keys without affecting the tables' structure (i.e., no additional columns are added).

Fixing #534 Issue