### PR TITLE
[4.x] Add cache driver option

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -53,6 +53,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Telescope Cache Driver
+    |--------------------------------------------------------------------------
+    |
+    | This configuration options determines the cache driver that will be
+    | used throughout Telescope.
+    | Hmmmm...
+    |
+    */
+
+    'cache_driver' => env('TELESCOPE_CACHE_DRIVER', 'default'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Telescope Master Switch
     |--------------------------------------------------------------------------
     |

--- a/src/Http/Controllers/DumpController.php
+++ b/src/Http/Controllers/DumpController.php
@@ -3,11 +3,11 @@
 namespace Laravel\Telescope\Http\Controllers;
 
 use Illuminate\Cache\ArrayStore;
-use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Http\Request;
 use Laravel\Telescope\Contracts\EntriesRepository;
 use Laravel\Telescope\EntryType;
 use Laravel\Telescope\Storage\EntryQueryOptions;
+use Laravel\Telescope\Telescope;
 use Laravel\Telescope\Watchers\DumpWatcher;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
@@ -24,12 +24,11 @@ class DumpController extends EntryController
     /**
      * Create a new controller instance.
      *
-     * @param  \Illuminate\Contracts\Cache\Repository  $cache
      * @return void
      */
-    public function __construct(CacheRepository $cache)
+    public function __construct()
     {
-        $this->cache = $cache;
+        $this->cache = Telescope::cacheStore();
     }
 
     /**

--- a/src/Http/Controllers/EntryController.php
+++ b/src/Http/Controllers/EntryController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Telescope\Contracts\EntriesRepository;
 use Laravel\Telescope\Storage\EntryQueryOptions;
+use Laravel\Telescope\Telescope;
 
 abstract class EntryController extends Controller
 {
@@ -69,7 +70,7 @@ abstract class EntryController extends Controller
             return 'disabled';
         }
 
-        if (cache('telescope:pause-recording', false)) {
+        if (Telescope::cacheStore()->get('telescope:pause-recording', false)) {
             return 'paused';
         }
 

--- a/src/Http/Controllers/RecordingController.php
+++ b/src/Http/Controllers/RecordingController.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Telescope\Http\Controllers;
 
-use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Routing\Controller;
+use Laravel\Telescope\Telescope;
 
 class RecordingController extends Controller
 {
@@ -17,12 +17,11 @@ class RecordingController extends Controller
     /**
      * Create a new controller instance.
      *
-     * @param  \Illuminate\Contracts\Cache\Repository  $cache
      * @return void
      */
-    public function __construct(CacheRepository $cache)
+    public function __construct()
     {
-        $this->cache = $cache;
+        $this->cache = Telescope::cacheStore();
     }
 
     /**

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -251,7 +251,7 @@ class Telescope
 
         return ! $request->is(
             array_merge([
-                config('telescope.path') . '*',
+                config('telescope.path').'*',
                 'telescope-api*',
                 'vendor/telescope*',
                 'horizon*',

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -128,7 +128,7 @@ class Telescope
     public static $runsMigrations = true;
 
     /**
-     * The cache store to be used throughout Telescope
+     * The cache store to be used throughout Telescope.
      *
      * @var \Illuminate\Contracts\Cache\Repository
      */
@@ -161,7 +161,7 @@ class Telescope
     }
 
     /**
-     * Set the cache store to be used throughout Telescope
+     * Set the cache store to be used throughout Telescope.
      *
      * @param \Illuminate\Foundation\Application  $app
      * @return void
@@ -175,7 +175,7 @@ class Telescope
     }
 
     /**
-     * Get the cache store to be used throughout Telescope
+     * Get the cache store to be used throughout Telescope.
      *
      * @return \Illuminate\Contracts\Cache\Repository
      */
@@ -251,7 +251,7 @@ class Telescope
 
         return ! $request->is(
             array_merge([
-                config('telescope.path').'*',
+                config('telescope.path') . '*',
                 'telescope-api*',
                 'vendor/telescope*',
                 'horizon*',

--- a/src/Watchers/DumpWatcher.php
+++ b/src/Watchers/DumpWatcher.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Telescope\Watchers;
 
-use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Laravel\Telescope\IncomingDumpEntry;
 use Laravel\Telescope\Telescope;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
@@ -12,24 +11,23 @@ use Symfony\Component\VarDumper\VarDumper;
 class DumpWatcher extends Watcher
 {
     /**
-     * The cache factory implementation.
+     * The cache repository implementation.
      *
-     * @var \Illuminate\Contracts\Cache\Factory
+     * @var \Illuminate\Contracts\Cache\Repository
      */
     protected $cache;
 
     /**
      * Create a new watcher instance.
      *
-     * @param  \Illuminate\Contracts\Cache\Factory  $cache
      * @param  array  $options
      * @return void
      */
-    public function __construct(CacheFactory $cache, array $options = [])
+    public function __construct(array $options = [])
     {
         parent::__construct($options);
 
-        $this->cache = $cache;
+        $this->cache = Telescope::cacheStore();
     }
 
     /**


### PR DESCRIPTION
# Summary
This PR adds a `cache_driver` option to the `telescope.php` config in order to override the cache store/driver that Telescope uses throughout.

# Motivation
The motivation of this is due to the error in #1023. When you are developing locally using a redis cache which is not local due to using Homestead, Sail, or some other virtual environment, `composer` and `artisan` commands ran locally fail due to the redis cache not being accessible. The redis config in the `.env` cannot be changed as it is needed for the virtual environment - meaning we cannot use the forwarded port as the virtual environment needs the actual port (e.g. `6379` and not `63790`).

I personally ran into the issue trying to run `composer update`, `php artisan make:test` and even just `php artisan`.

# Not a breaking change
This PR is backward compatible. If the `cache_driver` option doesn't exist, it defaults to the default cache driver.

# Remaining tasks
- [ ] Improve the description for the option in the `telescope.php` config
- [ ] Write some tests