### PR TITLE
[4.x] Implement new GateEvaluated event

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "ext-json": "*",
-        "laravel/framework": "^8.2",
+        "laravel/framework": "^8.29",
         "symfony/var-dumper": "^5.0"
     },
     "require-dev": {

--- a/src/Watchers/FetchesStackTrace.php
+++ b/src/Watchers/FetchesStackTrace.php
@@ -9,11 +9,12 @@ trait FetchesStackTrace
     /**
      * Find the first frame in the stack trace outside of Telescope/Laravel.
      *
+     * @param  string|array  $forgetLines
      * @return array
      */
-    protected function getCallerFromStackTrace()
+    protected function getCallerFromStackTrace($forgetLines = 0)
     {
-        $trace = collect(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))->forget(0);
+        $trace = collect(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))->forget($forgetLines);
 
         return $trace->first(function ($frame) {
             if (! isset($frame['file'])) {

--- a/tests/Watchers/GateWatcherTest.php
+++ b/tests/Watchers/GateWatcherTest.php
@@ -105,10 +105,29 @@ class GateWatcherTest extends FeatureTestCase
 
         $this->assertSame(EntryType::GATE, $entry->type);
         $this->assertSame(__FILE__, $entry->content['file']);
-        $this->assertSame(231, $entry->content['line']);
+        $this->assertSame(250, $entry->content['line']);
         $this->assertSame('create', $entry->content['ability']);
         $this->assertSame('allowed', $entry->content['result']);
         $this->assertSame([[]], $entry->content['arguments']);
+    }
+
+    public function test_gate_watcher_registers_after_checks()
+    {
+        Gate::after(function (?User $user) {
+            return true;
+        });
+
+        $check = Gate::check('foo-bar');
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertTrue($check);
+        $this->assertSame(EntryType::GATE, $entry->type);
+        $this->assertSame(__FILE__, $entry->content['file']);
+        $this->assertSame(120, $entry->content['line']);
+        $this->assertSame('foo-bar', $entry->content['ability']);
+        $this->assertSame('allowed', $entry->content['result']);
+        $this->assertEmpty($entry->content['arguments']);
     }
 
     public function test_gate_watcher_registers_denied_policy_entries()
@@ -125,7 +144,7 @@ class GateWatcherTest extends FeatureTestCase
 
         $this->assertSame(EntryType::GATE, $entry->type);
         $this->assertSame(__FILE__, $entry->content['file']);
-        $this->assertSame(236, $entry->content['line']);
+        $this->assertSame(255, $entry->content['line']);
         $this->assertSame('update', $entry->content['ability']);
         $this->assertSame('denied', $entry->content['result']);
         $this->assertSame([[]], $entry->content['arguments']);
@@ -145,7 +164,7 @@ class GateWatcherTest extends FeatureTestCase
 
         $this->assertSame(EntryType::GATE, $entry->type);
         $this->assertSame(__FILE__, $entry->content['file']);
-        $this->assertSame(226, $entry->content['line']);
+        $this->assertSame(245, $entry->content['line']);
         $this->assertSame('view', $entry->content['ability']);
         $this->assertSame('allowed', $entry->content['result']);
         $this->assertSame([[]], $entry->content['arguments']);
@@ -165,7 +184,7 @@ class GateWatcherTest extends FeatureTestCase
 
         $this->assertSame(EntryType::GATE, $entry->type);
         $this->assertSame(__FILE__, $entry->content['file']);
-        $this->assertSame(241, $entry->content['line']);
+        $this->assertSame(260, $entry->content['line']);
         $this->assertSame('delete', $entry->content['ability']);
         $this->assertSame('denied', $entry->content['result']);
         $this->assertSame([[]], $entry->content['arguments']);


### PR DESCRIPTION
This PR implements the new `GateEvaluated` event which will be shipped with tomorrow's Laravel v8.29.0 release. It fixes an issue where Gate `after` checks weren't properly recorded by Telescope.

I had to introduce a breaking change for the `getCallerFromStackTrace` call to allow it to pass the lines that should be forgotten from the stack trace when recording the backtrace. I needed to introduce this because the backtrace is now two lines instead of two. Another option is to put the contents from `recordGateCheck` in `handleGateEvaluated` but that would be an even bigger breaking change I think.

Fixes https://github.com/laravel/telescope/issues/1014