### PR TITLE
Read from Horizon config when ignoring requests

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -232,7 +232,7 @@ class Telescope
             collect([
                 'telescope-api*',
                 'vendor/telescope*',
-                'horizon*',
+                (config('horizon.path') ?? 'horizon') . '*',
                 'vendor/horizon*',
             ])
             ->merge(config('telescope.ignore_paths', []))

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -232,7 +232,7 @@ class Telescope
             collect([
                 'telescope-api*',
                 'vendor/telescope*',
-                (config('horizon.path') ?? 'horizon') . '*',
+                (config('horizon.path') ?? 'horizon').'*',
                 'vendor/horizon*',
             ])
             ->merge(config('telescope.ignore_paths', []))


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This is a small change that modifies https://github.com/laravel/telescope/pull/200 slightly by reading the Horizon path (if one is set / exists) when ignoring requests coming from Horizon, rather than hardcoding the default `horizon/*` path.