### PR TITLE
Update index.vue to show Host of request

### DIFF
--- a/resources/js/screens/requests/index.vue
+++ b/resources/js/screens/requests/index.vue
@@ -12,6 +12,7 @@
     <index-screen title="Requests" resource="requests">
         <tr slot="table-header">
             <th scope="col">Verb</th>
+            <th scope="col">Host</th>
             <th scope="col">Path</th>
             <th scope="col">Status</th>
             <th scope="col">Duration</th>
@@ -26,6 +27,8 @@
                     {{slotProps.entry.content.method}}
                 </span>
             </td>
+            
+            <td :title="slotProps.entry.content.uri">{{truncate(slotProps.entry.headers.host, 60)}}</td>
 
             <td :title="slotProps.entry.content.uri">{{truncate(slotProps.entry.content.uri, 60)}}</td>
 


### PR DESCRIPTION
For who using subdomains show the host of request path.

When using a subdomain, more than one request sent to the same path appears on the requests page. To clear up the confusion, a host column can be added to the table.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
