### PR TITLE
[4.x] Allow select entry types to be pruned

### DIFF
--- a/src/Console/PruneCommand.php
+++ b/src/Console/PruneCommand.php
@@ -12,7 +12,9 @@ class PruneCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'telescope:prune {--hours=24 : The number of hours to retain Telescope data}';
+    protected $signature = 'telescope:prune
+                            {--hours=24 : The number of hours to retain Telescope data}
+                            {--type=* : Entry types to be pruned}';
 
     /**
      * The console command description.
@@ -29,6 +31,9 @@ class PruneCommand extends Command
      */
     public function handle(PrunableRepository $repository)
     {
-        $this->info($repository->prune(now()->subHours($this->option('hours'))).' entries pruned.');
+        $this->info($repository->prune(
+                now()->subHours($this->option('hours')),
+                $this->option('type')
+            ).' entries pruned.');
     }
 }

--- a/src/Contracts/PrunableRepository.php
+++ b/src/Contracts/PrunableRepository.php
@@ -10,7 +10,8 @@ interface PrunableRepository
      * Prune all of the entries older than the given date.
      *
      * @param  \DateTimeInterface  $before
+     * @param  array  $entryTypes
      * @return int
      */
-    public function prune(DateTimeInterface $before);
+    public function prune(DateTimeInterface $before, array $entryTypes = []);
 }

--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -333,11 +333,15 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
      * Prune all of the entries older than the given date.
      *
      * @param  \DateTimeInterface  $before
+     * @param  array  $entryTypes
      * @return int
      */
-    public function prune(DateTimeInterface $before)
+    public function prune(DateTimeInterface $before, array $entryTypes = [])
     {
         $query = $this->table('telescope_entries')
+                ->when(!empty($entryTypes), function ($query) use ($entryTypes) {
+                    $query->whereIn('type', $entryTypes);
+                })
                 ->where('created_at', '<', $before);
 
         $totalDeleted = 0;

--- a/tests/Console/PruneCommandTest.php
+++ b/tests/Console/PruneCommandTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Telescope\Tests\Console;
 
 use Laravel\Telescope\Database\Factories\EntryModelFactory;
+use Laravel\Telescope\EntryType;
 use Laravel\Telescope\Tests\FeatureTestCase;
 
 class PruneCommandTest extends FeatureTestCase
@@ -29,5 +30,26 @@ class PruneCommandTest extends FeatureTestCase
         $this->artisan('telescope:prune', ['--hours' => 4])->expectsOutput('1 entries pruned.');
 
         $this->assertDatabaseMissing('telescope_entries', ['uuid' => $recent->uuid]);
+    }
+
+    public function test_prune_command_can_vary_types()
+    {
+        EntryModelFactory::new()->createMany([
+                ['type' => EntryType::REQUEST, 'created_at' => now()->subDays(2)],
+                ['type' => EntryType::QUERY, 'created_at' => now()->subDays(2)],
+            ]
+        );
+
+        $this->artisan('telescope:prune', ['--type' => ['request']])->expectsOutput('1 entries pruned.');
+
+        $this->assertDatabaseHas('telescope_entries', ['type' => EntryType::QUERY]);
+
+        $this->assertDatabaseMissing('telescope_entries', ['type' => EntryType::REQUEST]);
+
+        EntryModelFactory::new()->create(['type' => EntryType::REQUEST, 'created_at' => now()->subDays(2)]);
+
+        $this->artisan('telescope:prune')->expectsOutput('2 entries pruned.');
+
+        $this->assertDatabaseCount('telescope_entries', 0);
     }
 }


### PR DESCRIPTION
While pruning prevents accumulating records, there are cases when we do want to keep some of the data (e.g. exceptions that still needs to be resolved).

This PR allows for pruning selected entry types by adding `--type` option to the `prune` command.