### PR TITLE
[4.x] Laravel Octane fix: GateWatcher handles stack trace caller not found

### DIFF
--- a/src/Watchers/FetchesStackTrace.php
+++ b/src/Watchers/FetchesStackTrace.php
@@ -10,7 +10,7 @@ trait FetchesStackTrace
      * Find the first frame in the stack trace outside of Telescope/Laravel.
      *
      * @param  string|array  $forgetLines
-     * @return array
+     * @return array|null
      */
     protected function getCallerFromStackTrace($forgetLines = 0)
     {

--- a/src/Watchers/GateWatcher.php
+++ b/src/Watchers/GateWatcher.php
@@ -58,8 +58,8 @@ class GateWatcher extends Watcher
             'ability' => $ability,
             'result' => $this->gateResult($result),
             'arguments' => $this->formatArguments($arguments),
-            'file' => $caller['file'],
-            'line' => $caller['line'],
+            'file' => $caller['file'] ?? null,
+            'line' => $caller['line'] ?? null,
         ]));
 
         return $result;


### PR DESCRIPTION
Fixes https://github.com/laravel/telescope/issues/1072 & https://github.com/laravel/telescope/issues/1122

TLDR: `GateWatcher` throws an exception because it can't find the PHP source code location that triggered a gate check for an app using Swoole/Laravel Octane.

With `config('telescope.watchers.Watchers\GateWatcher.ignore_packages')` enabled (the default setting), method `getCallerFromStackTrace()` returns `null` because only vendor/laravel/* code is traced through and no app/Http/Controllers/*.php file is reached. Middleware `vendor/laravel/framework/src/Illuminate/Auth/Middleware/Authorize.php` triggered the gate check and `GateWatcher@recordGateCheck()` throws an exception attempting to save the Telescope entry for a missing file location.

https://github.com/laravel/telescope/blob/e31d4e7916513ab7a3ff2c42b4095f16d1dbb5dd/resources/js/screens/gates/preview.vue#L38-L43

The UI hides caller file location details if they're not stored in the Telescope entry so set that path to `null` and prevent this exception.

> This provides less details about what triggered gate checks in Octane apps, but the alternative is adding a `GateWatcher` entry creation fallback to a hardcoded value of `Illuminate/Auth/Middleware/Authorize@handle()`.

Also fix the `getCallerFromStackTrace()` docblock for `@return` as method `QueryWatcher@recordQuery()` already has a conditional for when it returns `null` .