### PR TITLE
[4.x] Fix issue with array hydration

### DIFF
--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -219,7 +219,7 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
             }
 
             $content = json_encode(array_merge(
-                json_decode($entry->content ?? $entry['content'], true) ?: [], $update->changes
+                json_decode($entry->content ?? $entry['content'] ?? [], true) ?: [], $update->changes
             ));
 
             $this->table('telescope_entries')

--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -219,7 +219,7 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
             }
 
             $content = json_encode(array_merge(
-                json_decode($entry->content, true) ?: [], $update->changes
+                json_decode($entry->content ?? $entry['content'], true) ?: [], $update->changes
             ));
 
             $this->table('telescope_entries')


### PR DESCRIPTION
If users have set retrieval of results from the database query builder to array hydration, the content parameter of an Telescope entry will be an array instead of an object. Therefor we'll need to fallback to an array if the parameter isn't an object.

Fixes #1164