### PR TITLE
[4.x] Remove Laravel 7 workarounds

### DIFF
--- a/tests/FeatureTestCase.php
+++ b/tests/FeatureTestCase.php
@@ -2,9 +2,7 @@
 
 namespace Laravel\Telescope\Tests;
 
-use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\TestResponse as LegacyTestResponse;
 use Illuminate\Queue\Queue;
 use Illuminate\Testing\TestResponse;
 use Laravel\Telescope\Contracts\EntriesRepository;
@@ -22,11 +20,7 @@ class FeatureTestCase extends TestCase
     {
         parent::setUp();
 
-        if (Application::VERSION === '7.x-dev' || version_compare(Application::VERSION, '7.0', '>=')) {
-            TestResponse::macro('terminateTelescope', [$this, 'terminateTelescope']);
-        } else {
-            LegacyTestResponse::macro('terminateTelescope', [$this, 'terminateTelescope']);
-        }
+        TestResponse::macro('terminateTelescope', [$this, 'terminateTelescope']);
 
         Telescope::flushEntries();
         Telescope::$afterStoringHooks = [];

--- a/tests/Http/RouteTest.php
+++ b/tests/Http/RouteTest.php
@@ -2,8 +2,6 @@
 
 namespace Laravel\Telescope\Tests\Http;
 
-use Illuminate\Foundation\Application;
-use Illuminate\Foundation\Testing\TestResponse as LegacyTestResponse;
 use Illuminate\Testing\TestResponse;
 use Laravel\Telescope\Database\Factories\EntryModelFactory;
 use Laravel\Telescope\EntryType;
@@ -83,11 +81,7 @@ class RouteTest extends FeatureTestCase
             return $this;
         };
 
-        if (Application::VERSION === '7.x-dev' || version_compare(Application::VERSION, '7.0', '>=')) {
-            TestResponse::macro('assertJsonExactFragment', $assertion);
-        } else {
-            LegacyTestResponse::macro('assertJsonExactFragment', $assertion);
-        }
+        TestResponse::macro('assertJsonExactFragment', $assertion);
     }
 
     public function test_named_route()


### PR DESCRIPTION
Telescope v4 only supports Laravel v8 so these can now be safely removed.