### PR TITLE
Relax user type in GateWatcher to match Laravel base framework.

### DIFF
--- a/src/Watchers/GateWatcher.php
+++ b/src/Watchers/GateWatcher.php
@@ -40,13 +40,13 @@ class GateWatcher extends Watcher
     /**
      * Record a gate check.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|mixed|null  $user
      * @param  string  $ability
      * @param  bool  $result
      * @param  array  $arguments
      * @return bool
      */
-    public function recordGateCheck(?Authenticatable $user, $ability, $result, $arguments)
+    public function recordGateCheck($user, $ability, $result, $arguments)
     {
         if (! Telescope::isRecording() || $this->shouldIgnore($ability)) {
             return;


### PR DESCRIPTION
The current `Watchers\GateWatcher` class expects to receive an optional Authenticatable value in place of the `$user` variable. This causes an exception to be thrown if you define gates against non-Authenticatable objects.

Gates can be defined against any object/model and may not be a user, even if this is the most common use case.
For example, in my app, I use a feature flag library that registers features as gates against an Organization model, where you can then do something like `$organization->can('v2.0')`.

The interface of the laravel `Gate` class specifies that it can be an Authenticatable or **mixed** parameter:
```
/**
     * Get a guard instance for the given user.
     *
     * @param  \Illuminate\Contracts\Auth\Authenticatable|mixed  $user
     * @return static
     */
    public function forUser($user);
```

This PR removes the type restriction in favour of accepting what is passed from Laravel itself, which resolves the exception.

Image attached as an example of the exception thrown
![localhost_14400_dashboard](https://user-images.githubusercontent.com/3436576/162761149-e6032f1f-8592-4cd2-bc61-99a4c658e499.png)
.