### PR TITLE
Add auto night theme mode

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -13,7 +13,14 @@
 
     <!-- Style sheets-->
     <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet">
-    <link href="{{ asset(mix($cssFile, 'vendor/telescope')) }}" rel="stylesheet" type="text/css">
+
+    @if($darkTheme !== 'auto')
+        <link href="{{ asset(mix($darkTheme, 'vendor/telescope')) }}" rel="stylesheet" type="text/css">
+    @else
+        <link href="{{ asset(mix('app.css', 'vendor/telescope')) }}" rel="stylesheet" type="text/css">
+        <link href="{{ asset(mix('app-dark.css', 'vendor/telescope')) }}" media="(prefers-color-scheme: dark)"  rel="stylesheet" type="text/css">
+    @endif
+
 </head>
 <body>
 <div id="telescope" v-cloak>

--- a/src/Http/Controllers/HomeController.php
+++ b/src/Http/Controllers/HomeController.php
@@ -15,7 +15,7 @@ class HomeController extends Controller
     public function index()
     {
         return view('telescope::layout', [
-            'cssFile' => Telescope::$useDarkTheme ? 'app-dark.css' : 'app.css',
+            'darkTheme' => Telescope::$useDarkTheme === 'auto' ? 'auto' : (Telescope::$useDarkTheme ? 'app-dark.css' : 'app.css'),
             'telescopeScriptVariables' => Telescope::scriptVariables(),
         ]);
     }

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -762,7 +762,8 @@ class Telescope
     }
 
     /**
-     * Specifies that Telescope should use the dark theme.
+     * Specifies that Telescope should automatically
+     * detect if the user has requested a light or dark theme.
      *
      * @return static
      */

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -762,6 +762,18 @@ class Telescope
     }
 
     /**
+     * Specifies that Telescope should use the dark theme.
+     *
+     * @return static
+     */
+    public static function autoNightTheme()
+    {
+        static::$useDarkTheme = 'auto';
+
+        return new static;
+    }
+
+    /**
      * Register the Telescope user avatar callback.
      *
      * @param  \Closure  $callback


### PR DESCRIPTION
Using media(prefers-color-scheme: dark) in link stylesheet so theme can automatically switch between light and dark mode on the fly since current telescope's night theme setting doesn't follow the operating system's or the browser's settings.