### PR TITLE
Allow filtering many tags

### DIFF
--- a/src/Storage/EntryTagModel.php
+++ b/src/Storage/EntryTagModel.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Laravel\Telescope\Storage;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Log;
+
+class EntryTagModel extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'telescope_entries_tags';
+
+    /**
+     * The name of the "updated at" column.
+     *
+     * @var string
+     */
+    const UPDATED_AT = null;
+
+    /**
+     * The primary key for the model.
+     *
+     * @var string
+     */
+    protected $primaryKey = null;
+
+    /**
+     * Prevent Eloquent from overriding uuid with `lastInsertId`.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * Get the current connection name for the model.
+     *
+     * @return string
+     */
+    public function getConnectionName()
+    {
+        return config('telescope.storage.database.connection');
+    }
+}


### PR DESCRIPTION
Adds the ability to filter entries with multiple tags separated by comma.
Example: status:200,graphql will only display entries with these 2 tags (status:200 and graphql)