### PR TITLE
[4.x] Attempt to fix model hydration

### DIFF
--- a/src/Watchers/ModelWatcher.php
+++ b/src/Watchers/ModelWatcher.php
@@ -51,15 +51,15 @@ class ModelWatcher extends Watcher
             return;
         }
 
-        $model = FormatModel::given($data[0]);
+        $modelClass = FormatModel::given($data[0]);
 
         $changes = $data[0]->getChanges();
 
         Telescope::recordModelEvent(IncomingEntry::make(array_filter([
             'action' => $this->action($event),
-            'model' => $model,
+            'model' => $modelClass,
             'changes' => empty($changes) ? null : $changes,
-        ]))->tags([$model]));
+        ]))->tags([$modelClass]));
     }
 
     /**
@@ -84,7 +84,13 @@ class ModelWatcher extends Watcher
 
             Telescope::recordModelEvent($this->hydrationEntries[$modelClass]);
         } else {
-            $this->hydrationEntries[$modelClass]->content['count']++;
+            $entry = $this->hydrationEntries[$modelClass];
+
+            if (is_string($this->hydrationEntries[$modelClass]->content)) {
+                $entry->content = json_decode($entry->content, true);
+            }
+
+            $entry->content['count']++;
         }
     }
 


### PR DESCRIPTION
This is an attempt to fix https://github.com/laravel/telescope/issues/1081 & https://github.com/laravel/telescope/issues/1068.

https://github.com/laravel/telescope/pull/1000 introduced the ability to record how many hydrations of a specific model occurred. This however, does not seem to function properly on Vapor specifically. [It was originally also post-reported on the related PR](https://github.com/laravel/telescope/pull/1000#discussion_r559066549) but given the nature of it being Vapor specific it was very hard to reproduce for the OP.

My analysis leads me to believe that the saving of the incoming entry occurs and then afterwards, for some reason unknown, Telescope still attempts to hydrate a model when being run on Vapor. Because [the incoming entry's `content` has already been json encoded here](https://github.com/laravel/telescope/blob/4.x/src/Storage/DatabaseEntriesRepository.php#L145), it's now a string and the following exception occurs for people:

> Cannot access offset of type string on string

I think this is because of some processing that happens after recording the entry which hydrates the same model again. It seems Vapor specific but most likely it's specifically due to any way an app handles processing after Telescope recording. However I could not in any way reproduce this locally.

Therefor I'm not 100% sure this fix will provide a solution to the aforementioned issues. Someone managed to solve it [by modifying the `DatabaseEntriesRepository`](https://github.com/laravel/telescope/issues/1068#issuecomment-852019407) but I don't think that's the correct place since this is specific to the `ModelWatcher`. I do not entirely know if Telescope will attempt to save the new entries again or if it'll ignore it.

I'd appreciate it if anyone from the related issues could attempt to deploy a fork of Telescope with this to see if that solves the issue for them on Vapor.