### PR TITLE
Set user model name in "Auth" tag

### DIFF
--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -149,7 +149,7 @@ class IncomingEntry
             ],
         ]);
 
-        $this->tags(['Auth:'.$user->getAuthIdentifier()]);
+        $this->tags([class_basename($user).':'.$user->getAuthIdentifier()]);
 
         return $this;
     }


### PR DESCRIPTION
at now while set `$this->user` in `IncomingEntry.php`, telescope add tag `"Auth:".$user->getAuthIdentifier()`. But if u have some `Authenticatable` model, like `User`, `Admin` etc (with different auth drivers), u get in telescope `Auth:1` from User model and `Auth:1` from Admin model.

With this PR in same case, u get `User:1` and `Admin:1` tags. `class_basename` function from laravel used