### PR TITLE
[4.x] Fix key handling for ModelWatcher

### DIFF
--- a/src/Watchers/ModelWatcher.php
+++ b/src/Watchers/ModelWatcher.php
@@ -51,9 +51,9 @@ class ModelWatcher extends Watcher
             return;
         }
 
-        $modelClass = FormatModel::given($data[0]);
+        $modelClass = FormatModel::given($data['model'] ?? $data[0]);
 
-        $changes = $data[0]->getChanges();
+        $changes = ($data['model'] ?? $data[0])->getChanges();
 
         Telescope::recordModelEvent(IncomingEntry::make(array_filter([
             'action' => $this->action($event),
@@ -71,7 +71,7 @@ class ModelWatcher extends Watcher
     public function recordHydrations($data)
     {
         if (! ($this->options['hydrations'] ?? false)
-            || ! $this->shouldRecordHydration($modelClass = get_class($data[0]))) {
+            || ! $this->shouldRecordHydration($modelClass = get_class($data['model'] ?? $data[0]))) {
             return;
         }
 


### PR DESCRIPTION
It seems a breakage snuck in with my previous PR: https://github.com/laravel/telescope/pull/1174. Because the payload is decoded as an associative array (as should because we can't guarantee the data order in the payload), when new events happen with this payload we'll need to reference the named key instead. 

It's beyond me why new events are recorded but I guess this can happen since every eloquent model event is being watched. 

Fixes https://github.com/laravel/telescope/issues/1178