### PR TITLE
Fix migrations in tests with Laravel 9.52 & 10

### DIFF
--- a/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class CreateTelescopeEntriesTable extends Migration
 {
     /**
      * The database schema.


### PR DESCRIPTION
After PR https://github.com/laravel/framework/pull/46073 telescope migration is failing in tests when using in-memory databases.

```
...
128) Laravel\Telescope\Tests\Watchers\ViewWatcherTest::test_view_watcher_registers_views
Illuminate\Database\QueryException: SQLSTATE[HY000]: General error: 1 table "telescope_entries" already exists (Connection: testbench, SQL: create table "telescope_entries" ("sequence" integer primary key autoincrement not null, "uuid" varchar not null, "batch_id" varchar not null, "family_hash" varchar, "should_display_on_index" tinyint(1) not null default '1', "type" varchar not null, "content" text not null, "created_at" datetime))

/home/kirlit26/telescope_fork/vendor/laravel/framework/src/Illuminate/Database/Connection.php:760
/home/kirlit26/telescope_fork/vendor/laravel/framework/src/Illuminate/Database/Connection.php:720
/home/kirlit26/telescope_fork/vendor/laravel/framework/src/Illuminate/Database/Connection.php:546
/home/kirlit26/telescope_fork/vendor/laravel/framework/src/Illuminate/Database/Schema/Blueprint.php:109
/home/kirlit26/telescope_fork/vendor/laravel/framework/src/Illuminate/Database/Schema/Builder.php:439
/home/kirlit26/telescope_fork/vendor/laravel/framework/src/Illuminate/Database/Schema/Builder.php:285
/home/kirlit26/telescope_fork/database/migrations/2018_08_08_100000_create_telescope_entries_table.php:52
...
ERRORS!
Tests: 130, Assertions: 9, Errors: 128.
```

 Replacing an anonymous migration class with a named one solves this problem.
```
PHPUnit 9.5.23 #StandWithUkraine

Runtime:       PHP 8.1.7-1ubuntu3.2
Configuration: /home/kirlit26/telescope_fork/phpunit.xml.dist

...............................................................  63 / 130 ( 48%)
............................................................... 126 / 130 ( 96%)
....                                                            130 / 130 (100%)

Time: 00:01.316, Memory: 58.50 MB

```