### PR TITLE
 adjust text-break layout with text-break class

### DIFF
--- a/resources/js/components/RelatedEntries.vue
+++ b/resources/js/components/RelatedEntries.vue
@@ -210,7 +210,7 @@
                     <tr v-for="entry in exceptions">
                         <td :title="entry.content.class">
                             {{truncate(entry.content.class, 70)}}<br>
-                            <small class="text-muted">{{truncate(entry.content.message, 100)}}</small>
+                            <small class="text-muted text-break">{{truncate(entry.content.message, 200)}}</small>
                         </td>
 
                         <td class="table-fit">


### PR DESCRIPTION
adjust text-break layout with text-break class

In the case of very long text, the layout was breaking with this adjustment, it automatically fixes it, I increased it to 200 characters as well.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
