### PR TITLE
Add config key for environments telescope can be accessed in

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -20,6 +20,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Telescope Environments
+    |--------------------------------------------------------------------------
+    |
+    | These are the environments which can be set in .env where telescope can
+    | be accessed in. If accessing in environment which is not in this array
+    | you will get an HTTP 403 error.
+    |
+     */
+    'environments' => [
+        'local',
+        // e.g. 'staging', 'production'
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Telescope Path
     |--------------------------------------------------------------------------
     |

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -28,6 +28,7 @@ return [
     | you will get an HTTP 403 error.
     |
      */
+
     'environments' => [
         'local',
         // e.g. 'staging', 'production'

--- a/src/AuthorizesRequests.php
+++ b/src/AuthorizesRequests.php
@@ -33,7 +33,7 @@ trait AuthorizesRequests
     public static function check($request)
     {
         return (static::$authUsing ?: function () {
-            return app()->environment('local');
+            return app()->environment(config('telescope.environments', ['local']));
         })($request);
     }
 }


### PR DESCRIPTION
Currently, Laravel Telescope cannot be accessed in Environments like staging and production.

This PR adds a config key "environments" which contains a single value | array.

The AuthorizesRequests.php File reads this key or, if the key does not exists, it assumes only local access.