### PR TITLE
[4.x] Add failed client request to incoming entry

### DIFF
--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -284,13 +284,24 @@ class IncomingEntry
     }
 
     /**
-     * Determine if the incoming entry is an client request.
+     * Determine if the incoming entry is a client request.
      *
      * @return bool
      */
     public function isClientRequest()
     {
         return $this->type === EntryType::CLIENT_REQUEST;
+    }
+
+    /**
+     * Determine if the incoming entry is a failed client request.
+     *
+     * @return bool
+     */
+    public function isFailedClientRequest()
+    {
+        return $this->type === EntryType::CLIENT_REQUEST &&
+            ($this->content['response_status'] ?? 200) >= 500;
     }
 
     /**


### PR DESCRIPTION
Sometimes it can be handy to be able to quickly log outgoing HTTP client requests in production using a ENV variable however it takes a few more links to only log any **failed** outgoing HTTP client requests.

This PR adds a very simple `isFailedClientRequest` method that is almost identical to `isFailedRequest` that will allow the logging of failed HTTP client requests with in the service provider.

```php
Telescope::filter(function (IncomingEntry $entry) {
    if ($this->app->environment('local')) {
        return true;
    }

    return $entry->isReportableException() ||
        $entry->isFailedRequest() ||
        $entry->isClientRequest() ||
        $entry->isFailedClientRequest() || // easy addition
        $entry->isFailedJob() ||
        $entry->isScheduledTask() ||
        $entry->hasMonitoredTag();
});
```

Note: didn't add any tests as can't see any for existing filters - happy to add tests if required but did test locally and it works well.