### PR TITLE
Add the Ability to Pass Custom `ignore_paths` To Query Watcher

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -145,6 +145,7 @@ return [
             'enabled' => env('TELESCOPE_GATE_WATCHER', true),
             'ignore_abilities' => [],
             'ignore_packages' => true,
+            'ignore_paths' => [],
         ],
 
         Watchers\JobWatcher::class => env('TELESCOPE_JOB_WATCHER', true),
@@ -162,6 +163,7 @@ return [
         Watchers\QueryWatcher::class => [
             'enabled' => env('TELESCOPE_QUERY_WATCHER', true),
             'ignore_packages' => true,
+            'ignore_paths' => [],
             'slow' => 100,
         ],
 

--- a/src/Watchers/FetchesStackTrace.php
+++ b/src/Watchers/FetchesStackTrace.php
@@ -21,9 +21,7 @@ trait FetchesStackTrace
                 return false;
             }
 
-            return ! Str::contains($frame['file'],
-                base_path('vendor'.DIRECTORY_SEPARATOR.$this->ignoredVendorPath())
-            );
+            return ! Str::contains($frame['file'], $this->ignoredPaths());
         });
     }
 
@@ -37,5 +35,15 @@ trait FetchesStackTrace
         if (! ($this->options['ignore_packages'] ?? true)) {
             return 'laravel';
         }
+    }
+
+    /**
+     * Backtrace files containing any of these strings won't be used.
+     */
+    protected function ignoredPaths(): array {
+        return array_merge(
+            [base_path('vendor'.DIRECTORY_SEPARATOR.$this->ignoredVendorPath())],
+            $this->options['ignore_paths'] ?? []
+        );
     }
 }

--- a/src/Watchers/FetchesStackTrace.php
+++ b/src/Watchers/FetchesStackTrace.php
@@ -40,7 +40,8 @@ trait FetchesStackTrace
     /**
      * Backtrace files containing any of these strings won't be used.
      */
-    protected function ignoredPaths(): array {
+    protected function ignoredPaths(): array
+    {
         return array_merge(
             [base_path('vendor'.DIRECTORY_SEPARATOR.$this->ignoredVendorPath())],
             $this->options['ignore_paths'] ?? []

--- a/src/Watchers/FetchesStackTrace.php
+++ b/src/Watchers/FetchesStackTrace.php
@@ -27,6 +27,8 @@ trait FetchesStackTrace
 
     /**
      * Get the file paths that should not be used by backtraces.
+     *
+     * @return array
      */
     protected function ignoredPaths(): array
     {
@@ -37,7 +39,7 @@ trait FetchesStackTrace
     }
 
     /**
-     * Choose the frame outside of either Telescope/Laravel or all packages.
+     * Choose the frame outside of either Telescope / Laravel or all packages.
      *
      * @return string|null
      */

--- a/src/Watchers/FetchesStackTrace.php
+++ b/src/Watchers/FetchesStackTrace.php
@@ -26,6 +26,17 @@ trait FetchesStackTrace
     }
 
     /**
+     * Get the file paths that should not be used by backtraces.
+     */
+    protected function ignoredPaths(): array
+    {
+        return array_merge(
+            [base_path('vendor'.DIRECTORY_SEPARATOR.$this->ignoredVendorPath())],
+            $this->options['ignore_paths'] ?? []
+        );
+    }
+
+    /**
      * Choose the frame outside of either Telescope/Laravel or all packages.
      *
      * @return string|null
@@ -35,16 +46,5 @@ trait FetchesStackTrace
         if (! ($this->options['ignore_packages'] ?? true)) {
             return 'laravel';
         }
-    }
-
-    /**
-     * Backtrace files containing any of these strings won't be used.
-     */
-    protected function ignoredPaths(): array
-    {
-        return array_merge(
-            [base_path('vendor'.DIRECTORY_SEPARATOR.$this->ignoredVendorPath())],
-            $this->options['ignore_paths'] ?? []
-        );
     }
 }


### PR DESCRIPTION
**Problem**

The "file" portion of the Query Watcher is unhelpful if you extend certain classes (e.g. `MySqlConnection.php`) since that adds a persistent layer to the stack trace.

<img src="https://user-images.githubusercontent.com/5145006/205431502-c1265726-6e5b-42c7-b07a-726ae18c3fc2.png" width="480px"/>

**Solution**

One easy fix for this is to allow folks to specify any extra files they want excluded from the stack trace like so:

```sql
Watchers\QueryWatcher::class => [
    'enabled' => env('TELESCOPE_QUERY_WATCHER', true),
    'ignore_packages' => true,
    'ignore_paths' => ['MySqlConnection.php'],
    'slow' => 100,
]
```

_(which fixes the above problem)_
<img src="https://user-images.githubusercontent.com/5145006/205431545-40e9efd5-fae5-4a30-8520-cf12a20a8808.png" width="480px"/>

**Where are the tests?**

`tests/Watchers/QueryWatcherTest.php` doesn't try testing `'file'` and there isn't a test file for `FetchesStackTrace.php`. I'm happy to take a go at adding some upon request if this solution seems acceptable. If not, let me know what solution you have in mind.