### PR TITLE
RequestWatcher & ClientRequestWatcher : HTML Response vs Empty Response

### DIFF
--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -115,6 +115,10 @@ class ClientRequestWatcher extends Watcher
             return 'Redirected to '.$response->header('Location');
         }
 
+        if (empty($content)) {
+            return 'Empty Response';
+        }
+
         return 'HTML Response';
     }
 

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -203,6 +203,10 @@ class RequestWatcher extends Watcher
             ];
         }
 
+        if (is_string($content) && empty($content)) {
+            return 'Empty Response';
+        }
+
         return 'HTML Response';
     }
 


### PR DESCRIPTION
Hello,

I'm using Telescope to watch incoming request & outgoing request. 

I was wondering if possible to distinguish a HTML Response with content vs an empty HTML Response.

What you think ?
