### PR TITLE
Add option to record dumps even though the dump watcher tab is not open

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -124,7 +124,10 @@ return [
             'ignore' => [],
         ],
 
-        Watchers\DumpWatcher::class => env('TELESCOPE_DUMP_WATCHER', true),
+        Watchers\DumpWatcher::class => [
+            'enabled' => env('TELESCOPE_DUMP_WATCHER', true),
+            'always' => env('TELESCOPE_DUMP_WATCHER_ALWAYS', false),
+        ],
 
         Watchers\EventWatcher::class => [
             'enabled' => env('TELESCOPE_EVENT_WATCHER', true),

--- a/src/Watchers/DumpWatcher.php
+++ b/src/Watchers/DumpWatcher.php
@@ -40,7 +40,7 @@ class DumpWatcher extends Watcher
      */
     public function register($app)
     {
-        if (! $this->options['always'] && ! $this->cache->get('telescope:dump-watcher')) {
+        if (! ($this->options['always'] ?? false) && ! $this->cache->get('telescope:dump-watcher')) {
             return;
         }
 

--- a/src/Watchers/DumpWatcher.php
+++ b/src/Watchers/DumpWatcher.php
@@ -40,7 +40,7 @@ class DumpWatcher extends Watcher
      */
     public function register($app)
     {
-        if (! env('TELESCOPE_RECORD_DUMP_WATCHER_ALWAYS', false) && ! $this->cache->get('telescope:dump-watcher')) {
+        if (! $this->options['always'] && ! $this->cache->get('telescope:dump-watcher')) {
             return;
         }
 

--- a/src/Watchers/DumpWatcher.php
+++ b/src/Watchers/DumpWatcher.php
@@ -40,7 +40,7 @@ class DumpWatcher extends Watcher
      */
     public function register($app)
     {
-        if (! $this->cache->get('telescope:dump-watcher')) {
+        if (! env('TELESCOPE_RECORD_DUMP_WATCHER_ALWAYS', false) && ! $this->cache->get('telescope:dump-watcher')) {
             return;
         }
 


### PR DESCRIPTION
This PR adds an environment variable (`TELESCOPE_DUMP_WATCHER_ALWAYS`) to let the user decide if Telescope should record dumps even if the dump watcher tab is closed.

I always expect my dumps to be recorded by Telescope and every time I forget to keep the dump watcher tab open, it throws me off. Here is a non-breaking solution to that.