### PR TITLE
[4.x] Improvements for multiple Guards

### DIFF
--- a/resources/js/components/PreviewScreen.vue
+++ b/resources/js/components/PreviewScreen.vue
@@ -224,6 +224,13 @@
 
             <table class="table mb-0 card-bg-secondary table-borderless">
                 <tr>
+                    <td class="table-fit text-muted">Guard</td>
+
+                    <td>
+                        {{entry.content.user.guards.join(", ")}}
+                    </td>
+                </tr>
+                <tr>
                     <td class="table-fit text-muted">ID</td>
 
                     <td>

--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -154,7 +154,7 @@ class IncomingEntry
         ]);
         $this->tags([
             'Auth:'.$user->getAuthIdentifier(),
-            get_class($user).':'.$user->getAuthIdentifier()
+            get_class($user).':'.$user->getAuthIdentifier(),
         ]);
 
         return $this;
@@ -170,7 +170,7 @@ class IncomingEntry
 
                 return config("auth.providers.{$guard['provider']}.model");
             })
-            ->filter(fn($model) => $class === $model)
+            ->filter(fn ($model) => $class === $model)
             ->keys();
     }
 

--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -149,7 +149,7 @@ class IncomingEntry
             ],
         ]);
 
-        $this->tags(['Auth:'.$user->getAuthIdentifier()]);
+        $this->tags([get_class($user).':'.$user->getAuthIdentifier()]);
 
         return $this;
     }

--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -149,7 +149,10 @@ class IncomingEntry
             ],
         ]);
 
-        $this->tags([get_class($user).':'.$user->getAuthIdentifier()]);
+        $this->tags([
+            'Auth:'.$user->getAuthIdentifier(),
+            get_class($user).':'.$user->getAuthIdentifier()
+        ]);
 
         return $this;
     }


### PR DESCRIPTION
At the moment if you are using multiple guards on your app, there is not a way to identify which guard is being used on an entry.

The tag is always `Auth:1`.

I have updated the tag to include the full class name `{modelName}:{id}` as the screenshot bellow. 
In order to avoid any breaking changes to people that are monitoring tags at the moment for certain users I haven't removed the tag `Auth:{id}`

I have also added the guard name(s) on the Authenticated User Panel


![image](https://user-images.githubusercontent.com/15047879/220168071-e16aa713-e8e1-4c57-a8ac-a4ade539fae3.png)
