### PR TITLE
Added option to skip exception and relative occurrences when prune

### DIFF
--- a/src/Console/PruneCommand.php
+++ b/src/Console/PruneCommand.php
@@ -12,7 +12,7 @@ class PruneCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'telescope:prune {--hours=24 : The number of hours to retain Telescope data}';
+    protected $signature = 'telescope:prune {--hours=24 : The number of hours to retain Telescope data} {--skipException : If present will not delete the exception and relative occurrences}';
 
     /**
      * The console command description.
@@ -29,6 +29,6 @@ class PruneCommand extends Command
      */
     public function handle(PrunableRepository $repository)
     {
-        $this->info($repository->prune(now()->subHours($this->option('hours'))).' entries pruned.');
+        $this->info($repository->prune(now()->subHours($this->option('hours')), $this->option('skipException')) . ' entries pruned.');
     }
 }

--- a/src/Console/PruneCommand.php
+++ b/src/Console/PruneCommand.php
@@ -29,6 +29,6 @@ class PruneCommand extends Command
      */
     public function handle(PrunableRepository $repository)
     {
-        $this->info($repository->prune(now()->subHours($this->option('hours')), $this->option('skipException')) . ' entries pruned.');
+        $this->info($repository->prune(now()->subHours($this->option('hours')), $this->option('skipException')).' entries pruned.');
     }
 }

--- a/src/Contracts/PrunableRepository.php
+++ b/src/Contracts/PrunableRepository.php
@@ -10,7 +10,7 @@ interface PrunableRepository
      * Prune all of the entries older than the given date.
      *
      * @param  \DateTimeInterface  $before
-     * @param  boolean  $skipException
+     * @param  bool  $skipException
      * @return int
      */
     public function prune(DateTimeInterface $before, $skipException);

--- a/src/Contracts/PrunableRepository.php
+++ b/src/Contracts/PrunableRepository.php
@@ -10,7 +10,8 @@ interface PrunableRepository
      * Prune all of the entries older than the given date.
      *
      * @param  \DateTimeInterface  $before
+     * @param  boolean  $skipException
      * @return int
      */
-    public function prune(DateTimeInterface $before);
+    public function prune(DateTimeInterface $before, $skipException);
 }

--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -333,7 +333,7 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
      * Prune all of the entries older than the given date.
      *
      * @param  \DateTimeInterface  $before
-     * @param  boolean  $skipException
+     * @param  bool  $skipException
      * @return int
      */
     public function prune(DateTimeInterface $before, $skipException)

--- a/tests/Console/PruneCommandTest.php
+++ b/tests/Console/PruneCommandTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Telescope\Tests\Console;
 
 use Laravel\Telescope\Database\Factories\EntryModelFactory;
+use Laravel\Telescope\EntryType;
 use Laravel\Telescope\Tests\FeatureTestCase;
 
 class PruneCommandTest extends FeatureTestCase
@@ -25,6 +26,17 @@ class PruneCommandTest extends FeatureTestCase
         $recent = EntryModelFactory::new()->create(['created_at' => now()->subHours(5)]);
 
         $this->artisan('telescope:prune')->expectsOutput('0 entries pruned.');
+
+        $this->artisan('telescope:prune', ['--hours' => 4])->expectsOutput('1 entries pruned.');
+
+        $this->assertDatabaseMissing('telescope_entries', ['uuid' => $recent->uuid]);
+    }
+
+    public function test_prune_command_can_skip_exception()
+    {
+        $recent = EntryModelFactory::new()->create(['type' => EntryType::EXCEPTION, 'created_at' => now()->subHours(5)]);
+
+        $this->artisan('telescope:prune', ['--skipException' => true])->expectsOutput('0 entries pruned.');
 
         $this->artisan('telescope:prune', ['--hours' => 4])->expectsOutput('1 entries pruned.');
 


### PR DESCRIPTION
Hi, I have made a PR to give to possibility to keep exception and occurrences related to them, the reason is because in my case i have to make a prune every often but i would like to keep the exception and check them when i have time. This PR shouldn't break any existing features

