### PR TITLE
Add pause and resume commands

### DIFF
--- a/src/Console/PauseCommand.php
+++ b/src/Console/PauseCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+
+class PauseCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'telescope:pause';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Pause all telescope watchers';
+    
+    /**
+     * The cache repository implementation.
+     *
+     * @var \Illuminate\Contracts\Cache\Repository
+     */
+    protected CacheRepository $cache;
+    
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct(CacheRepository $cache)
+    {
+        $this->cache = $cache;
+    
+        parent::__construct();
+    }
+    
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (!$this->cache->get('telescope:pause-recording')) {
+            $this->cache->put('telescope:pause-recording', true, now()->addDays(30));
+        }
+    
+        $this->info('Telescope was paused successfully.');
+    }
+}

--- a/src/Console/ResumeCommand.php
+++ b/src/Console/ResumeCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+
+class ResumeCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'telescope:resume';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Resume all telescope watchers';
+
+    /**
+     * The cache repository implementation.
+     *
+     * @var \Illuminate\Contracts\Cache\Repository
+     */
+    protected CacheRepository $cache;
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct(CacheRepository $cache)
+    {
+        $this->cache = $cache;
+
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if ($this->cache->get('telescope:pause-recording')) {
+            $this->cache->forget('telescope:pause-recording');
+        }
+
+        $this->info('Telescope was resumed successfully.');
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Opening a pull request for the above based on closed issue #655, adding two new commands for pausing and resuming telescope.

Think it would be good functionality to have, and shouldn't break any existing tests as the commands shouldn't collide with anything. As the state of pause/resume is being stored in the cache, I have noticed times where post build/release of my own apps, we have cleared the cache and Telescope has started watching again, slowing down the production application, so this has become a manual activity to pause it again. Adding these commands would allow them to be triggered without the need for manual input.

Sorry if there is anything I'm missing, first time I've done this.

