### PR TITLE
Fix issue where json_encode quietly fails due to binary data inside telescope entry

### DIFF
--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -142,7 +142,7 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
 
         $entries->chunk($this->chunkSize)->each(function ($chunked) use ($table) {
             $table->insert($chunked->map(function ($entry) {
-                $entry->content = json_encode($entry->content);
+                $entry->content = json_encode($entry->content, JSON_INVALID_UTF8_SUBSTITUTE);
 
                 return $entry->toArray();
             })->toArray());


### PR DESCRIPTION
I have encountered an issue, where the telescope did not save any requests for me.

**Example of issue**:
Send a request to the application with telescope enabled: `/?my-parameter=4jOH%1a%14)%1a7%d1%60%8cd%40t%94%86m%e6%f8`
**The expected result**: Request to be logged (if so configured) in the telescope.
**Actual result**: Nothing is saved (as if no request was sent)

**Cause**:
json_encode in some situations fails to encode binary data, silently fails, and returns false.

**Possible abuse**:
This can also be abused and requests which are generated for malicious purposes could be hidden from the telescope simply by including a bit of binary data which fails to json_encode.

**Solution**:
We can tell json_encode to replace invalid utf8 characters to \0xfffd. Which corrupts the original request before saving it database, however, it seems like the lesser of two evils.