### PR TITLE
[4.x] Rewind http client response after recording

### DIFF
--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -91,7 +91,7 @@ class ClientRequestWatcher extends Watcher
     protected function response(Response $response)
     {
         $content = $response->body();
-        
+
         $stream = $response->toPsrResponse()->getBody();
 
         if ($stream->isSeekable()) {

--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -91,6 +91,12 @@ class ClientRequestWatcher extends Watcher
     protected function response(Response $response)
     {
         $content = $response->body();
+        
+        $stream = $response->toPsrResponse()->getBody();
+
+        if ($stream->isSeekable()) {
+            $stream->rewind();
+        }
 
         if (is_string($content)) {
             if (is_array(json_decode($content, true)) &&


### PR DESCRIPTION
When response is recorded it sets the response stream to eof and when trying to access the contents of the stream you get an empty string.

This PR rewinds the stream to beginning after copying the content of the response.

To reproduce
```
$response = Http::get('https://httpbin.org/get');

echo $response->toPsrResponse()->getBody()->getContents();
```