### PR TITLE
Handle when $batch is null

### DIFF
--- a/src/Watchers/JobWatcher.php
+++ b/src/Watchers/JobWatcher.php
@@ -187,6 +187,10 @@ class JobWatcher extends Watcher
         if (isset($properties['batchId'])) {
             $batch = app(BatchRepository::class)->find($properties['batchId']);
 
+            if (is_null($batch)) {
+                return;
+            }
+
             Telescope::recordUpdate(EntryUpdate::make(
                 $properties['batchId'], EntryType::BATCH, $batch->toArray()
             ));


### PR DESCRIPTION
`BatchRepository::find()` may return `Batch` or `null`. This fixes laravel/nova-issues#3243

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>
