### PR TITLE
[4.x] Move cache read inside handler to avoid early cache call

### DIFF
--- a/src/Watchers/DumpWatcher.php
+++ b/src/Watchers/DumpWatcher.php
@@ -40,14 +40,14 @@ class DumpWatcher extends Watcher
      */
     public function register($app)
     {
-        if (! $this->cache->get('telescope:dump-watcher')) {
-            return;
-        }
-
         $htmlDumper = new HtmlDumper();
         $htmlDumper->setDumpHeader('');
 
         VarDumper::setHandler(function ($var) use ($htmlDumper) {
+            if (! $this->cache->get('telescope:dump-watcher')) {
+                return;
+            }
+
             $this->recordDump($htmlDumper->dump(
                 (new VarCloner)->cloneVar($var), true
             ));


### PR DESCRIPTION
Move cache read inside VarDumper handler to avoid cache call during package discovery/composer install calls. Fixes #1023.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
