### PR TITLE
[4.x] Adding the ability to filter more than one tag at once with comma

### DIFF
--- a/src/Storage/EntryModel.php
+++ b/src/Storage/EntryModel.php
@@ -118,7 +118,7 @@ class EntryModel extends Model
         $query->when($options->tag, function ($query, $tag) {
             return $query->whereIn('uuid', function ($query) use ($tag) {
                 $tags = preg_split('/(\s*,*\s*)+,+(\s*,*\s*)+/', trim($tag));
-                
+
                 $query->select('entry_uuid')->from('telescope_entries_tags')
                 ->whereIn('tag', $tags)
                 ->when(count($tags) > 1, function ($query) use ($tags) {

--- a/src/Storage/EntryModel.php
+++ b/src/Storage/EntryModel.php
@@ -117,7 +117,13 @@ class EntryModel extends Model
     {
         $query->when($options->tag, function ($query, $tag) {
             return $query->whereIn('uuid', function ($query) use ($tag) {
-                $query->select('entry_uuid')->from('telescope_entries_tags')->whereTag($tag);
+                $tags = preg_split('/(\s*,*\s*)+,+(\s*,*\s*)+/', trim($tag));
+                
+                $query->select('entry_uuid')->from('telescope_entries_tags')
+                ->whereIn('tag', $tags)
+                ->when(count($tags) > 1, function ($query) use ($tags) {
+                    $query->groupBy('entry_uuid')->havingRaw('count(entry_uuid) = ?', [count($tags)]);
+                });
             });
         });
 


### PR DESCRIPTION
I changed the way how tags whare filtered, making possible filter requests per more than one tag at once separating them by comma.
That way you can combine tags for a more precision analisys of requests