### PR TITLE
Fix mail to check to allow for null `to` fields

### DIFF
--- a/resources/js/screens/mail/index.vue
+++ b/resources/js/screens/mail/index.vue
@@ -2,7 +2,7 @@
     export default {
         methods: {
             recipientsCount(entry){
-                return _.union(Object.keys(entry.content.to),
+                return _.union((entry.content.to ? Object.keys(entry.content.to) : []),
                         (entry.content.cc ? Object.keys(entry.content.cc) : []),
                         (entry.content.bcc ? Object.keys(entry.content.bcc) : []),
                         (entry.content.replyTo ? Object.keys(entry.content.replyTo) : [])).length;


### PR DESCRIPTION
We have notifications that are sent using solely `bcc` recipients in our app and this causes the `Mail` resource to load infinitely.

This change accounts for the fact that `entry.content.to` can be null for a valid mailable.

Related #851.