### PR TITLE
Redirect the user to the base path after clearing entries

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -86,7 +86,7 @@ new Vue({
         clearEntries() {
             if (confirm('Are you sure you want to delete all Telescope data?')) {
                 axios.delete(Telescope.basePath + '/telescope-api/entries').then((response) => {
-                    window.location = Telescope.basePath
+                    window.location = Telescope.basePath;
                 });
             }
         },


### PR DESCRIPTION
If the user is viewing the details of a (request, command, etc ...) the "clearEntries" function just reloads the page of the entry which was deleted, I think it should redirect to `Telescope.basePath`