### PR TITLE
Add support for ignoring by HTTP Verb

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -171,6 +171,7 @@ return [
             'enabled' => env('TELESCOPE_REQUEST_WATCHER', true),
             'size_limit' => env('TELESCOPE_RESPONSE_SIZE_LIMIT', 64),
             'ignore_status_codes' => [],
+            'ignore_verbs' => [],
         ],
 
         Watchers\ScheduleWatcher::class => env('TELESCOPE_SCHEDULE_WATCHER', true),

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -170,8 +170,8 @@ return [
         Watchers\RequestWatcher::class => [
             'enabled' => env('TELESCOPE_REQUEST_WATCHER', true),
             'size_limit' => env('TELESCOPE_RESPONSE_SIZE_LIMIT', 64),
+            'ignore_http_methods' => [],
             'ignore_status_codes' => [],
-            'ignore_verbs' => [],
         ],
 
         Watchers\ScheduleWatcher::class => env('TELESCOPE_SCHEDULE_WATCHER', true),

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -36,8 +36,7 @@ class RequestWatcher extends Watcher
      */
     public function recordRequest(RequestHandled $event)
     {
-        if (! Telescope::isRecording() ||
-            $this->shouldIgnoreStatusCode($event)) {
+        if (! Telescope::isRecording() || $this->shouldIgnoreStatusCode($event) || $this->shouldIgnoreVerb($event)) {
             return;
         }
 
@@ -70,6 +69,20 @@ class RequestWatcher extends Watcher
         return in_array(
             $event->response->getStatusCode(),
             $this->options['ignore_status_codes'] ?? []
+        );
+    }
+
+    /**
+     * Determine if the request should be ignored based on its verb.
+     *
+     * @param  mixed  $event
+     * @return bool
+     */
+    protected function shouldIgnoreVerb($event)
+    {
+        return in_array(
+            $event->request->method(),
+            $this->options['ignore_verbs'] ?? []
         );
     }
 

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -61,7 +61,7 @@ class RequestWatcher extends Watcher
     }
 
     /**
-     * Determine if the request should be ignored based on its verb.
+     * Determine if the request should be ignored based on its method.
      *
      * @param  mixed  $event
      * @return bool

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -36,7 +36,9 @@ class RequestWatcher extends Watcher
      */
     public function recordRequest(RequestHandled $event)
     {
-        if (! Telescope::isRecording() || $this->shouldIgnoreStatusCode($event) || $this->shouldIgnoreVerb($event)) {
+        if (! Telescope::isRecording() ||
+            $this->shouldIgnoreHttpMethod($event) ||
+            $this->shouldIgnoreStatusCode($event)) {
             return;
         }
 
@@ -59,6 +61,22 @@ class RequestWatcher extends Watcher
     }
 
     /**
+     * Determine if the request should be ignored based on its verb.
+     *
+     * @param  mixed  $event
+     * @return bool
+     */
+    protected function shouldIgnoreHttpMethod($event)
+    {
+        return in_array(
+            strtolower($event->request->method()),
+            collect($this->options['ignore_http_methods'] ?? [])->map(function ($method) {
+                return strtolower($method);
+            })->all()
+        );
+    }
+
+    /**
      * Determine if the request should be ignored based on its status code.
      *
      * @param  mixed  $event
@@ -69,20 +87,6 @@ class RequestWatcher extends Watcher
         return in_array(
             $event->response->getStatusCode(),
             $this->options['ignore_status_codes'] ?? []
-        );
-    }
-
-    /**
-     * Determine if the request should be ignored based on its verb.
-     *
-     * @param  mixed  $event
-     * @return bool
-     */
-    protected function shouldIgnoreVerb($event)
-    {
-        return in_array(
-            $event->request->method(),
-            $this->options['ignore_verbs'] ?? []
         );
     }
 


### PR DESCRIPTION
Added the ability to disable request recording to `Watchers\RequestWatcher::class` by HTTP verb method.

I often have a situation where I need to turn off the preflight `OPTIONS` requests  recording or record only `GET` requests, so that it doesn't get distracting.