### PR TITLE
[2.x] Truncate request url more

### DIFF
--- a/resources/js/screens/requests/index.vue
+++ b/resources/js/screens/requests/index.vue
@@ -27,7 +27,7 @@
                 </span>
             </td>
 
-            <td :title="slotProps.entry.content.uri">{{truncate(slotProps.entry.content.uri, 60)}}</td>
+            <td :title="slotProps.entry.content.uri">{{truncate(slotProps.entry.content.uri, 50)}}</td>
 
             <td class="table-fit">
                 <span class="badge font-weight-light" :class="'badge-'+requestStatusClass(slotProps.entry.content.response_status)">


### PR DESCRIPTION
This fixes an issue where the requests table was overflowing when the url path is too long. We can solve this simply by truncating the url a bit more.

Fixes #1193
