### PR TITLE
[4.x] `Telescope:withoutRecording()` should be exception safe

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -260,9 +260,11 @@ class Telescope
 
         static::$shouldRecord = false;
 
-        call_user_func($callback);
-
-        static::$shouldRecord = $shouldRecord;
+        try {
+            call_user_func($callback);
+        } finally {
+            static::$shouldRecord = $shouldRecord;
+        }
     }
 
     /**


### PR DESCRIPTION
`Telescope:withoutRecording()` is not exception safe: the original state will not be restored if the exception is thrown in the callback. This PR make `Telescope:withoutRecording()`  exception safe.