### PR TITLE
Defer loading monitored tags

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -146,7 +146,7 @@ class Telescope
             (static::runningApprovedArtisanCommand($app) ||
             static::handlingApprovedRequest($app))
         ) {
-            static::startRecording();
+            static::startRecording($loadMonitoredTags = false);
         }
     }
 
@@ -246,11 +246,14 @@ class Telescope
     /**
      * Start recording entries.
      *
+     * @param  bool  $loadMonitoredTags
      * @return void
      */
-    public static function startRecording()
+    public static function startRecording($loadMonitoredTags = true)
     {
-        app(EntriesRepository::class)->loadMonitoredTags();
+        if ($loadMonitoredTags) {
+            app(EntriesRepository::class)->loadMonitoredTags();
+        }
 
         static::$shouldRecord = ! cache('telescope:pause-recording');
     }


### PR DESCRIPTION
This PR updates the bootstrapping process to not load monitored tags during TelescopeServiceProvider::boot() and defer their loading until they first time they are actually needed.

Fixes https://github.com/laravel/telescope/issues/818