### PR TITLE
Prevent `Laravel\Scout\Jobs\MakeSearchable` job from being recorded to avoid memory leak

### DIFF
--- a/src/Watchers/JobWatcher.php
+++ b/src/Watchers/JobWatcher.php
@@ -49,6 +49,10 @@ class JobWatcher extends Watcher
             return;
         }
 
+        if (get_class($payload['data']['command']) === 'Laravel\Scout\Jobs\MakeSearchable') {
+            return;
+        }
+
         $content = array_merge([
             'status' => 'pending',
         ], $this->defaultJobData($connection, $queue, $payload, $this->data($payload)));


### PR DESCRIPTION
@taylorotwell: As promised: this exact change in Telescope prevents a memory leak (causing models to be retained) when running the `scout:import` command w/ Laravel Scout. 

This happened in our case when the models being bulk imported are rather large and logging in Telescope is on. At that point, importing more than a 10k model entries simply ends the import as PHP runs out of memory. If the job is not recorded, this issue does not occur.

For anyone else reading, please take a look at the discussion in https://github.com/laravel/scout/pull/703 where I explain in more detail what happened in our use case.