### PR TITLE
Dont register redis watcher if the redis service is not bound into the container.

### DIFF
--- a/src/Watchers/RedisWatcher.php
+++ b/src/Watchers/RedisWatcher.php
@@ -16,6 +16,10 @@ class RedisWatcher extends Watcher
      */
     public function register($app)
     {
+        if (! $app->bound('redis')) {
+            return;
+        }
+
         $app['events']->listen(CommandExecuted::class, [$this, 'recordCommand']);
 
         foreach ((array) $app['redis']->connections() as $connection) {

--- a/tests/Watchers/RedisWatcherTest.php
+++ b/tests/Watchers/RedisWatcherTest.php
@@ -2,10 +2,12 @@
 
 namespace Laravel\Telescope\Tests\Watchers;
 
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Facades\Redis;
 use Laravel\Telescope\EntryType;
 use Laravel\Telescope\Tests\FeatureTestCase;
 use Laravel\Telescope\Watchers\RedisWatcher;
+use Mockery;
 
 class RedisWatcherTest extends FeatureTestCase
 {
@@ -35,5 +37,23 @@ class RedisWatcherTest extends FeatureTestCase
         $this->assertSame(EntryType::REDIS, $entry->type);
         $this->assertSame('get telescope:test', $entry->content['command']);
         $this->assertSame('default', $entry->content['connection']);
+    }
+
+    public function test_does_not_register_when_redis_unbound()
+    {
+        $app = Mockery::mock(Application::class);
+
+        $app->makePartial();
+
+        $app->expects('bound')
+            ->with('redis')
+            ->andReturn(false);
+
+        $app->shouldNotReceive('make')
+            ->with('redis');
+
+        $watcher = new RedisWatcher([]);
+
+        $watcher->register($app);
     }
 }


### PR DESCRIPTION
When installing Telescope into a Laravel application which has opted out of Redis support by removing the `RedisServiceProvider` in `app.php`, a `BindingResolutionException` is thrown during auto-discovery:

```sh
 ⇒  composer require --dev laravel/telescope
Info from https://repo.packagist.org: #StandWithUkraine
Using version ^4.9 for laravel/telescope
./composer.json has been updated
Running composer update laravel/telescope
Loading composer repositories with package information
Updating dependencies
Lock file operations: 1 install, 0 updates, 0 removals
  - Locking laravel/telescope (v4.9.4)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Downloading laravel/telescope (v4.9.4)
  - Installing laravel/telescope (v4.9.4): Extracting archive
Generating optimized autoload files
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover --ansi

   Illuminate\Contracts\Container\BindingResolutionException

  Target class [redis] does not exist.

  at vendor/laravel/framework/src/Illuminate/Container/Container.php:877
    873▕
    874▕         try {
    875▕             $reflector = new ReflectionClass($concrete);
    876▕         } catch (ReflectionException $e) {
  ➜ 877▕             throw new BindingResolutionException("Target class [$concrete] does not exist.", 0, $e);
    878▕         }
    879▕
    880▕         // If the type is not instantiable, the developer is attempting to resolve
    881▕         // an abstract type such as an Interface or Abstract Class and there is

  1   [internal]:0
      Illuminate\Foundation\Application::Illuminate\Foundation\{closure}(Object(Laravel\Telescope\TelescopeServiceProvider))

      +18 vendor frames
  20  [internal]:0
      Illuminate\Foundation\Application::Illuminate\Foundation\{closure}(Object(Laravel\Telescope\TelescopeServiceProvider))
Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 1
```

This can be prevented by disabling the watcher using a .env value, or modifying the `telescope.php` config file, but a user who is installing Telescope for the first time wont expect to have to do such a thing to get it working.

This pr makes the RedisWatcher register itself only when `redis` is bound into the application container to avoid this issue.

Thanks for your time.