### PR TITLE
Remove asset manifest check and warning

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -201,12 +201,6 @@
             </div>
 
             <div class="col-10">
-                @if (! $assetsAreCurrent)
-                    <div class="alert alert-warning">
-                        The published Telescope assets are not up-to-date with the installed version. To update, run:<br/><code>php artisan telescope:publish</code>
-                    </div>
-                @endif
-
                 <router-view></router-view>
             </div>
         </div>

--- a/src/Http/Controllers/HomeController.php
+++ b/src/Http/Controllers/HomeController.php
@@ -17,7 +17,6 @@ class HomeController extends Controller
         return view('telescope::layout', [
             'cssFile' => Telescope::$useDarkTheme ? 'app-dark.css' : 'app.css',
             'telescopeScriptVariables' => Telescope::scriptVariables(),
-            'assetsAreCurrent' => Telescope::assetsAreCurrent(),
         ]);
     }
 }

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -12,7 +12,6 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Testing\Fakes\EventFake;
 use Laravel\Telescope\Contracts\EntriesRepository;
 use Laravel\Telescope\Contracts\TerminableRepository;
-use RuntimeException;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
 use Throwable;
 

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Illuminate\Support\Testing\Fakes\EventFake;
 use Laravel\Telescope\Contracts\EntriesRepository;
@@ -787,23 +786,5 @@ class Telescope
         static::$runsMigrations = false;
 
         return new static;
-    }
-
-    /**
-     * Check if assets are up-to-date.
-     *
-     * @return bool
-     *
-     * @throws \RuntimeException
-     */
-    public static function assetsAreCurrent()
-    {
-        $publishedPath = public_path('vendor/telescope/mix-manifest.json');
-
-        if (! File::exists($publishedPath)) {
-            throw new RuntimeException('The Telescope assets are not published. Please run: php artisan telescope:publish');
-        }
-
-        return File::get($publishedPath) === File::get(__DIR__.'/../public/mix-manifest.json');
     }
 }


### PR DESCRIPTION
This PR reverts #729, removing the checks to determine at runtime if Telescope's assets are published and up to date.

The exception that is thrown if the assets appear to be missing doesn't play nicely with Vapor because it assumes that the assets should be present on the local filesystem at runtime, and the warning feels unnecessary too since for quite a long time now the docs have had [very clear instructions about how to keep assets up to date automatically](https://laravel.com/docs/8.x/telescope#upgrading-telescope).

Closes #1062.

See also laravel/telescope#594 and laravel/horizon#554, this warning wasn't immediately popular when it was added and both Telescope and Horizon now provide documentation that make it unnecessary.