### PR TITLE
Fix syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,9 @@
 *.md diff=markdown
 *.php diff=php
 
+public/*.css binary
+public/*.js binary
+
 /.github export-ignore
 /art export-ignore
 /tests export-ignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
             "devDependencies": {
                 "axios": "^0.21",
                 "bootstrap": "^4.5.0",
-                "highlight.js": "^10.4.1",
+                "highlight.js": "^11.3.1",
                 "jquery": "^3.5",
                 "laravel-mix": "^6.0.6",
                 "lodash": "^4.17.19",
@@ -6232,12 +6232,12 @@
             "dev": true
         },
         "node_modules/highlight.js": {
-            "version": "10.7.2",
-            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.2.tgz",
-            "integrity": "sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg==",
+            "version": "11.3.1",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.3.1.tgz",
+            "integrity": "sha512-PUhCRnPjLtiLHZAQ5A/Dt5F8cWZeMyj9KRsACsWT+OD6OP0x6dp5OmT5jdx0JgEyPxPZZIPQpRN2TciUT7occw==",
             "dev": true,
             "engines": {
-                "node": "*"
+                "node": ">=12.0.0"
             }
         },
         "node_modules/hmac-drbg": {
@@ -20307,9 +20307,9 @@
             "dev": true
         },
         "highlight.js": {
-            "version": "10.7.2",
-            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.2.tgz",
-            "integrity": "sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg==",
+            "version": "11.3.1",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.3.1.tgz",
+            "integrity": "sha512-PUhCRnPjLtiLHZAQ5A/Dt5F8cWZeMyj9KRsACsWT+OD6OP0x6dp5OmT5jdx0JgEyPxPZZIPQpRN2TciUT7occw==",
             "dev": true
         },
         "hmac-drbg": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "devDependencies": {
         "axios": "^0.21",
         "bootstrap": "^4.5.0",
-        "highlight.js": "^10.4.1",
+        "highlight.js": "^11.3.1",
         "jquery": "^3.5",
         "laravel-mix": "^6.0.6",
         "lodash": "^4.17.19",

--- a/resources/js/components/ExceptionCodePreview.vue
+++ b/resources/js/components/ExceptionCodePreview.vue
@@ -1,6 +1,21 @@
 <script type="text/ecmascript-6">
+    import hljs from 'highlight.js/lib/core';
+    import php from 'highlight.js/lib/languages/php';
+
+    hljs.registerLanguage('php', php);
+
     export default {
         props: ['lines', 'highlightedLine'],
+
+        methods: {
+            highlight(line, number){
+                if (number == this.highlightedLine) {
+                    return line;
+                }
+
+                return hljs.highlight(line, { language: 'php' }).value;
+            }
+        }
     }
 </script>
 
@@ -8,7 +23,7 @@
     <pre class="code-bg px-4 mb-0 text-white">
         <p v-for="(line, number) in lines"
            class="mb-0"
-           :class="{'highlight': number == highlightedLine}"><span class="mr-4">{{number}}</span> <span>{{line}}</span></p>
+           :class="{'highlight': number == highlightedLine}"><span class="mr-4">{{number}}</span> <span v-html="highlight(line, number)" /></p>
     </pre>
 </template>
 

--- a/resources/js/screens/queries/preview.vue
+++ b/resources/js/screens/queries/preview.vue
@@ -1,14 +1,15 @@
 <script type="text/ecmascript-6">
-    import hljs from 'highlight.js/lib/highlight';
+    import hljs from 'highlight.js/lib/core';
     import sql from 'highlight.js/lib/languages/sql';
     import { format } from 'sql-formatter';
+
+    hljs.registerLanguage('sql', sql);
 
     export default {
         methods: {
             highlightSQL() {
                 this.$nextTick(() => {
-                    hljs.registerLanguage('sql', sql);
-                    hljs.highlightBlock(this.$refs.sqlcode);
+                    hljs.highlightElement(this.$refs.sqlcode);
                 });
             },
             formatSql(sql) {

--- a/resources/sass/base.scss
+++ b/resources/sass/base.scss
@@ -1,5 +1,5 @@
-@import 'syntaxhighlight';
 @import 'node_modules/bootstrap/scss/bootstrap';
+@import 'syntaxhighlight';
 
 body {
     padding-bottom: 20px;

--- a/resources/sass/syntaxhighlight.scss
+++ b/resources/sass/syntaxhighlight.scss
@@ -1,6 +1,5 @@
 .vjs-tree {
-    // Fallback for missing fonts from vue-json-pretty on Ubuntu
-    font-family: Monaco, Menlo, Consolas, Bitstream Vera Sans Mono, monospace !important;
+    font-family: $font-family-monospace;
 
     .vjs-tree__content {
         border-left: 1px dotted rgba(204, 204, 204, 0.28) !important;
@@ -15,9 +14,7 @@
         position: absolute;
         left: -30px;
     }
-    .vjs-value__null {
-        color: #a291f5 !important;
-    }
+    .vjs-value__null,
     .vjs-value__number,
     .vjs-value__boolean {
         color: #a291f5 !important;
@@ -29,17 +26,30 @@
 
 .hljs-keyword,
 .hljs-selector-tag,
-.hljs-addition {
-    color: #8bd72f;
+.hljs-addition,
+.hljs-attr {
+    color: #13ce66;
 }
 
 .hljs-string,
-.hljs-meta .hljs-meta-string,
-.hljs-doctag,
-.hljs-regexp {
+.hljs-meta,
+.hljs-name,
+.hljs-type,
+.hljs-symbol,
+.hljs-bullet,
+.hljs-variable,
+.hljs-template-tag,
+.hljs-template-variable {
     color: #dacb4d;
 }
 
+.hljs-comment,
+.hljs-quote,
+.hljs-deletion {
+    color: #bfcbd9;
+}
+
+.hljs-title,
 .hljs-number,
 .hljs-literal {
     color: #a291f5 !important;

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -35,5 +35,8 @@ mix.options({
                 '@': path.resolve(__dirname, 'resources/js/'),
             },
         },
-        plugins: [new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)],
+        plugins: [new webpack.IgnorePlugin({
+            resourceRegExp: /^\.\/locale$/,
+            contextRegExp: /moment$/,
+        })],
     });


### PR DESCRIPTION
This PR fixes the syntax highlighting issues on the queries and the exceptions.

The syntax highlighting on the SQL code wasn't working at all:

#### Before
<img alt="queries-before" src="https://user-images.githubusercontent.com/667144/139736031-cd19dfb0-d001-4857-9546-a1b3cc2598db.png">

#### After

<img alt="queries-after" src="https://user-images.githubusercontent.com/667144/139736093-84bac847-e437-4dc0-9adc-f8dc2d0cc739.png">

There was no syntax highlighting on the exception code preview:

#### Before

<img alt="exception-before" src="https://user-images.githubusercontent.com/667144/139736431-00b51d82-7683-4589-981d-a83e2f333cd3.png">

#### After

<img alt="exception-after" src="https://user-images.githubusercontent.com/667144/139736449-f55cb523-8d0c-4135-b6a4-53157fbb7349.png">

I've updated highlight.js from 10.x to 11.x and added some css classes.

Also, I've reduced the bundle size by updating an outdated webpack configuration.
The `webpack.IgnorePlugin` has changed its syntax since it was added in 2018.

So now the bundle is reduced from **1128kb** to **894kb**!

See: https://webpack.js.org/plugins/ignore-plugin/#example-of-ignoring-moment-locales

I will also submit a PR in Horizon which uses the same configuration for webpack.IgnorePlugin.