### PR TITLE
[4.x] Display Tags on Index Pages 

### DIFF
--- a/resources/js/screens/batches/index.vue
+++ b/resources/js/screens/batches/index.vue
@@ -26,6 +26,10 @@
                 <small class="text-muted">
                     Connection: {{slotProps.entry.content.connection}} | Queue: {{slotProps.entry.content.queue}}
                 </small>
+                <br>
+                <small class="text-muted text-break" v-if="slotProps.entry.tags && slotProps.entry.tags.length">
+                    Tags: {{ slotProps.entry.tags && slotProps.entry.tags.length ? slotProps.entry.tags.slice(0,3).join(', ') : '' }}<span v-if="slotProps.entry.tags.length > 3"> ({{ slotProps.entry.tags.length - 3 }} more)</span>
+                </small>
             </td>
 
             <td>

--- a/resources/js/screens/cache/index.vue
+++ b/resources/js/screens/cache/index.vue
@@ -19,7 +19,13 @@
 
 
         <template slot="row" slot-scope="slotProps">
-            <td>{{truncate(slotProps.entry.content.key, 80)}}</td>
+            <td>
+                {{truncate(slotProps.entry.content.key, 80)}}
+                <br>
+                <small class="text-muted text-break" v-if="slotProps.entry.tags && slotProps.entry.tags.length">
+                    Tags: {{ slotProps.entry.tags && slotProps.entry.tags.length ? slotProps.entry.tags.slice(0,3).join(', ') : '' }}<span v-if="slotProps.entry.tags.length > 3"> ({{ slotProps.entry.tags.length - 3 }} more)</span>
+                </small>
+            </td>
 
             <td class="table-fit">
                 <span class="badge" :class="'badge-'+cacheActionTypeClass(slotProps.entry.content.type)">

--- a/resources/js/screens/events/index.vue
+++ b/resources/js/screens/events/index.vue
@@ -19,6 +19,10 @@
                 <span class="badge badge-secondary ml-2" v-if="slotProps.entry.content.broadcast">
                     Broadcast
                 </span>
+                <br>
+                <small class="text-muted text-break" v-if="slotProps.entry.tags && slotProps.entry.tags.length">
+                    Tags: {{ slotProps.entry.tags && slotProps.entry.tags.length ? slotProps.entry.tags.slice(0,3).join(', ') : '' }}<span v-if="slotProps.entry.tags.length > 3"> ({{ slotProps.entry.tags.length - 3 }} more)</span>
+                </small>
             </td>
 
             <td class="table-fit text-right text-muted">{{slotProps.entry.content.listeners.length}}</td>

--- a/resources/js/screens/exceptions/index.vue
+++ b/resources/js/screens/exceptions/index.vue
@@ -18,6 +18,10 @@
                 {{truncate(slotProps.entry.content.class, 70)}}<br>
 
                 <small class="text-muted">{{truncate(slotProps.entry.content.message, 100)}}</small>
+                <br>
+                <small class="text-muted text-break" v-if="slotProps.entry.tags && slotProps.entry.tags.length">
+                    Tags: {{ slotProps.entry.tags && slotProps.entry.tags.length ? slotProps.entry.tags.slice(0,3).join(', ') : '' }}<span v-if="slotProps.entry.tags.length > 3"> ({{ slotProps.entry.tags.length - 3 }} more)</span>
+                </small>
             </td>
 
             <td class="table-fit text-right text-muted" v-if="!$route.query.family_hash && !$route.query.tag">

--- a/resources/js/screens/gates/index.vue
+++ b/resources/js/screens/gates/index.vue
@@ -19,7 +19,13 @@
 
 
         <template slot="row" slot-scope="slotProps">
-            <td>{{truncate(slotProps.entry.content.ability, 80)}}</td>
+            <td>
+                {{truncate(slotProps.entry.content.ability, 80)}}
+                <br>
+                <small class="text-muted text-break" v-if="slotProps.entry.tags && slotProps.entry.tags.length">
+                    Tags: {{ slotProps.entry.tags && slotProps.entry.tags.length ? slotProps.entry.tags.slice(0,3).join(', ') : '' }}<span v-if="slotProps.entry.tags.length > 3"> ({{ slotProps.entry.tags.length - 3 }} more)</span>
+                </small>
+            </td>
 
             <td class="table-fit">
                 <span class="badge" :class="'badge-'+gateResultClass(slotProps.entry.content.result)">

--- a/resources/js/screens/jobs/index.vue
+++ b/resources/js/screens/jobs/index.vue
@@ -24,6 +24,10 @@
                 <small class="text-muted">
                     Connection: {{slotProps.entry.content.connection}} | Queue: {{slotProps.entry.content.queue}}
                 </small>
+                <br>
+                <small class="text-muted text-break" v-if="slotProps.entry.tags && slotProps.entry.tags.length">
+                    Tags: {{ slotProps.entry.tags && slotProps.entry.tags.length ? slotProps.entry.tags.slice(0,3).join(', ') : '' }}<span v-if="slotProps.entry.tags.length > 3"> ({{ slotProps.entry.tags.length - 3 }} more)</span>
+                </small>
             </td>
 
             <td class="table-fit">

--- a/resources/js/screens/logs/index.vue
+++ b/resources/js/screens/logs/index.vue
@@ -18,7 +18,13 @@
         </tr>
 
         <template slot="row" slot-scope="slotProps">
-            <td :title="slotProps.entry.content.message">{{truncate(slotProps.entry.content.message, 50)}}</td>
+            <td :title="slotProps.entry.content.message">
+                {{truncate(slotProps.entry.content.message, 50)}}
+                <br>
+                <small class="text-muted text-break" v-if="slotProps.entry.tags && slotProps.entry.tags.length">
+                    Tags: {{ slotProps.entry.tags && slotProps.entry.tags.length ? slotProps.entry.tags.slice(0,3).join(', ') : '' }}<span v-if="slotProps.entry.tags.length > 3"> ({{ slotProps.entry.tags.length - 3 }} more)</span>
+                </small>
+            </td>
 
             <td class="table-fit">
                 <span class="badge" :class="'badge-'+logLevelClass(slotProps.entry.content.level)">

--- a/resources/js/screens/mail/index.vue
+++ b/resources/js/screens/mail/index.vue
@@ -15,6 +15,7 @@
     <index-screen title="Mail" resource="mail">
         <tr slot="table-header">
             <th scope="col">Mailable</th>
+            <th scope="col">Subject</th>
             <th scope="col" class="text-right">Recipients</th>
             <th scope="col">Happened</th>
             <th scope="col"></th>
@@ -30,10 +31,12 @@
                 </span>
 
                 <br>
-
-                <small class="text-muted" :title="slotProps.entry.content.subject">
-                    Subject: {{truncate(slotProps.entry.content.subject, 90)}}
+                <small class="text-muted text-break" v-if="slotProps.entry.tags && slotProps.entry.tags.length">
+                    Tags: {{ slotProps.entry.tags && slotProps.entry.tags.length ? slotProps.entry.tags.slice(0,3).join(', ') : '' }}<span v-if="slotProps.entry.tags.length > 3"> ({{ slotProps.entry.tags.length - 3 }} more)</span>
                 </small>
+            </td>
+            <td :title="slotProps.entry.content.subject">
+                {{truncate(slotProps.entry.content.subject, 90)}}
             </td>
 
             <td class="table-fit text-right text-muted">{{recipientsCount(slotProps.entry)}}</td>

--- a/resources/js/screens/notifications/index.vue
+++ b/resources/js/screens/notifications/index.vue
@@ -25,8 +25,11 @@
                 <small class="text-muted" :title="slotProps.entry.content.notifiable">
                     Recipient: {{truncate(slotProps.entry.content.notifiable, 90)}}
                 </small>
+                <br>
+                <small class="text-muted text-break" v-if="slotProps.entry.tags && slotProps.entry.tags.length">
+                    Tags: {{ slotProps.entry.tags && slotProps.entry.tags.length ? slotProps.entry.tags.slice(0,3).join(', ') : '' }}<span v-if="slotProps.entry.tags.length > 3"> ({{ slotProps.entry.tags.length - 3 }} more)</span>
+                </small>
             </td>
-
             <td class="table-fit text-muted">{{truncate(slotProps.entry.content.channel, 20)}}</td>
 
             <td class="table-fit text-muted" :data-timeago="slotProps.entry.created_at" :title="slotProps.entry.created_at">

--- a/resources/js/screens/redis/index.vue
+++ b/resources/js/screens/redis/index.vue
@@ -13,7 +13,13 @@
 
 
         <template slot="row" slot-scope="slotProps">
-            <td><code>{{truncate(slotProps.entry.content.command, 80)}}</code></td>
+            <td>
+                <code>{{truncate(slotProps.entry.content.command, 80)}}</code>
+                <br>
+                <small class="text-muted text-break" v-if="slotProps.entry.tags && slotProps.entry.tags.length">
+                    Tags: {{ slotProps.entry.tags && slotProps.entry.tags.length ? slotProps.entry.tags.slice(0,3).join(', ') : '' }}<span v-if="slotProps.entry.tags.length > 3"> ({{ slotProps.entry.tags.length - 3 }} more)</span>
+                </small>
+            </td>
 
             <td class="table-fit text-right text-muted">{{slotProps.entry.content.time}}ms</td>
 

--- a/resources/js/screens/requests/index.vue
+++ b/resources/js/screens/requests/index.vue
@@ -27,7 +27,13 @@
                 </span>
             </td>
 
-            <td :title="slotProps.entry.content.uri">{{truncate(slotProps.entry.content.uri, 50)}}</td>
+            <td :title="slotProps.entry.content.uri">
+                {{truncate(slotProps.entry.content.uri, 50)}}
+                <br>
+                <small class="text-muted text-break" v-if="slotProps.entry.tags && slotProps.entry.tags.length">
+                    Tags: {{ slotProps.entry.tags && slotProps.entry.tags.length ? slotProps.entry.tags.slice(0,3).join(', ') : '' }}<span v-if="slotProps.entry.tags.length > 3"> ({{ slotProps.entry.tags.length - 3 }} more)</span>
+                </small>
+            </td>
 
             <td class="table-fit text-center">
                 <span class="badge" :class="'badge-'+requestStatusClass(slotProps.entry.content.response_status)">

--- a/resources/js/screens/views/index.vue
+++ b/resources/js/screens/views/index.vue
@@ -23,6 +23,10 @@
             <td>
                 {{slotProps.entry.content.name}} <br/>
                 <small class="text-muted">{{truncate(slotProps.entry.content.path, 100)}}</small>
+                <br>
+                <small class="text-muted text-break" v-if="slotProps.entry.tags && slotProps.entry.tags.length">
+                    Tags: {{ slotProps.entry.tags && slotProps.entry.tags.length ? slotProps.entry.tags.slice(0,3).join(', ') : '' }}<span v-if="slotProps.entry.tags.length > 3"> ({{ slotProps.entry.tags.length - 3 }} more)</span>
+                </small>
             </td>
 
             <td class="table-fit text-right text-muted">

--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -60,12 +60,10 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
      */
     public function find($id): EntryResult
     {
-        $entry = EntryModel::on($this->connection)->whereUuid($id)->firstOrFail();
-
-        $tags = $this->table('telescope_entries_tags')
-                        ->where('entry_uuid', $id)
-                        ->pluck('tag')
-                        ->all();
+        $entry = EntryModel::on($this->connection)
+            ->whereUuid($id)
+            ->with('tags')
+            ->firstOrFail();
 
         return new EntryResult(
             $entry->uuid,
@@ -75,7 +73,7 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
             $entry->family_hash,
             $entry->content,
             $entry->created_at,
-            $tags
+            $entry->tags->pluck('tag')->all()
         );
     }
 

--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -88,6 +88,7 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
     {
         return EntryModel::on($this->connection)
             ->withTelescopeOptions($type, $options)
+            ->with('tags')
             ->take($options->limit)
             ->orderByDesc('sequence')
             ->get()->reject(function ($entry) {
@@ -101,7 +102,7 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
                     $entry->family_hash,
                     $entry->content,
                     $entry->created_at,
-                    []
+                    $entry->tags->pluck('tag')->all()
                 );
             })->values();
     }

--- a/src/Storage/EntryModel.php
+++ b/src/Storage/EntryModel.php
@@ -126,8 +126,8 @@ class EntryModel extends Model
     protected function whereTag($query, EntryQueryOptions $options)
     {
         $query->when($options->tag, function ($query, $tag) {
-            return $query->whereIn('uuid', function ($query) use ($tag) {
-                $query->select('entry_uuid')->from('telescope_entries_tags')->whereTag($tag);
+            return $query->whereHas('tags', function ($query) use ($tag) {
+                $query->whereTag($tag);
             });
         });
 

--- a/src/Storage/EntryModel.php
+++ b/src/Storage/EntryModel.php
@@ -55,6 +55,16 @@ class EntryModel extends Model
     public $incrementing = false;
 
     /**
+     * Define the tag relationship.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function tags()
+    {
+        return $this->hasMany(EntryTagModel::class, 'entry_uuid');
+    }
+
+    /**
      * Scope the query for the given query options.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query

--- a/src/Storage/EntryTagModel.php
+++ b/src/Storage/EntryTagModel.php
@@ -41,4 +41,14 @@ class EntryTagModel extends Model
      * @var bool
      */
     public $incrementing = false;
+
+    /**
+     * Get the current connection name for the model.
+     *
+     * @return string
+     */
+    public function getConnectionName()
+    {
+        return config('telescope.storage.database.connection');
+    }
 }

--- a/src/Storage/EntryTagModel.php
+++ b/src/Storage/EntryTagModel.php
@@ -3,7 +3,6 @@
 namespace Laravel\Telescope\Storage;
 
 use Illuminate\Database\Eloquent\Model;
-use Laravel\Telescope\Database\Factories\EntryModelFactory;
 
 class EntryTagModel extends Model
 {

--- a/src/Storage/EntryTagModel.php
+++ b/src/Storage/EntryTagModel.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Laravel\Telescope\Storage;
+
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Telescope\Database\Factories\EntryModelFactory;
+
+class EntryTagModel extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'telescope_entries_tags';
+
+    /**
+     * Indicates if the model should be timestamped.
+     *
+     * @var bool
+     */
+    public $timestamps = false;
+
+    /**
+     * The primary key for the model.
+     *
+     * @var string
+     */
+    protected $primaryKey = '';
+
+    /**
+     * The "type" of the auto-incrementing ID.
+     *
+     * @var string
+     */
+    protected $keyType = '';
+
+    /**
+     * Prevent Eloquent from overriding uuid with `lastInsertId`.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+}


### PR DESCRIPTION
Similar to the Horizon UI, I think it will be useful to display the tags on the index page for the watchers that support it.

The tags will only be displayed if they exists and on the following pages

- Requests
- Jobs
- Batches
- Cache
- Events
- Exceptions
- Gates
- Logs
- Mail
- Notifications
- Redis
- Views

As part of this PR, I have added a new model EntryTagModel and the relationship tags have been defined on the EntryModel. The `whereTag` method has been updated as part of this


![image](https://user-images.githubusercontent.com/15047879/220142298-02b9c1f6-047e-4361-ad11-7ff5f5c30e1f.png)

![image](https://user-images.githubusercontent.com/15047879/220142424-27fba807-d0a1-4cff-bba3-b1a1cbd05b82.png)

![image](https://user-images.githubusercontent.com/15047879/220145810-135b8757-e019-4b44-9d9d-f0bb4c4ee93f.png)
