### PR TITLE
Slow query filter method added

### DIFF
--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -213,6 +213,16 @@ class IncomingEntry
     }
 
     /**
+     * Determine if the incoming entry is a slow query.
+     *
+     * @return bool
+     */
+    public function isSlowQuery()
+    {
+        return $this->type === EntryType::QUERY && ($this->content['slow'] ?? false);
+    }
+
+    /**
      * Determine if the incoming entry is an authorization gate check.
      *
      * @return bool


### PR DESCRIPTION
### To filter slow query it looks like 

```
Telescope::filter(function (IncomingEntry $entry) {

    return $entry->type === EntryType::QUERY && ($entry->content['slow'] ?? false);

});
``` 


### If we use method it's much more readable and easy to add multiple or
```
Telescope::filter(function (IncomingEntry $entry) { 
    return $entry->isSlowQuery();
});
```