### PR TITLE
Http Client Watcher Does not Log XML Request and Responses

### DIFF
--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -185,6 +185,11 @@ class ClientRequestWatcher extends Watcher
     protected function input(Request $request)
     {
         if (! $request->isMultipart()) {
+            
+            if(!$request->data()){
+                return $request->body();
+            }
+            
             return $request->data();
         }
 

--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -109,6 +109,10 @@ class ClientRequestWatcher extends Watcher
             if (Str::startsWith(strtolower($response->header('Content-Type')), 'text/plain')) {
                 return $this->contentWithinLimits($content) ? $content : 'Purged By Telescope';
             }
+            
+            if (Str::contains(strtolower($response->header('Content-Type')), 'xml')){
+                return $content;
+            }
         }
 
         if ($response->redirect()) {


### PR DESCRIPTION
Here is the before request and response display of XML Requests in Telescope HTTP Client Watcher

**Before**
![image](https://user-images.githubusercontent.com/48653948/133206037-4ef11857-91ee-4dcc-9414-d5293608da21.png)

**After**
![image](https://user-images.githubusercontent.com/48653948/133206298-9f500388-e09b-4053-a6ec-eda0a92cf31c.png)
