### PR TITLE
[4.x] Add Model Hydration Watcher

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -1,6 +1,7 @@
 <?php
 
 use Laravel\Telescope\Http\Middleware\Authorize;
+use Laravel\Telescope\Storage\EntryModel;
 use Laravel\Telescope\Watchers;
 
 return [
@@ -138,6 +139,11 @@ return [
         Watchers\ModelWatcher::class => [
             'enabled' => env('TELESCOPE_MODEL_WATCHER', true),
             'events' => ['eloquent.*'],
+        ],
+
+        Watchers\ModelHydrationWatcher::class => [
+            'enabled' => env('TELESCOPE_MODEL_HYDRATION_WATCHER', true),
+            'ignore' => [EntryModel::class],
         ],
 
         Watchers\NotificationWatcher::class => env('TELESCOPE_NOTIFICATION_WATCHER', true),

--- a/resources/js/components/RelatedEntries.vue
+++ b/resources/js/components/RelatedEntries.vue
@@ -50,6 +50,8 @@
                     this.currentTab = 'queries'
                 } else if (this.models.length) {
                     this.currentTab = 'models'
+                } else if (this.hydrations.length) {
+                    this.currentTab = 'hydrations'
                 } else if (this.jobs.length) {
                     this.currentTab = 'jobs'
                 } else if (this.mails.length) {
@@ -107,6 +109,10 @@
                 return _.filter(this.batch, {type: 'model'});
             },
 
+            hydrations() {
+                return _.filter(this.batch, {type: 'hydration'});
+            },
+
             jobs() {
                 return _.filter(this.batch, {type: 'job'});
             },
@@ -149,6 +155,7 @@
                     {title: "Views", type: "views", count: this.views.length},
                     {title: "Queries", type: "queries", count: this.queries.length},
                     {title: "Models", type: "models", count: this.models.length},
+                    {title: "Hydrations", type: "hydrations", count: this.hydrations.length},
                     {title: "Gates", type: "gates", count: this.gates.length},
                     {title: "Jobs", type: "jobs", count: this.jobs.length},
                     {title: "Mail", type: "mails", count: this.mails.length},
@@ -304,6 +311,36 @@
 
                     <td class="table-fit">
                         <router-link :to="{name:'model-preview', params:{id: entry.id}}" class="control-action">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 16">
+                                <path d="M16.56 13.66a8 8 0 0 1-11.32 0L.3 8.7a1 1 0 0 1 0-1.42l4.95-4.95a8 8 0 0 1 11.32 0l4.95 4.95a1 1 0 0 1 0 1.42l-4.95 4.95-.01.01zm-9.9-1.42a6 6 0 0 0 8.48 0L19.38 8l-4.24-4.24a6 6 0 0 0-8.48 0L2.4 8l4.25 4.24h.01zM10.9 12a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"></path>
+                            </svg>
+                        </router-link>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+
+            <!-- Related Model Hydrations -->
+            <table class="table table-hover table-sm mb-0" v-show="currentTab=='hydrations' && hydrations.length">
+                <thead>
+                <tr>
+                    <th>Model</th>
+                    <th>Hydrations</th>
+                    <th></th>
+                </tr>
+                </thead>
+
+                <tbody>
+                <tr v-for="entry in hydrations">
+                    <td :title="entry.content.model">{{truncate(entry.content.model, 100)}}</td>
+                    <td class="table-fit">
+                        <span class="badge font-weight-light">
+                            {{entry.content.count}}
+                        </span>
+                    </td>
+
+                    <td class="table-fit">
+                        <router-link :to="{name:'hydration-preview', params:{id: entry.id}}" class="control-action">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 16">
                                 <path d="M16.56 13.66a8 8 0 0 1-11.32 0L.3 8.7a1 1 0 0 1 0-1.42l4.95-4.95a8 8 0 0 1 11.32 0l4.95 4.95a1 1 0 0 1 0 1.42l-4.95 4.95-.01.01zm-9.9-1.42a6 6 0 0 0 8.48 0L19.38 8l-4.24-4.24a6 6 0 0 0-8.48 0L2.4 8l4.25 4.24h.01zM10.9 12a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"></path>
                             </svg>

--- a/resources/js/routes.js
+++ b/resources/js/routes.js
@@ -128,6 +128,18 @@ export default [
     },
 
     {
+        path: '/hydrations/:id',
+        name: 'hydration-preview',
+        component: require('./screens/hydrations/preview').default,
+    },
+
+    {
+        path: '/hydrations',
+        name: 'hydrations',
+        component: require('./screens/hydrations/index').default,
+    },
+
+    {
         path: '/requests/:id',
         name: 'request-preview',
         component: require('./screens/requests/preview').default,

--- a/resources/js/screens/hydrations/index.vue
+++ b/resources/js/screens/hydrations/index.vue
@@ -1,0 +1,43 @@
+<script type="text/ecmascript-6">
+    import StylesMixin from './../../mixins/entriesStyles';
+
+    export default {
+        mixins: [
+            StylesMixin,
+        ],
+    }
+</script>
+
+<template>
+    <index-screen title="Model Hydrations" resource="hydrations">
+        <tr slot="table-header">
+            <th scope="col">Model</th>
+            <th scope="col">Hydrations</th>
+            <th scope="col">Happened</th>
+            <th scope="col"></th>
+        </tr>
+
+
+        <template slot="row" slot-scope="slotProps">
+            <td>{{truncate(slotProps.entry.content.model, 70)}}</td>
+
+            <td class="table-fit">
+                <span class="badge font-weight-light">
+                    {{slotProps.entry.content.count}}
+                </span>
+            </td>
+
+            <td class="table-fit" :data-timeago="slotProps.entry.created_at" :title="slotProps.entry.created_at">
+                {{timeAgo(slotProps.entry.created_at)}}
+            </td>
+
+            <td class="table-fit">
+                <router-link :to="{name:'hydration-preview', params:{id: slotProps.entry.id}}" class="control-action">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 16">
+                        <path d="M16.56 13.66a8 8 0 0 1-11.32 0L.3 8.7a1 1 0 0 1 0-1.42l4.95-4.95a8 8 0 0 1 11.32 0l4.95 4.95a1 1 0 0 1 0 1.42l-4.95 4.95-.01.01zm-9.9-1.42a6 6 0 0 0 8.48 0L19.38 8l-4.24-4.24a6 6 0 0 0-8.48 0L2.4 8l4.25 4.24h.01zM10.9 12a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"></path>
+                    </svg>
+                </router-link>
+            </td>
+        </template>
+    </index-screen>
+</template>

--- a/resources/js/screens/hydrations/preview.vue
+++ b/resources/js/screens/hydrations/preview.vue
@@ -1,0 +1,40 @@
+<script type="text/ecmascript-6">
+    import _ from 'lodash';
+    import StylesMixin from './../../mixins/entriesStyles';
+
+    export default {
+        mixins: [
+            StylesMixin,
+        ],
+
+
+        data(){
+            return {
+                entry: null,
+                batch: [],
+            };
+        },
+    }
+</script>
+
+<template>
+    <preview-screen title="Model Action" resource="hydrations" :id="$route.params.id">
+        <template slot="table-parameters" slot-scope="slotProps">
+            <tr>
+                <td class="table-fit font-weight-bold">Model</td>
+                <td>
+                    {{slotProps.entry.content.model}}
+                </td>
+            </tr>
+
+            <tr>
+                <td class="table-fit font-weight-bold">Hydrations</td>
+                <td>
+                    <span class="badge font-weight-light">
+                        {{slotProps.entry.content.count}}
+                    </span>
+                </td>
+            </tr>
+        </template>
+    </preview-screen>
+</template>

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -166,6 +166,14 @@
                         </router-link>
                     </li>
                     <li class="nav-item">
+                        <router-link active-class="active" to="/hydrations" class="nav-link d-flex align-items-center">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+                                <path d="M3 1h4c1.1045695 0 2 .8954305 2 2v4c0 1.1045695-.8954305 2-2 2H3c-1.1045695 0-2-.8954305-2-2V3c0-1.1045695.8954305-2 2-2zm0 2v4h4V3H3zm10-2h4c1.1045695 0 2 .8954305 2 2v4c0 1.1045695-.8954305 2-2 2h-4c-1.1045695 0-2-.8954305-2-2V3c0-1.1045695.8954305-2 2-2zm0 2v4h4V3h-4zM3 11h4c1.1045695 0 2 .8954305 2 2v4c0 1.1045695-.8954305 2-2 2H3c-1.1045695 0-2-.8954305-2-2v-4c0-1.1045695.8954305-2 2-2zm0 2v4h4v-4H3zm10-2h4c1.1045695 0 2 .8954305 2 2v4c0 1.1045695-.8954305 2-2 2h-4c-1.1045695 0-2-.8954305-2-2v-4c0-1.1045695.8954305-2 2-2zm0 2v4h4v-4h-4z"></path>
+                            </svg>
+                            <span>Model Hydrations</span>
+                        </router-link>
+                    </li>
+                    <li class="nav-item">
                         <router-link active-class="active" to="/notifications" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
                                 <path d="M3 6c0-1.1.9-2 2-2h8l4-4h2v16h-2l-4-4H5a2 2 0 0 1-2-2H1V6h2zm8 9v5H8l-1.67-5H5v-2h8v2h-2z"></path>

--- a/src/EntryType.php
+++ b/src/EntryType.php
@@ -14,6 +14,7 @@ class EntryType
     public const LOG = 'log';
     public const MAIL = 'mail';
     public const MODEL = 'model';
+    public const HYDRATION = 'hydration';
     public const NOTIFICATION = 'notification';
     public const QUERY = 'query';
     public const REDIS = 'redis';

--- a/src/Http/Controllers/ModelHydrationsController.php
+++ b/src/Http/Controllers/ModelHydrationsController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Laravel\Telescope\Http\Controllers;
+
+use Laravel\Telescope\EntryType;
+use Laravel\Telescope\Watchers\ModelHydrationWatcher;
+
+class ModelHydrationsController extends EntryController
+{
+    /**
+     * The entry type for the controller.
+     *
+     * @return string
+     */
+    protected function entryType()
+    {
+        return EntryType::HYDRATION;
+    }
+
+    /**
+     * The watcher class for the controller.
+     *
+     * @return string
+     */
+    protected function watcher()
+    {
+        return ModelHydrationWatcher::class;
+    }
+}

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -52,6 +52,10 @@ Route::get('/telescope-api/queries/{telescopeEntryId}', 'QueriesController@show'
 Route::post('/telescope-api/models', 'ModelsController@index');
 Route::get('/telescope-api/models/{telescopeEntryId}', 'ModelsController@show');
 
+// Model hydration entries...
+Route::post('/telescope-api/hydrations', 'ModelHydrationsController@index');
+Route::get('/telescope-api/hydrations/{telescopeEntryId}', 'ModelHydrationsController@show');
+
 // Requests entries...
 Route::post('/telescope-api/requests', 'RequestsController@index');
 Route::get('/telescope-api/requests/{telescopeEntryId}', 'RequestsController@show');

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -441,6 +441,17 @@ class Telescope
      * @param  \Laravel\Telescope\IncomingEntry  $entry
      * @return void
      */
+    public static function recordHydrationEvent(IncomingEntry $entry)
+    {
+        static::record(EntryType::HYDRATION, $entry);
+    }
+
+    /**
+     * Record the given entry.
+     *
+     * @param  \Laravel\Telescope\IncomingEntry  $entry
+     * @return void
+     */
     public static function recordModelEvent(IncomingEntry $entry)
     {
         static::record(EntryType::MODEL, $entry);

--- a/src/Watchers/ModelHydrationWatcher.php
+++ b/src/Watchers/ModelHydrationWatcher.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Laravel\Telescope\Watchers;
+
+use Laravel\Telescope\IncomingEntry;
+use Laravel\Telescope\Storage\EntryModel;
+use Laravel\Telescope\Telescope;
+
+class ModelHydrationWatcher extends Watcher
+{
+    /**
+     * Telescope entries to store the count of models retrieved.
+     *
+     * @var array
+     */
+    public $modelEntries = [];
+
+    /**
+     * Register the watcher.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return void
+     */
+    public function register($app)
+    {
+        $app['events']->listen('eloquent.retrieved*', [$this, 'recordAction']);
+
+        Telescope::afterStoring(function () {
+            $this->flush();
+        });
+    }
+
+    /**
+     * Record an action.
+     *
+     * @param  string  $event
+     * @param  array  $data
+     * @return void
+     */
+    public function recordAction($event, $data)
+    {
+        if (! Telescope::isRecording() || ! $this->shouldRecord($modelClass = get_class($data[0]))) {
+            return;
+        }
+
+        if (! isset($this->modelEntries[$modelClass])) {
+            $this->modelEntries[$modelClass] = IncomingEntry::make([
+                'model' => $modelClass,
+                'count' => 1,
+            ])->tags([$modelClass]);
+
+            Telescope::recordHydrationEvent($this->modelEntries[$modelClass]);
+        } else {
+            $this->modelEntries[$modelClass]->content['count']++;
+        }
+    }
+
+    /**
+     * Flush the cached entries.
+     *
+     * @return void
+     */
+    public function flush()
+    {
+        $this->modelEntries = [];
+    }
+
+    /**
+     * Determine if the hydration should be recorded for the model class.
+     *
+     * @param  string  $modelClass
+     * @return bool
+     */
+    private function shouldRecord($modelClass)
+    {
+        return collect($this->options['ignore'] ?? [EntryModel::class])
+            ->every(function ($class) use ($modelClass) {
+                return $modelClass !== $class && ! is_subclass_of($modelClass, $class);
+            });
+    }
+}

--- a/tests/FeatureTestCase.php
+++ b/tests/FeatureTestCase.php
@@ -29,11 +29,13 @@ class FeatureTestCase extends TestCase
         }
 
         Telescope::flushEntries();
+        Telescope::$afterStoringHooks = [];
     }
 
     protected function tearDown(): void
     {
         Telescope::flushEntries();
+        Telescope::$afterStoringHooks = [];
 
         Queue::createPayloadUsing(null);
 

--- a/tests/Watchers/ModelHydrationWatcherTest.php
+++ b/tests/Watchers/ModelHydrationWatcherTest.php
@@ -57,4 +57,3 @@ class TestUser extends Model
 
     protected $guarded = [];
 }
-

--- a/tests/Watchers/ModelHydrationWatcherTest.php
+++ b/tests/Watchers/ModelHydrationWatcherTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Laravel\Telescope\Tests\Watchers;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use Laravel\Telescope\EntryType;
+use Laravel\Telescope\Telescope;
+use Laravel\Telescope\Tests\FeatureTestCase;
+use Laravel\Telescope\Watchers\ModelHydrationWatcher;
+
+class ModelHydrationWatcherTest extends FeatureTestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app->get('config')->set('telescope.watchers', [
+            ModelHydrationWatcher::class => true,
+        ]);
+    }
+
+    public function test_model_hydration_watcher_registers_entry()
+    {
+        Telescope::withoutRecording(function () {
+            $this->loadLaravelMigrations();
+        });
+
+        $this->createUser();
+        $this->createUser();
+        $this->createUser();
+
+        TestUser::all();
+        Telescope::stopRecording();
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::HYDRATION, $entry->type);
+        $this->assertSame(3, $entry->content['count']);
+        $this->assertSame(TestUser::class, $entry->content['model']);
+        $this->assertCount(1, $this->loadTelescopeEntries());
+    }
+
+    protected function createUser()
+    {
+        TestUser::create([
+            'name' => 'Telescope',
+            'email' => Str::random(),
+            'password' => 1,
+        ]);
+    }
+}
+
+class TestUser extends Model
+{
+    protected $table = 'users';
+
+    protected $guarded = [];
+}
+


### PR DESCRIPTION
### Motivation
While debugging, it is very useful to know how many models are being hydrated for a request - something that can have a significant on performance / memory usage. So, I've added a model hydration watcher that records the number of models hydrated for each model. Inspired from a similar popular feature of Debugbar: https://github.com/barryvdh/laravel-debugbar/pull/947

### Index Screen
![hydrations](https://user-images.githubusercontent.com/16099046/101981358-48d8ed80-3c92-11eb-87e4-d9cf273ce443.png)

### Preview Screen
![hydrations-preview](https://user-images.githubusercontent.com/16099046/101981360-4f676500-3c92-11eb-80c7-44c89dea2d95.png)

### Related Entries
![hydrations-related-entries](https://user-images.githubusercontent.com/16099046/101981367-57bfa000-3c92-11eb-8d88-7c9735677bbf.png)

### Note
This PR would need a re-build and I haven't committed the compiled files (just the source) as per the contribution guidelines.