### PR TITLE
Using custom table name, and adding schema for the table

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -53,6 +53,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Telescope Custom Table Name
+    |--------------------------------------------------------------------------
+    | This configues custom name for table
+    |
+    */
+
+    'table_name' => [
+        'telescope_entries'      => 'telescope_entries',
+        'telescope_entries_tags' => 'telescope_entries_tags',
+        'telescope_monitoring'   => 'telescope_monitoring',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Telescope Master Switch
     |--------------------------------------------------------------------------
     |

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -55,7 +55,9 @@ return [
     |--------------------------------------------------------------------------
     | Telescope Custom Table Name
     |--------------------------------------------------------------------------
-    | This configues custom name for table
+    | This configures custom name for table. The name can include schema. 
+    | Your default schema will be used instead if you didn't specify.
+    | eg: 'telescope_entries'      => 'your_schema.telescope_entries',
     |
     */
 

--- a/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -13,6 +13,10 @@ return new class extends Migration
      */
     protected $schema;
 
+    protected $telescope_entries;
+    protected $telescope_entries_tags;
+    protected $telescope_monitoring;
+
     /**
      * Create a new migration instance.
      *
@@ -21,6 +25,10 @@ return new class extends Migration
     public function __construct()
     {
         $this->schema = Schema::connection($this->getConnection());
+
+        $this->telescope_entries      = config('telescope.table_name.telescope_entries');
+        $this->telescope_entries_tags = config('telescope.table_name.telescope_entries_tags');
+        $this->telescope_monitoring   = config('telescope.table_name.telescope_monitoring');
     }
 
     /**
@@ -40,7 +48,7 @@ return new class extends Migration
      */
     public function up()
     {
-        $this->schema->create('telescope_entries', function (Blueprint $table) {
+        $this->schema->create($this->telescope_entries, function (Blueprint $table) {
             $table->bigIncrements('sequence');
             $table->uuid('uuid');
             $table->uuid('batch_id');
@@ -57,7 +65,7 @@ return new class extends Migration
             $table->index(['type', 'should_display_on_index']);
         });
 
-        $this->schema->create('telescope_entries_tags', function (Blueprint $table) {
+        $this->schema->create($this->telescope_entries_tags, function (Blueprint $table) {
             $table->uuid('entry_uuid');
             $table->string('tag');
 
@@ -66,11 +74,11 @@ return new class extends Migration
 
             $table->foreign('entry_uuid')
                   ->references('uuid')
-                  ->on('telescope_entries')
+                  ->on($this->telescope_entries)
                   ->onDelete('cascade');
         });
 
-        $this->schema->create('telescope_monitoring', function (Blueprint $table) {
+        $this->schema->create($this->telescope_monitoring, function (Blueprint $table) {
             $table->string('tag');
         });
     }
@@ -82,8 +90,8 @@ return new class extends Migration
      */
     public function down()
     {
-        $this->schema->dropIfExists('telescope_entries_tags');
-        $this->schema->dropIfExists('telescope_entries');
-        $this->schema->dropIfExists('telescope_monitoring');
+        $this->schema->dropIfExists($this->telescope_entries_tags);
+        $this->schema->dropIfExists($this->telescope_entries);
+        $this->schema->dropIfExists($this->telescope_monitoring);
     }
 };

--- a/src/Storage/EntryModel.php
+++ b/src/Storage/EntryModel.php
@@ -11,13 +11,6 @@ class EntryModel extends Model
     use HasFactory;
 
     /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = 'telescope_entries';
-
-    /**
      * The name of the "updated at" column.
      *
      * @var string
@@ -117,7 +110,7 @@ class EntryModel extends Model
     {
         $query->when($options->tag, function ($query, $tag) {
             return $query->whereIn('uuid', function ($query) use ($tag) {
-                $query->select('entry_uuid')->from('telescope_entries_tags')->whereTag($tag);
+                $query->select('entry_uuid')->from(config('telescope.table_name.telescope_entries_tags'))->whereTag($tag);
             });
         });
 
@@ -182,6 +175,16 @@ class EntryModel extends Model
     public function getConnectionName()
     {
         return config('telescope.storage.database.connection');
+    }
+
+    /**
+     * Get the current connection name for the model.
+     *
+     * @return string
+     */
+    public function getTable()
+    {
+        return config('telescope.table_name.telescope_entries');
     }
 
     /**

--- a/src/Storage/EntryModel.php
+++ b/src/Storage/EntryModel.php
@@ -178,7 +178,7 @@ class EntryModel extends Model
     }
 
     /**
-     * Get the current connection name for the model.
+     * Get the current table name for the model.
      *
      * @return string
      */


### PR DESCRIPTION
User can choose to set the table to other table name, and also use schema for the table.
Default behavior for the table name is fixed to _**dbo**.telescope_entries_. 
In _Config > telescope.php_, just change the lines below: 
`'table_name' => [
        'telescope_entries'      => 'telescope_entries'
    ],` to 
`'table_name' => [
        'telescope_entries'      => 'schema.telescope_entries'
    ],`, the table name is now _**schema**.telescope_entries_
This enables multiple Telescope to be installed in the same database, provided each laravel use different schema.

The example above only for 1 table name, you can rename only 1 or all 3 table that are required.