### PR TITLE
Always register migrations

### DIFF
--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -18,6 +18,7 @@ class TelescopeServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $this->registerMigrations();
         $this->registerCommands();
         $this->registerPublishing();
 
@@ -29,7 +30,6 @@ class TelescopeServiceProvider extends ServiceProvider
 
         $this->registerRoutes();
         $this->registerResources();
-        $this->registerMigrations();
 
         Telescope::start($this->app);
         Telescope::listenForStorageOpportunities($this->app);


### PR DESCRIPTION
I think we need to register migrations even if telescope is disabled so database would be ready when we switch state enable/disable. So there is no need to check and run migrations every time we enable telescope. It can be useful for CI/CD.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
