### PR TITLE
Add response tab with full details for Gate screen

### DIFF
--- a/resources/js/screens/gates/preview.vue
+++ b/resources/js/screens/gates/preview.vue
@@ -11,6 +11,7 @@
             return {
                 entry: null,
                 batch: [],
+                currentTab: 'arguments'
             };
         }
     }
@@ -45,10 +46,17 @@
 
         <div slot="after-attributes-card" slot-scope="slotProps">
             <div class="card mt-5">
-                <div class="card-header"><h5>Arguments</h5></div>
-
+                <ul class="nav nav-pills">
+                    <li class="nav-item">
+                        <a class="nav-link" :class="{active: currentTab=='arguments'}" href="#" v-on:click.prevent="currentTab='arguments'">Arguments</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" :class="{active: currentTab=='response'}" href="#" v-on:click.prevent="currentTab='response'">Response</a>
+                    </li>
+                </ul>
                 <div class="code-bg p-4 mb-0 text-white">
-                    <vue-json-pretty :data="slotProps.entry.content.arguments"></vue-json-pretty>
+                    <vue-json-pretty :data="slotProps.entry.content.arguments" v-if="currentTab=='arguments'"></vue-json-pretty>
+                    <vue-json-pretty :data="slotProps.entry.content.response" v-if="currentTab=='response'"></vue-json-pretty>
                 </div>
             </div>
         </div>

--- a/src/Watchers/GateWatcher.php
+++ b/src/Watchers/GateWatcher.php
@@ -59,6 +59,7 @@ class GateWatcher extends Watcher
             'arguments' => $this->formatArguments($arguments),
             'file' => $caller['file'] ?? null,
             'line' => $caller['line'] ?? null,
+            'response' => $result instanceof Response ? $result->toArray() : null,
         ]));
 
         return $result;


### PR DESCRIPTION
I'm using `allow` and `deny`  Response in my Policies like this.

```
    public function viewAny(User $user): Response
    {
        if (...) {
            return $this->deny("User role is not authorized");
        }

        return $this->allow();
    }
```

This let me send a specific message when Authorization is refused but the data is ignored by telescope.

Here I propose to record and display the response content in a new tab next to `Arguments` one