### PR TITLE
[4.x] Add exception context on job details

### DIFF
--- a/resources/js/screens/jobs/preview.vue
+++ b/resources/js/screens/jobs/preview.vue
@@ -95,6 +95,9 @@
                         <a class="nav-link" :class="{active: currentTab=='preview'}" href="#" v-on:click.prevent="currentTab='preview'" v-if="slotProps.entry.content.exception">Exception Location</a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" :class="{active: currentTab=='context'}" href="#" v-on:click.prevent="currentTab='context'" v-if="slotProps.entry.content.exception">Context</a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" :class="{active: currentTab=='trace'}" href="#" v-on:click.prevent="currentTab='trace'" v-if="slotProps.entry.content.exception">Stacktrace</a>
                     </li>
                 </ul>
@@ -103,6 +106,9 @@
                         <vue-json-pretty :data="slotProps.entry.content.data"></vue-json-pretty>
                     </div>
                     <pre class="code-bg p-4 mb-0 text-white" v-if="slotProps.entry.content.exception" v-show="currentTab=='exception'">{{slotProps.entry.content.exception.message}}</pre>
+                    <div class="code-bg p-4 mb-0 text-white" v-show="currentTab=='context'">
+                        <vue-json-pretty :data="slotProps.entry.content.exception.context"></vue-json-pretty>
+                    </div>
                     <stack-trace :trace="slotProps.entry.content.exception.trace" v-if="slotProps.entry.content.exception" v-show="currentTab=='trace'"></stack-trace>
                     <code-preview
                             v-if="slotProps.entry.content.exception"

--- a/src/Watchers/JobWatcher.php
+++ b/src/Watchers/JobWatcher.php
@@ -115,7 +115,7 @@ class JobWatcher extends Watcher
                     'line_preview' => ExceptionContext::get($event->exception),
                     'context' => method_exists($event->exception, 'context')
                         ? $event->exception->context()
-                        : [],
+                        : null,
                 ],
             ]
         )->addTags(['failed']));

--- a/src/Watchers/JobWatcher.php
+++ b/src/Watchers/JobWatcher.php
@@ -113,6 +113,9 @@ class JobWatcher extends Watcher
                     'trace' => $event->exception->getTrace(),
                     'line' => $event->exception->getLine(),
                     'line_preview' => ExceptionContext::get($event->exception),
+                    'context' => method_exists($event->exception, 'context')
+                        ? $event->exception->context()
+                        : [],
                 ],
             ]
         )->addTags(['failed']));


### PR DESCRIPTION
When an exception is thrown in a job, it is not shown on the "Exceptions" page but only on the "Job Details" page ([see this discussion](https://github.com/laravel/telescope/issues/626#issuecomment-1023507962)). The context of an exception coming from a job is therefore never shown on Telescope.

This PR remedies this by adding a "Context" tab on failed job pages.

<img width="1426" alt="Screenshot" src="https://user-images.githubusercontent.com/15859384/151434033-612d3374-302b-422e-b829-6e157dc327e3.png">

