### PR TITLE
[4.x] Implemented fallback for PDO::quote method on QueryWatcher

### DIFF
--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -124,10 +124,10 @@ class QueryWatcher extends Watcher
             throw_if('IM001' !== $e->getCode(), $e);
         }
 
-        // Fallback in case that PDO::quote function is missing.
+        // Fallback when PDO::quote function is missing...
         $binding = \strtr($binding, [
-            chr(26) => '\\Z',   // Substitute
-            chr(8) => '\\b',    // Backspace
+            chr(26) => '\\Z',
+            chr(8) => '\\b',
             '"' => '\"',
             "'" => "\'",
             '\\' => '\\\\',

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -118,8 +118,8 @@ class QueryWatcher extends Watcher
      * @param string $binding
      * @return string
      */
-    protected function quoteStringBinding($event, $binding) {
-
+    protected function quoteStringBinding($event, $binding) 
+    {
         try {
             return $event->connection->getPdo()->quote($binding);
         } catch (\PDOException $e) {
@@ -128,13 +128,13 @@ class QueryWatcher extends Watcher
 
         // Fallback in case that PDO::quote function is missing.
         $binding = \strtr($binding, [
-            chr(26) => "\\Z",   // Substitute
-            chr(8) => "\\b",    // Backspace
+            chr(26) => '\\Z',   // Substitute
+            chr(8) => '\\b',    // Backspace
             '"' => '\"',
             "'" => "\'",
             '\\' => '\\\\'
         ]);
 
-        return "'" . $binding . "'";
+        return "'".$binding."'";
     }
 }

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -10,7 +10,6 @@ class QueryWatcher extends Watcher
 {
     use FetchesStackTrace;
 
-
     /**
      * Register the watcher.
      *
@@ -110,7 +109,6 @@ class QueryWatcher extends Watcher
         return $sql;
     }
 
-
     /**
      * Add quotes to string bindings.
      *
@@ -118,7 +116,7 @@ class QueryWatcher extends Watcher
      * @param string $binding
      * @return string
      */
-    protected function quoteStringBinding($event, $binding) 
+    protected function quoteStringBinding($event, $binding)
     {
         try {
             return $event->connection->getPdo()->quote($binding);
@@ -132,7 +130,7 @@ class QueryWatcher extends Watcher
             chr(8) => '\\b',    // Backspace
             '"' => '\"',
             "'" => "\'",
-            '\\' => '\\\\'
+            '\\' => '\\\\',
         ]);
 
         return "'".$binding."'";

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -100,7 +100,7 @@ class QueryWatcher extends Watcher
             if ($binding === null) {
                 $binding = 'null';
             } elseif (! is_int($binding) && ! is_float($binding)) {
-                $binding = $event->quoteStringBinding($event, $binding);
+                $binding = $this->quoteStringBinding($event, $binding);
             }
 
             $sql = preg_replace($regex, $binding, $sql, 1);

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -113,7 +113,7 @@ class QueryWatcher extends Watcher
      * Add quotes to string bindings.
      *
      * @param  \Illuminate\Database\Events\QueryExecuted  $event
-     * @param string $binding
+     * @param  string  $binding
      * @return string
      */
     protected function quoteStringBinding($event, $binding)


### PR DESCRIPTION
This pull request will solve https://github.com/laravel/telescope/issues/1065.

Note: The fallback method may not constraint with all the target databases that ODBC is connected, It means that there is no way to know which charset, and quote symbol is the default used by the database, however the fallback method should represent an accurate query string for the most popular databases like mSQL, BigQuery or Snowflake.
