### PR TITLE
[4.x] Add model hydrations to model watcher

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -138,6 +138,7 @@ return [
         Watchers\ModelWatcher::class => [
             'enabled' => env('TELESCOPE_MODEL_WATCHER', true),
             'events' => ['eloquent.*'],
+            'hydrations' => true,
         ],
 
         Watchers\NotificationWatcher::class => env('TELESCOPE_NOTIFICATION_WATCHER', true),

--- a/resources/js/mixins/entriesStyles.js
+++ b/resources/js/mixins/entriesStyles.js
@@ -37,6 +37,7 @@ export default {
         modelActionClass(action) {
             if (action == 'created') return 'success';
             if (action == 'updated') return 'info';
+            if (action == 'retrieved') return 'secondary';
             if (action == 'deleted' || action == 'forceDeleted') return 'danger';
         },
 

--- a/resources/js/screens/models/preview.vue
+++ b/resources/js/screens/models/preview.vue
@@ -35,8 +35,9 @@
                     </span>
                 </td>
             </tr>
+
             <tr v-if="slotProps.entry.content.count">
-                <td class="table-fit font-weight-bold">Hydrations</td>
+                <td class="table-fit font-weight-bold">Hydrated</td>
                 <td>
                     {{slotProps.entry.content.count}}
                 </td>

--- a/resources/js/screens/models/preview.vue
+++ b/resources/js/screens/models/preview.vue
@@ -35,6 +35,12 @@
                     </span>
                 </td>
             </tr>
+            <tr v-if="slotProps.entry.content.count">
+                <td class="table-fit font-weight-bold">Hydrations</td>
+                <td>
+                    {{slotProps.entry.content.count}}
+                </td>
+            </tr>
         </template>
 
         <div slot="after-attributes-card" slot-scope="slotProps">

--- a/src/Watchers/ModelWatcher.php
+++ b/src/Watchers/ModelWatcher.php
@@ -45,7 +45,7 @@ class ModelWatcher extends Watcher
             return;
         }
 
-        if (Str::is('*retrieved*', $event) && ($this->options['hydrations'] ?? false)) {
+        if (Str::is('*retrieved*', $event)) {
             $this->recordHydrations($data);
 
             return;
@@ -70,7 +70,8 @@ class ModelWatcher extends Watcher
      */
     public function recordHydrations($data)
     {
-        if (! $this->shouldRecordHydration($modelClass = get_class($data[0]))) {
+        if (! ($this->options['hydrations'] ?? false)
+            || ! $this->shouldRecordHydration($modelClass = get_class($data[0]))) {
             return;
         }
 

--- a/src/Watchers/ModelWatcher.php
+++ b/src/Watchers/ModelWatcher.php
@@ -74,7 +74,7 @@ class ModelWatcher extends Watcher
             return;
         }
 
-       if (! isset($this->hydrationEntries[$modelClass])) {
+        if (! isset($this->hydrationEntries[$modelClass])) {
             $this->hydrationEntries[$modelClass] = IncomingEntry::make([
                 'action' => 'retrieved',
                 'model' => $modelClass,

--- a/src/Watchers/ModelWatcher.php
+++ b/src/Watchers/ModelWatcher.php
@@ -5,10 +5,18 @@ namespace Laravel\Telescope\Watchers;
 use Illuminate\Support\Str;
 use Laravel\Telescope\FormatModel;
 use Laravel\Telescope\IncomingEntry;
+use Laravel\Telescope\Storage\EntryModel;
 use Laravel\Telescope\Telescope;
 
 class ModelWatcher extends Watcher
 {
+    /**
+     * Telescope entries to store the count model hydrations.
+     *
+     * @var array
+     */
+    public $hydrationEntries = [];
+
     /**
      * Register the watcher.
      *
@@ -18,6 +26,10 @@ class ModelWatcher extends Watcher
     public function register($app)
     {
         $app['events']->listen($this->options['events'] ?? 'eloquent.*', [$this, 'recordAction']);
+
+        Telescope::afterStoring(function () {
+            $this->flush();
+        });
     }
 
     /**
@@ -33,6 +45,12 @@ class ModelWatcher extends Watcher
             return;
         }
 
+        if (Str::is('*retrieved*', $event) && ($this->options['hydrations'] ?? false)) {
+            $this->recordHydrations($data);
+
+            return;
+        }
+
         $model = FormatModel::given($data[0]);
 
         $changes = $data[0]->getChanges();
@@ -42,6 +60,41 @@ class ModelWatcher extends Watcher
             'model' => $model,
             'changes' => empty($changes) ? null : $changes,
         ]))->tags([$model]));
+    }
+
+    /**
+     * Record model hydrations.
+     *
+     * @param  array  $data
+     * @return void
+     */
+    public function recordHydrations($data)
+    {
+        if (! $this->shouldRecordHydration($modelClass = get_class($data[0]))) {
+            return;
+        }
+
+       if (! isset($this->hydrationEntries[$modelClass])) {
+            $this->hydrationEntries[$modelClass] = IncomingEntry::make([
+                'action' => 'retrieved',
+                'model' => $modelClass,
+                'count' => 1,
+            ])->tags([$modelClass]);
+
+            Telescope::recordModelEvent($this->hydrationEntries[$modelClass]);
+        } else {
+            $this->hydrationEntries[$modelClass]->content['count']++;
+        }
+    }
+
+    /**
+     * Flush the cached entries.
+     *
+     * @return void
+     */
+    public function flush()
+    {
+        $this->hydrationEntries = [];
     }
 
     /**
@@ -66,7 +119,21 @@ class ModelWatcher extends Watcher
     private function shouldRecord($eventName)
     {
         return Str::is([
-            '*created*', '*updated*', '*restored*', '*deleted*',
+            '*created*', '*updated*', '*restored*', '*deleted*', '*retrieved*',
         ], $eventName);
+    }
+
+    /**
+     * Determine if the hydration should be recorded for the model class.
+     *
+     * @param  string  $modelClass
+     * @return bool
+     */
+    private function shouldRecordHydration($modelClass)
+    {
+        return collect($this->options['ignore'] ?? [EntryModel::class])
+            ->every(function ($class) use ($modelClass) {
+                return $modelClass !== $class && ! is_subclass_of($modelClass, $class);
+            });
     }
 }

--- a/tests/FeatureTestCase.php
+++ b/tests/FeatureTestCase.php
@@ -29,11 +29,13 @@ class FeatureTestCase extends TestCase
         }
 
         Telescope::flushEntries();
+        Telescope::$afterStoringHooks = [];
     }
 
     protected function tearDown(): void
     {
         Telescope::flushEntries();
+        Telescope::$afterStoringHooks = [];
 
         Queue::createPayloadUsing(null);
 


### PR DESCRIPTION
### Motivation
Re-attempt of https://github.com/laravel/telescope/pull/999 without a separate tab or watcher.

This PR adds the ability to record model hydrations within the Model Watcher (without a separate tab or watcher). This would help to know how many models are being hydrated for a request - something that can have a significant on performance / memory usage. Inspired from a similar popular feature of Debugbar: barryvdh/laravel-debugbar#947.

There are no breaking changes with this PR. To enable recording of model hydrations, we would need to enable the `hydrations` flag in the `config/telescope.php` file like so:

```php
Watchers\ModelWatcher::class => [
    'enabled' => env('TELESCOPE_MODEL_WATCHER', true),
    'events' => ['eloquent.*'],
    'hydrations' => true,
],
```

### Index Screen (The retrieved is the one for model hydrations)
![hydrations](https://user-images.githubusercontent.com/16099046/101992310-54e79e00-3cd8-11eb-96ca-6ac9022b21d7.png)

### Preview Screen
![hydrations-preview](https://user-images.githubusercontent.com/16099046/101992312-5add7f00-3cd8-11eb-95af-96e94b4323e3.png)

### Related Entries
![hydrations-related-entries](https://user-images.githubusercontent.com/16099046/101992320-60d36000-3cd8-11eb-92d4-8e8464fd9c06.png)

### Note
This PR would need a re-build and I haven't committed the compiled files (just the source) as per the contribution guidelines.