### PR TITLE
Add support for model keys cast to backed enums in FormatModel

### DIFF
--- a/src/FormatModel.php
+++ b/src/FormatModel.php
@@ -25,7 +25,7 @@ class FormatModel
             $keys = $model->getKey();
         }
 
-        if ($keys instanceof BackedEnum) {
+        if (interface_exists('BackedEnum') && ($keys instanceof BackedEnum)) {
             $keys = $keys->value;
         }
 

--- a/src/FormatModel.php
+++ b/src/FormatModel.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Telescope;
 
+use BackedEnum;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Arr;
 
@@ -24,14 +25,8 @@ class FormatModel
             $keys = $model->getKey();
         }
 
-        $keys = Arr::wrap($keys);
-
-        if (interface_exists('BackedEnum')) {
-            $keys = array_map(function ($value) {
-                return ($value instanceof \BackedEnum) ? $value->value : $value;
-            }, $keys);
-        }
-
-        return get_class($model).':'.implode('_', $keys);
+        return get_class($model).':'.implode('_', array_map(function ($value) {
+            return $value instanceof BackedEnum ? $value->value : $value;
+        }, Arr::wrap($keys)));
     }
 }

--- a/src/FormatModel.php
+++ b/src/FormatModel.php
@@ -24,10 +24,14 @@ class FormatModel
             $keys = $model->getKey();
         }
 
-        if (interface_exists('BackedEnum') && ($keys instanceof \BackedEnum)) {
-            $keys = $keys->value;
+        $keys = Arr::wrap($keys);
+
+        if (interface_exists('BackedEnum')) {
+            $keys = array_map(function ($value) {
+                return ($value instanceof \BackedEnum) ? $value->value : $value;
+            }, $keys);
         }
 
-        return get_class($model).':'.implode('_', Arr::wrap($keys));
+        return get_class($model).':'.implode('_', $keys);
     }
 }

--- a/src/FormatModel.php
+++ b/src/FormatModel.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Telescope;
 
+use BackedEnum;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Arr;
 
@@ -23,6 +24,9 @@ class FormatModel
         } else {
             $keys = $model->getKey();
         }
+
+        if ($keys instanceof BackedEnum)
+		    $keys = $keys->value;
 
         return get_class($model).':'.implode('_', Arr::wrap($keys));
     }

--- a/src/FormatModel.php
+++ b/src/FormatModel.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Telescope;
 
-use BackedEnum;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Arr;
 
@@ -25,7 +24,7 @@ class FormatModel
             $keys = $model->getKey();
         }
 
-        if (interface_exists('BackedEnum') && ($keys instanceof BackedEnum)) {
+        if (interface_exists('BackedEnum') && ($keys instanceof \BackedEnum)) {
             $keys = $keys->value;
         }
 

--- a/src/FormatModel.php
+++ b/src/FormatModel.php
@@ -25,8 +25,9 @@ class FormatModel
             $keys = $model->getKey();
         }
 
-        if ($keys instanceof BackedEnum)
-		    $keys = $keys->value;
+        if ($keys instanceof BackedEnum) {
+            $keys = $keys->value;
+        }
 
         return get_class($model).':'.implode('_', Arr::wrap($keys));
     }


### PR DESCRIPTION
As the title states, add support for model keys cast to backed enums in FormatModel. I have not scouted the whole codebase, there may be other places where a fix is needed to support backed enums for model keys.

I came across this bug while working on a project of mine. I had left this project alone for a couple of weeks before resuming it today. The issue didn't happen before, and I did a `composer update` when resuming, so this might be a  regression. I, unfortunately, do not have the time to check more thoroughly.

Hope this helps. Thank you.