### PR TITLE
Merge previously defined view data when building the view mailable data

### DIFF
--- a/src/ExtractsMailableTags.php
+++ b/src/ExtractsMailableTags.php
@@ -14,12 +14,16 @@ trait ExtractsMailableTags
      */
     protected static function registerMailableTagExtractor()
     {
-        Mailable::buildViewDataUsing(function ($mailable) {
-            return [
+        $existingCallback = Mailable::$viewDataCallback;
+
+        Mailable::buildViewDataUsing(function ($mailable) use ($existingCallback) {
+            $existingData = $existingCallback ? call_user_func( $existingCallback, $mailable ) : [];
+
+            return array_merge($existingData, [
                 '__telescope' => ExtractTags::from($mailable),
                 '__telescope_mailable' => get_class($mailable),
                 '__telescope_queued' => in_array(ShouldQueue::class, class_implements($mailable)),
-            ];
+            ]);
         });
     }
 }

--- a/src/ExtractsMailableTags.php
+++ b/src/ExtractsMailableTags.php
@@ -17,7 +17,7 @@ trait ExtractsMailableTags
         $existingCallback = Mailable::$viewDataCallback;
 
         Mailable::buildViewDataUsing(function ($mailable) use ($existingCallback) {
-            $existingData = $existingCallback ? call_user_func( $existingCallback, $mailable ) : [];
+            $existingData = $existingCallback ? call_user_func($existingCallback, $mailable) : [];
 
             return array_merge($existingData, [
                 '__telescope' => ExtractTags::from($mailable),


### PR DESCRIPTION
Hi! :wave: 

In a project I manage, in which we use Telescope, we also have set up functionality to record any sent emails in the database using the `Illuminate\Mail\Mailable::buildViewDataUsing()` callback to pass the payload to the `MessageSending` or `MessageSent` events.

When we have Telescope enabled, we find that this functionality breaks. This is because when Telescope starts it registers its own data to build up views with, and therefore overwrites our mailable data. For reference, this is where we define our own mailable data: https://github.com/bristol-su/portal-mail/blob/develop/src/MailServiceProvider.php#L89

This PR retrieves the current callback during the `start` function, and then if it isn't empty calls it when building View data and merges the result with Telescopes view data. This won't lead to any breaking changes since all the Telescope data is still present and prioritised over existing data, but will allow telescope users to still use the overriding view data feature.