### PR TITLE
[4.x] Handle redis connection exception on DumpWatcher register

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -256,6 +256,7 @@ class Telescope
         }
 
         $recordingPaused = false;
+
         try {
             $recordingPaused = cache('telescope:pause-recording');
         } catch (\Exception) {

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -259,7 +259,7 @@ class Telescope
 
         try {
             $recordingPaused = cache('telescope:pause-recording');
-        } catch (\Exception) {
+        } catch (Exception) {
             //
         }
 

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -255,7 +255,14 @@ class Telescope
             app(EntriesRepository::class)->loadMonitoredTags();
         }
 
-        static::$shouldRecord = ! cache('telescope:pause-recording');
+        $recordingPaused = false;
+        try {
+            $recordingPaused = cache('telescope:pause-recording');
+        } catch (\Exception) {
+            //
+        }
+
+        static::$shouldRecord = ! $recordingPaused;
     }
 
     /**

--- a/src/Watchers/DumpWatcher.php
+++ b/src/Watchers/DumpWatcher.php
@@ -41,9 +41,7 @@ class DumpWatcher extends Watcher
     public function register($app)
     {
         try {
-            $dumpWatcherCache = $this->cache->get('telescope:dump-watcher');
-
-            if (! ($this->options['always'] ?? false) && ! $dumpWatcherCache) {
+            if (! ($this->options['always'] ?? false) && ! $this->cache->get('telescope:dump-watcher')) {
                 return;
             }
         } catch (\Exception) {

--- a/src/Watchers/DumpWatcher.php
+++ b/src/Watchers/DumpWatcher.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Telescope\Watchers;
 
+use Exception;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Laravel\Telescope\IncomingDumpEntry;
 use Laravel\Telescope\Telescope;
@@ -44,7 +45,7 @@ class DumpWatcher extends Watcher
 
         try {
             $dumpWatcherCache = $this->cache->get('telescope:dump-watcher');
-        } catch (\Exception) {
+        } catch (Exception) {
             //
         }
 

--- a/src/Watchers/DumpWatcher.php
+++ b/src/Watchers/DumpWatcher.php
@@ -41,6 +41,7 @@ class DumpWatcher extends Watcher
     public function register($app)
     {
         $dumpWatcherCache = false;
+
         try {
             $dumpWatcherCache = $this->cache->get('telescope:dump-watcher');
         } catch (\Exception) {

--- a/src/Watchers/DumpWatcher.php
+++ b/src/Watchers/DumpWatcher.php
@@ -40,11 +40,14 @@ class DumpWatcher extends Watcher
      */
     public function register($app)
     {
+        $dumpWatcherCache = false;
         try {
-            if (! ($this->options['always'] ?? false) && ! $this->cache->get('telescope:dump-watcher')) {
-                return;
-            }
+            $dumpWatcherCache = $this->cache->get('telescope:dump-watcher');
         } catch (\Exception) {
+            //
+        }
+
+        if (! ($this->options['always'] ?? false) && $dumpWatcherCache) {
             return;
         }
 

--- a/src/Watchers/DumpWatcher.php
+++ b/src/Watchers/DumpWatcher.php
@@ -47,7 +47,7 @@ class DumpWatcher extends Watcher
             //
         }
 
-        if (! ($this->options['always'] ?? false) && $dumpWatcherCache) {
+        if (! ($this->options['always'] ?? false) && ! $dumpWatcherCache) {
             return;
         }
 

--- a/src/Watchers/DumpWatcher.php
+++ b/src/Watchers/DumpWatcher.php
@@ -40,7 +40,13 @@ class DumpWatcher extends Watcher
      */
     public function register($app)
     {
-        if (! ($this->options['always'] ?? false) && ! $this->cache->get('telescope:dump-watcher')) {
+        try {
+            $dumpWatcherCache = $this->cache->get('telescope:dump-watcher');
+
+            if (! ($this->options['always'] ?? false) && ! $dumpWatcherCache) {
+                return;
+            }
+        } catch (\Exception) {
             return;
         }
 


### PR DESCRIPTION
Fixes issue #620

When trying to `composer install` locally with the redis cache driver configured, if redis is unreachable the following error occurs:
```
php_network_getaddresses: getaddrinfo for redis failed: nodename nor servname provided, or not known

  at [internal]:0
      1▕ 

      +24 vendor frames 
  25  [internal]:0
      Illuminate\Foundation\Application::Illuminate\Foundation\{closure}(Object(Laravel\Telescope\TelescopeServiceProvider))

      +5 vendor frames 
  31  artisan:35
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 1
```

This PR fixes the issue by handling the occurred exception and returning from the WatchDumper registration handler. Same for the Telescope::startRecording method.