### PR TITLE
[3.x] Fix `telescope.domain` usage.

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -186,7 +186,36 @@ class Telescope
      */
     protected static function handlingApprovedRequest($app)
     {
-        return ! $app->runningInConsole() && ! $app['request']->is(
+        if ($app->runningInConsole()) {
+            return false;
+        }
+
+        return static::requestIsToApprovedDomain($app['request'])
+            || static::requestIsToApprovedUri($app['request']);
+    }
+
+    /**
+     * Determine if the request is to an approved domain.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    protected static function requestIsToApprovedDomain($request): bool
+    {
+        $currentHost = $request->getHost();
+
+        return config('telescope.domain', $currentHost) !== $currentHost;
+    }
+
+    /**
+     * Determine if the request is to an approved URI.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    protected static function requestIsToApprovedUri($request): bool
+    {
+        return ! $request->is(
             array_merge([
                 config('telescope.path').'*',
                 'telescope-api*',


### PR DESCRIPTION
```php
// config/telescope.php
return [
    'domain' => 'telescope.example.com',
    'path' => null,
];
```
If you use `domain` without `path` `handlingApprovedRequest` always return false because `config('telescope.path').'*'` is `'*'` 
I propose check domain before check path.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
