### PR TITLE
Add a new "Clear Entries" button at the top of Telescope

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -87,6 +87,6 @@ new Vue({
             axios.post(Telescope.basePath + '/telescope-api/clear-entries');
 
             this.$emit('clear-entries');
-        },        
+        },
     },
 });

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -82,5 +82,11 @@ new Vue({
             window.Telescope.recording = !Telescope.recording;
             this.recording = !this.recording;
         },
+
+        clearEntries() {
+            axios.post(Telescope.basePath + '/telescope-api/clear-entries');
+
+            this.$emit('clear-entries');
+        },        
     },
 });

--- a/resources/js/components/IndexScreen.vue
+++ b/resources/js/components/IndexScreen.vue
@@ -47,6 +47,17 @@
 
             this.tag = this.$route.query.tag || '';
 
+            this.$root.$on('clear-entries', () => {
+                this.entries = [];
+                this.hasMoreEntries = false;
+                this.hasNewEntries = false;
+                this.lastEntryIndex = '';
+                
+                this.checkForNewEntries();
+
+                this.ready = true;                
+            })            
+
             this.loadEntries((entries) => {
                 this.entries = entries;
 

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -41,6 +41,12 @@
                 </svg>
             </button>
 
+            <button class="btn btn-outline-primary mr-3" v-on:click.prevent="clearEntries" title="Clear Entries">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="icon fill-primary">
+                    <path d="M6 2l2-2h4l2 2h4v2H2V2h4zM3 6h14l-1 14H4L3 6zm5 2v10h1V8H8zm3 0v10h1V8h-1z"/>
+                </svg>
+            </button>
+
             <button class="btn btn-outline-primary mr-3" :class="{active: autoLoadsNewEntries}" v-on:click.prevent="autoLoadNewEntries" title="Auto Load Entries">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="icon fill-primary">
                     <path d="M10 3v2a5 5 0 0 0-3.54 8.54l-1.41 1.41A7 7 0 0 1 10 3zm4.95 2.05A7 7 0 0 1 10 17v-2a5 5 0 0 0 3.54-8.54l1.41-1.41zM10 20l-4-4 4-4v8zm0-12V0l4 4-4 4z"></path>

--- a/src/Http/Controllers/EntriesController.php
+++ b/src/Http/Controllers/EntriesController.php
@@ -6,7 +6,7 @@ use Illuminate\Routing\Controller;
 use Laravel\Telescope\Contracts\ClearableRepository;
 
 class EntriesController extends Controller
-{    
+{
     /**
      * Clear entries.
      *

--- a/src/Http/Controllers/EntriesController.php
+++ b/src/Http/Controllers/EntriesController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Laravel\Telescope\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+use Laravel\Telescope\Contracts\ClearableRepository;
+
+class EntriesController extends Controller
+{    
+    /**
+     * Clear entries.
+     *
+     * @return void
+     */
+    public function clear(ClearableRepository $storage)
+    {
+        $storage->clear();
+    }
+}

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -84,4 +84,7 @@ Route::post('/telescope-api/monitored-tags/delete', 'MonitoredTagController@dest
 // Toggle Recording...
 Route::post('/telescope-api/toggle-recording', 'RecordingController@toggle');
 
+// Clear Entries...
+Route::post('/telescope-api/clear-entries', 'EntriesController@clear');
+
 Route::get('/{view?}', 'HomeController@index')->where('view', '(.*)')->name('telescope');


### PR DESCRIPTION
This pull request adds a new "Clear Entries" button at the top of the layout (after the Pause Recording button).

Clicking it triggers a call the the backend which clears the entries in the database and also wipes the current in-memory entries of the Vue app.

The SVG icon comes from zondicons to match the other telescope icons.

This feature has been touroughly tested and works both when new entries are loaded automatically and when they are not.

Any comments, questions, code review, bugs of missing features would be very welcome.

Personally, as a heavy telescope user, this would be a very welcome feature, and a nice addition to the great tool that telescope is.

When debuging, this new button is much quicker than having to leave your curren window (telescope), go the terminal, call artisan telescope:clear, go back to telescope and refresh the window.

Thanks !