### PR TITLE
Check tags after set $this->user()

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -310,10 +310,6 @@ class Telescope
             return;
         }
 
-        $entry->type($type)->tags(Arr::collapse(array_map(function ($tagCallback) use ($entry) {
-            return $tagCallback($entry);
-        }, static::$tagUsing)));
-
         try {
             if (Auth::hasResolvedGuards() && Auth::hasUser()) {
                 $entry->user(Auth::user());
@@ -321,6 +317,10 @@ class Telescope
         } catch (Throwable $e) {
             // Do nothing.
         }
+
+		$entry->type($type)->tags(Arr::collapse(array_map(function ($tagCallback) use ($entry) {
+			return $tagCallback($entry);
+		}, static::$tagUsing)));
 
         static::withoutRecording(function () use ($entry) {
             if (collect(static::$filterUsing)->every->__invoke($entry)) {


### PR DESCRIPTION
At now, while u add tags in `register` method `TelescopeServiceProvider.php`, like:
```
Telescope::tag(function (IncomingEntry $entry) {
	$result = [];
	if ($entry->type === EntryType::CLIENT_REQUEST) {
		$result[] = 'http';
		$result[] = 'http:' . $entry->content['response_status'];
		if ($entry->content['response_status'] >= 400) {
			$result[] = 'failed';
		}
	}
	return $result;
});
```
u cant use `$entry->user`. its always `null`. 

This PR move parsing-tags-code after set-user-code. 