### PR TITLE
[4.x] Support JSON queries on telescope entries

### DIFF
--- a/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -47,7 +47,7 @@ class CreateTelescopeEntriesTable extends Migration
             $table->string('family_hash')->nullable();
             $table->boolean('should_display_on_index')->default(true);
             $table->string('type', 20);
-            $table->longText('content');
+            $table->json('content');
             $table->dateTime('created_at')->nullable();
 
             $table->unique('uuid');


### PR DESCRIPTION
Currently, Telescope uses the longText column type for content. However, databases such as PostgreSQL do not support JSON queries (with the `->` notation in Laravel) unless the data type is JSON. A simple use case is grouping the content by line number and file for slow queries, to see where the slowest queries appear in the code.

Moreover, even for databases like mysql, the native JSON type is more efficient for json queries, even though they are also supported on the text data type.