### PR TITLE
Use Throwable instead of Exception

### DIFF
--- a/src/IncomingExceptionEntry.php
+++ b/src/IncomingExceptionEntry.php
@@ -9,14 +9,14 @@ class IncomingExceptionEntry extends IncomingEntry
     /**
      * The underlying exception instance.
      *
-     * @var \Exception
+     * @var \Throwable
      */
     public $exception;
 
     /**
      * Create a new incoming entry instance.
      *
-     * @param  \Exception  $exception
+     * @param  \Throwable  $exception
      * @param  array  $content
      * @return void
      */

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -665,7 +665,7 @@ class Telescope
                 }
 
                 collect(static::$afterStoringHooks)->every->__invoke(static::$entriesQueue, $batchId);
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 app(ExceptionHandler::class)->report($e);
             }
         });

--- a/src/Watchers/ExceptionWatcher.php
+++ b/src/Watchers/ExceptionWatcher.php
@@ -2,13 +2,13 @@
 
 namespace Laravel\Telescope\Watchers;
 
-use Exception;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Support\Arr;
 use Laravel\Telescope\ExceptionContext;
 use Laravel\Telescope\ExtractTags;
 use Laravel\Telescope\IncomingExceptionEntry;
 use Laravel\Telescope\Telescope;
+use Throwable;
 
 class ExceptionWatcher extends Watcher
 {
@@ -78,6 +78,6 @@ class ExceptionWatcher extends Watcher
     private function shouldIgnore($event)
     {
         return ! isset($event->context['exception']) ||
-            ! $event->context['exception'] instanceof Exception;
+            ! $event->context['exception'] instanceof Throwable;
     }
 }

--- a/src/Watchers/LogWatcher.php
+++ b/src/Watchers/LogWatcher.php
@@ -2,11 +2,11 @@
 
 namespace Laravel\Telescope\Watchers;
 
-use Exception;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Support\Arr;
 use Laravel\Telescope\IncomingEntry;
 use Laravel\Telescope\Telescope;
+use Throwable;
 
 class LogWatcher extends Watcher
 {
@@ -62,6 +62,6 @@ class LogWatcher extends Watcher
     private function shouldIgnore($event)
     {
         return isset($event->context['exception']) &&
-            $event->context['exception'] instanceof Exception;
+            $event->context['exception'] instanceof Throwable;
     }
 }

--- a/tests/Watchers/ExceptionWatcherTest.php
+++ b/tests/Watchers/ExceptionWatcherTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Telescope\Tests\Watchers;
 
+use Error;
 use ErrorException;
 use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
@@ -36,7 +37,25 @@ class ExceptionWatcherTest extends FeatureTestCase
         $this->assertSame(EntryType::EXCEPTION, $entry->type);
         $this->assertSame(BananaException::class, $entry->content['class']);
         $this->assertSame(__FILE__, $entry->content['file']);
-        $this->assertSame(30, $entry->content['line']);
+        $this->assertSame(31, $entry->content['line']);
+        $this->assertSame('Something went bananas.', $entry->content['message']);
+        $this->assertArrayHasKey('trace', $entry->content);
+    }
+
+    public function test_exception_watcher_register_throwable_entries()
+    {
+        $handler = $this->app->get(ExceptionHandler::class);
+
+        $exception = new BananaError('Something went bananas.');
+
+        $handler->report($exception);
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::EXCEPTION, $entry->type);
+        $this->assertSame(BananaError::class, $entry->content['class']);
+        $this->assertSame(__FILE__, $entry->content['file']);
+        $this->assertSame(49, $entry->content['line']);
         $this->assertSame('Something went bananas.', $entry->content['message']);
         $this->assertArrayHasKey('trace', $entry->content);
     }
@@ -76,6 +95,11 @@ class ExceptionWatcherTest extends FeatureTestCase
 }
 
 class BananaException extends Exception
+{
+    //
+}
+
+class BananaError extends Error
 {
     //
 }


### PR DESCRIPTION
This will enable any Throwable, such as a PHP Error, to be picked up by Telescope and show up under the Exceptions tab.