### PR TITLE
Use intdiv where appropriate to prevent unexpected conversion to float.

### DIFF
--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -184,7 +184,7 @@ class RequestWatcher extends Watcher
     {
         $limit = $this->options['size_limit'] ?? 64;
 
-        return mb_strlen($content) / 1000 <= $limit;
+        return intdiv(mb_strlen($content), 1000) <= $limit;
     }
 
     /**


### PR DESCRIPTION
While using Telescope Toolbar I noticed that I couldn't view some of the profiles, so upon checking the request response on the Telescope dashboard it said `Purged By Telescope`.

I set `TELESCOPE_RESPONSE_SIZE_LIMIT` to some something really big and was still getting the same behavior. With some debugging I discovered that the check `mb_strlen($content) / 1000` was giving a float as the result rather than an int.

Setting `TELESCOPE_RESPONSE_SIZE_LIMIT` to a float fixed the issue, however, I don't imagine this is the expected behavior. As such we can fix this issue by using the `intdiv` function.
