### PR TITLE
[4.x] Adding code for Searching by Content

### DIFF
--- a/src/Storage/EntryModel.php
+++ b/src/Storage/EntryModel.php
@@ -65,11 +65,11 @@ class EntryModel extends Model
     public function scopeWithTelescopeOptions($query, $type, EntryQueryOptions $options)
     {
         $this->whereType($query, $type)
-            ->whereBatchId($query, $options)
-            ->whereTag($query, $options)
-            ->whereFamilyHash($query, $options)
-            ->whereBeforeSequence($query, $options)
-            ->filter($query, $options);
+                ->whereBatchId($query, $options)
+                ->whereTag($query, $options)
+                ->whereFamilyHash($query, $options)
+                ->whereBeforeSequence($query, $options)
+                ->filter($query, $options);
 
         return $query;
     }
@@ -118,10 +118,10 @@ class EntryModel extends Model
         $query->when($options->tag, function ($query, $tag) {
 
             // Adding code for Searching by Content
-            list($key,$values) = explode(':', $tag, 2);
+            [$key,$values] = explode(':', $tag, 2);
 
-            if (strtolower($key) == "content") {
-                return $query->where('content', 'like', "%" . $values . "%");
+            if (strtolower($key) == 'content') {
+                return $query->where('content', 'like', '%'.$values.'%');
             } else {
                 return $query->whereIn('uuid', function ($query) use ($tag) {
                     $query->select('entry_uuid')->from('telescope_entries_tags')->whereTag($tag);

--- a/src/Storage/EntryModel.php
+++ b/src/Storage/EntryModel.php
@@ -65,11 +65,11 @@ class EntryModel extends Model
     public function scopeWithTelescopeOptions($query, $type, EntryQueryOptions $options)
     {
         $this->whereType($query, $type)
-                ->whereBatchId($query, $options)
-                ->whereTag($query, $options)
-                ->whereFamilyHash($query, $options)
-                ->whereBeforeSequence($query, $options)
-                ->filter($query, $options);
+            ->whereBatchId($query, $options)
+            ->whereTag($query, $options)
+            ->whereFamilyHash($query, $options)
+            ->whereBeforeSequence($query, $options)
+            ->filter($query, $options);
 
         return $query;
     }
@@ -116,9 +116,17 @@ class EntryModel extends Model
     protected function whereTag($query, EntryQueryOptions $options)
     {
         $query->when($options->tag, function ($query, $tag) {
-            return $query->whereIn('uuid', function ($query) use ($tag) {
-                $query->select('entry_uuid')->from('telescope_entries_tags')->whereTag($tag);
-            });
+
+            // Adding code for Searching by Content
+            list($key,$values) = explode(':', $tag, 2);
+
+            if (strtolower($key) == "content") {
+                return $query->where('content', 'like', "%" . $values . "%");
+            } else {
+                return $query->whereIn('uuid', function ($query) use ($tag) {
+                    $query->select('entry_uuid')->from('telescope_entries_tags')->whereTag($tag);
+                });
+            }
         });
 
         return $this;


### PR DESCRIPTION
Adding Feature Search in the content of the request log.

Search by Syntax Example : Content: Value

Advantage: This will help search Content without tagging or untagged logs.