### PR TITLE
CacheWatcher hide values

### DIFF
--- a/src/Watchers/CacheWatcher.php
+++ b/src/Watchers/CacheWatcher.php
@@ -103,6 +103,33 @@ class CacheWatcher extends Watcher
     }
 
     /**
+     * Determine the value of an event.
+     *
+     * @param  mixed  $event
+     * @return mixed
+     */
+    private function formatValue($event)
+    {
+        return (! $this->shouldHideValue($event))
+                    ? $event->value
+                    : '********';
+    }
+
+    /**
+     * Determine if the event value should be ignored.
+     *
+     * @param  mixed  $event
+     * @return bool
+     */
+    private function shouldHideValue($event)
+    {
+        return Str::is(
+            $this->options['hidden'] ?? [],
+            $event->key
+        );
+    }
+
+    /**
      * @param  \Illuminate\Cache\Events\KeyWritten  $event
      * @return mixed
      */
@@ -125,31 +152,5 @@ class CacheWatcher extends Watcher
             'framework/schedule*',
             'telescope:*',
         ], $event->key);
-    }
-
-    /**
-     * Determine the value of an event.
-     *
-     * @param  mixed  $event
-     * @return mixed
-     */
-    private function formatValue($event)
-    {
-        return (! $this->shouldHideValue($event))
-            ? $event->value : '********';
-    }
-
-    /**
-     * Determine if the event value should be ignored.
-     *
-     * @param  mixed  $event
-     * @return bool
-     */
-    private function shouldHideValue($event)
-    {
-        return Str::is(
-            $this->options['hideValues'] ?? [],
-            $event->key
-        );
     }
 }

--- a/src/Watchers/CacheWatcher.php
+++ b/src/Watchers/CacheWatcher.php
@@ -42,7 +42,7 @@ class CacheWatcher extends Watcher
         Telescope::recordCache(IncomingEntry::make([
             'type' => 'hit',
             'key' => $event->key,
-            'value' => $event->value,
+            'value' => $this->formatValue($event),
         ]));
     }
 
@@ -79,7 +79,7 @@ class CacheWatcher extends Watcher
         Telescope::recordCache(IncomingEntry::make([
             'type' => 'set',
             'key' => $event->key,
-            'value' => $event->value,
+            'value' => $this->formatValue($event),
             'expiration' => $this->formatExpiration($event),
         ]));
     }
@@ -125,5 +125,31 @@ class CacheWatcher extends Watcher
             'framework/schedule*',
             'telescope:*',
         ], $event->key);
+    }
+
+    /**
+     * Determine the value of an event.
+     *
+     * @param  mixed  $event
+     * @return mixed
+     */
+    private function formatValue($event)
+    {
+        return (! $this->shouldHideValue($event))
+            ? $event->value : '********';
+    }
+
+    /**
+     * Determine if the event value should be ignored.
+     *
+     * @param  mixed  $event
+     * @return bool
+     */
+    private function shouldHideValue($event)
+    {
+        return Str::is(
+            $this->options['hideValues'] ?? [],
+            $event->key
+        );
     }
 }

--- a/tests/Watchers/CacheWatcherTest.php
+++ b/tests/Watchers/CacheWatcherTest.php
@@ -17,7 +17,7 @@ class CacheWatcherTest extends FeatureTestCase
         $app->get('config')->set('telescope.watchers', [
             CacheWatcher::class => [
                 'enabled' => true,
-                'hideValues' => [
+                'hidden' => [
                     'my-hidden-value-key',
                 ],
             ],

--- a/tests/Watchers/CacheWatcherTest.php
+++ b/tests/Watchers/CacheWatcherTest.php
@@ -20,7 +20,7 @@ class CacheWatcherTest extends FeatureTestCase
                 'hideValues' => [
                     'my-hidden-value-key',
                 ],
-            ]
+            ],
         ]);
     }
 

--- a/tests/Watchers/CacheWatcherTest.php
+++ b/tests/Watchers/CacheWatcherTest.php
@@ -15,7 +15,12 @@ class CacheWatcherTest extends FeatureTestCase
         parent::getEnvironmentSetUp($app);
 
         $app->get('config')->set('telescope.watchers', [
-            CacheWatcher::class => true,
+            CacheWatcher::class => [
+                'enabled' => true,
+                'hideValues' => [
+                    'my-hidden-value-key',
+                ],
+            ]
         ]);
     }
 
@@ -75,5 +80,35 @@ class CacheWatcherTest extends FeatureTestCase
         $this->assertSame(EntryType::CACHE, $entry->type);
         $this->assertSame('forget', $entry->content['type']);
         $this->assertSame('outdated', $entry->content['key']);
+    }
+
+    public function test_cache_watcher_hides_hidden_values_when_set()
+    {
+        $this->app->get(Repository::class)->put('my-hidden-value-key', 'laravel', 1);
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::CACHE, $entry->type);
+        $this->assertSame('set', $entry->content['type']);
+        $this->assertSame('my-hidden-value-key', $entry->content['key']);
+        $this->assertSame('********', $entry->content['value']);
+    }
+
+    public function test_cache_watcher_hides_hidden_values_when_retrieved()
+    {
+        $repository = $this->app->get(Repository::class);
+
+        Telescope::withoutRecording(function () use ($repository) {
+            $repository->put('my-hidden-value-key', 'laravel', 1);
+        });
+
+        $repository->get('my-hidden-value-key');
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::CACHE, $entry->type);
+        $this->assertSame('hit', $entry->content['type']);
+        $this->assertSame('my-hidden-value-key', $entry->content['key']);
+        $this->assertSame('********', $entry->content['value']);
     }
 }


### PR DESCRIPTION
When using telescope, I ran into a problem that cache values were too big to store (`SQLSTATE[08S01]: Communication link failure: 1153 Got a packet bigger than 'max_allowed_packet' bytes`). I do not need to know the value, but I do want to know the event happened. This feature allows to hide the value, based on the key and allowing wildcards.