### PR TITLE
[4.x] Do not record when unserializing command

### DIFF
--- a/src/Watchers/JobWatcher.php
+++ b/src/Watchers/JobWatcher.php
@@ -183,7 +183,11 @@ class JobWatcher extends Watcher
      */
     protected function updateBatch($payload)
     {
+        Telescope::$shouldRecord = false;
+
         $command = $this->getCommand($payload['data']);
+
+        Telescope::$shouldRecord = true;
 
         $properties = ExtractProperties::from(
             $command


### PR DESCRIPTION
This PR prevents Telescope from recording duplicate queries when unserializing a job. Ideally the duplicate queries shouldn't happen but at least this prevents duplicate date from being added to Telescope.

Fixes https://github.com/laravel/telescope/issues/1255