### PR TITLE
[4.x] Fix re-enabling recording

### DIFF
--- a/src/Watchers/JobWatcher.php
+++ b/src/Watchers/JobWatcher.php
@@ -183,11 +183,15 @@ class JobWatcher extends Watcher
      */
     protected function updateBatch($payload)
     {
+        $wasRecordingEnabled = Telescope::$shouldRecord;
+
         Telescope::$shouldRecord = false;
 
         $command = $this->getCommand($payload['data']);
 
-        Telescope::$shouldRecord = true;
+        if ($wasRecordingEnabled) {
+            Telescope::$shouldRecord = true;
+        }
 
         $properties = ExtractProperties::from(
             $command


### PR DESCRIPTION
Small adjustment for my PR at https://github.com/laravel/telescope/pull/1257. We should check if Telescope was recording to begin with. If it wasn't, we should also not re-enable recording.