### PR TITLE
[4.x] Add copy button in queries preview screen.

### DIFF
--- a/resources/js/components/CopyBtn.vue
+++ b/resources/js/components/CopyBtn.vue
@@ -1,0 +1,59 @@
+<script type="text/ecmascript-6">
+import $ from 'jquery';
+
+export default {
+    props: ['text'],
+
+    mounted() {
+        $('[data-toggle="tooltip"]').tooltip({})
+    },
+
+    methods: {
+        copyTextToClipboard() {
+            if (!navigator.clipboard) {
+                this.fallbackCopyTextToClipboard(this.text)
+                return;
+            }
+            navigator.clipboard.writeText(this.text).then(function () {
+                this.updateTooltipText()
+            }, function (err) {
+                alert('Unable to copying sql.')
+            });
+        },
+        fallbackCopyTextToClipboard() {
+            let textArea = document.createElement("textarea");
+            textArea.value = this.text;
+            // Avoid scrolling to bottom
+            textArea.style.top = "0";
+            textArea.style.left = "0";
+            textArea.style.position = "fixed";
+
+            document.body.appendChild(textArea);
+            textArea.focus();
+            textArea.select();
+
+            try {
+                document.execCommand('copy');
+                this.updateTooltipText()
+            } catch (err) {
+                alert('Unable to copying sql.')
+            }
+
+            document.body.removeChild(textArea);
+        },
+        updateTooltipText() {
+            $('.copy-btn').tooltip('dispose').attr('data-original-title', 'Copied!').tooltip('show').attr('data-original-title', 'Copy to clipboard');
+        }
+    }
+}
+</script>
+
+<template>
+    <button
+        class="d-inline btn btn-outline-primary btn-sm copy-btn"
+        @click="copyTextToClipboard()"
+        data-toggle="tooltip" data-placement="top" data-original-title="Copy to clipboard"
+    >
+        Copy
+    </button>
+</template>

--- a/resources/js/screens/queries/preview.vue
+++ b/resources/js/screens/queries/preview.vue
@@ -2,10 +2,12 @@
     import hljs from 'highlight.js/lib/core';
     import sql from 'highlight.js/lib/languages/sql';
     import { format } from 'sql-formatter';
+    import CopyBtn from "../../components/CopyBtn";
 
     hljs.registerLanguage('sql', sql);
 
     export default {
+        components: {CopyBtn},
         methods: {
             highlightSQL() {
                 this.$nextTick(() => {
@@ -52,7 +54,10 @@
 
         <div slot="after-attributes-card" slot-scope="slotProps">
             <div class="card mt-5">
-                <div class="card-header"><h5>Query</h5></div>
+                <div class="card-header">
+                    <h5 class="d-inline">Query</h5>
+                    <copy-btn class="float-right" :text="slotProps.entry.content.sql"></copy-btn>
+                </div>
 
                 <pre class="code-bg p-4 mb-0 text-white" ref="sqlcode">{{ formatSql(slotProps.entry.content.sql) }}</pre>
             </div>


### PR DESCRIPTION
With this PR a `copy` button was added to the queries preview screen. So that it will be easier to copy the SQL.

<img width="1440" alt="Screenshot 2022-01-25 at 7 08 15 PM" src="https://user-images.githubusercontent.com/17134979/150983450-1e8307e3-3d83-4f4f-a218-df61d79b6dbb.png">
