### PR TITLE
[4.x] Add allow list for Telescope events

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -137,6 +137,7 @@ return [
         Watchers\EventWatcher::class => [
             'enabled' => env('TELESCOPE_EVENT_WATCHER', true),
             'ignore' => [],
+            'allow' => [],
         ],
 
         Watchers\ExceptionWatcher::class => env('TELESCOPE_EXCEPTION_WATCHER', true),

--- a/src/Watchers/EventWatcher.php
+++ b/src/Watchers/EventWatcher.php
@@ -3,7 +3,6 @@
 namespace Laravel\Telescope\Watchers;
 
 use Closure;
-use Illuminate\Auth\Events\Registered;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Str;


### PR DESCRIPTION
This adds an explicit allow list for the EventWatcher to still record framework events that are added to this list even though all other framework events are ignored. This way, users can easily monitor events like Registred without being flooded with other framework events.

Resolves https://github.com/laravel/telescope/issues/1264