### PR TITLE
[4.x] Updated db command for clearing tables

### DIFF
--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -358,8 +358,8 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
      */
     public function clear()
     {
-        $this->table('telescope_entries')->delete();
-        $this->table('telescope_monitoring')->delete();
+        $this->table('telescope_entries')->truncate();
+        $this->table('telescope_monitoring')->truncate();
     }
 
     /**


### PR DESCRIPTION
Hello, while clearing the db tables the `delete` statement being used is significantly slower than `truncate`. 

The logs the `delete` keeps are useless since these tables contain only debugging info and not essential data.

While using `telescope:clear` it takes very much time for several million records whilst manually executing `truncate` takes a couple of seconds for about the same amount of records. Also it consumes fewer server resources. I think the statement should be changed from `delete` to `truncate`.

[Truncate Statement](https://dev.mysql.com/doc/refman/8.0/en/truncate-table.html)
[Truncate vs Delete](https://stackoverflow.com/questions/20559893/comparison-of-truncate-vs-delete-in-mysql-sqlserver)