### PR TITLE
[4.x] Fix: GateWatcher shows allowed when it is denied via Response class

### DIFF
--- a/src/Watchers/GateWatcher.php
+++ b/src/Watchers/GateWatcher.php
@@ -55,9 +55,20 @@ class GateWatcher extends Watcher
     }
 
     /**
-     * Determine if the result is denied or allowed.
+     * Determine if the ability should be ignored.
      *
-     * @param bool|\Illuminate\Auth\Access\Response $result
+     * @param  string  $ability
+     * @return bool
+     */
+    private function shouldIgnore($ability)
+    {
+        return Str::is($this->options['ignore_abilities'] ?? [], $ability);
+    }
+
+    /**
+     * Determine if the gate result is denied or allowed.
+     *
+     * @param  bool|\Illuminate\Auth\Access\Response  $result
      * @return string
      */
     private function gateResult($result)
@@ -67,17 +78,6 @@ class GateWatcher extends Watcher
         }
 
         return $result ? 'allowed' : 'denied';
-    }
-
-    /**
-     * Determine if the ability should be ignored.
-     *
-     * @param  string  $ability
-     * @return bool
-     */
-    private function shouldIgnore($ability)
-    {
-        return Str::is($this->options['ignore_abilities'] ?? [], $ability);
     }
 
     /**

--- a/src/Watchers/GateWatcher.php
+++ b/src/Watchers/GateWatcher.php
@@ -44,13 +44,28 @@ class GateWatcher extends Watcher
 
         Telescope::recordGate(IncomingEntry::make([
             'ability' => $ability,
-            'result' => $result ? 'allowed' : 'denied',
+            'result' => $this->gateResult($result),
             'arguments' => $this->formatArguments($arguments),
             'file' => $caller['file'],
             'line' => $caller['line'],
         ]));
 
         return $result;
+    }
+
+    /**
+     * Determine if the result is denied or allowed.
+     *
+     * @param bool|\Illuminate\Auth\Access\Response $result
+     * @return string
+     */
+    private function gateResult($result)
+    {
+        if ($result instanceof \Illuminate\Auth\Access\Response) {
+            return $result->allowed() ? 'allowed' : 'denied';
+        }
+
+        return $result ? 'allowed' : 'denied';
     }
 
     /**

--- a/src/Watchers/GateWatcher.php
+++ b/src/Watchers/GateWatcher.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Telescope\Watchers;
 
+use Illuminate\Auth\Access\Response;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Gate;
@@ -61,7 +62,7 @@ class GateWatcher extends Watcher
      */
     private function gateResult($result)
     {
-        if ($result instanceof \Illuminate\Auth\Access\Response) {
+        if ($result instanceof Response) {
             return $result->allowed() ? 'allowed' : 'denied';
         }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Error that happens
While returning and using the `Illuminate\Auth\Access\Response` class deny and allow methods from policies, I noticed that telescope is recording the Gate results as always **allowed**

I determined that the `$result` argument that the `GateWatcher` class is looking at it as only a bool, but this value also has the possibility of being an instance of `Illuminate\Auth\Access\Response` in the case of a policy that is returning a response, so when the policy has `$this->denied('Reason for denial')` the request entry reflects a status code of 403, but it is confusing to see the gate value is allowed.

As the intention of Telescope is to assist in debugging and seeing whats happening, this actually causes confusion in the long run.

## Fix

The changes I made was to look if the `$result` argument is an instance of the `Illuminate\Auth\Access\Response` class, if not it defaults to the original behaviour.


## Tests

The tests all passed locally, but will only know once the repo's ones run if they are correct.

The tests have a few changes for the Gate Watcher, but these are the line numbers and the additions I made. I am not sure if I was supposed to change the line numbers, but they shifted because of my additions I believe.