### PR TITLE
[4.x] Allows to specify the log level

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -149,7 +149,12 @@ return [
         ],
 
         Watchers\JobWatcher::class => env('TELESCOPE_JOB_WATCHER', true),
-        Watchers\LogWatcher::class => env('TELESCOPE_LOG_WATCHER', true),
+
+        Watchers\LogWatcher::class => [
+            'enabled' => env('TELESCOPE_LOG_WATCHER', true),
+            'level' => 'error',
+        ],
+
         Watchers\MailWatcher::class => env('TELESCOPE_MAIL_WATCHER', true),
 
         Watchers\ModelWatcher::class => [

--- a/src/Watchers/LogWatcher.php
+++ b/src/Watchers/LogWatcher.php
@@ -12,7 +12,7 @@ use Throwable;
 class LogWatcher extends Watcher
 {
     /**
-     * The list of log level priorities.
+     * The available log level priorities.
      */
     private const PRIORITIES = [
         LogLevel::DEBUG => 100,

--- a/src/Watchers/LogWatcher.php
+++ b/src/Watchers/LogWatcher.php
@@ -83,8 +83,8 @@ class LogWatcher extends Watcher
         $telescopeLevel = $this->options['level'] ?? 'debug';
         $eventLevel = $event->level;
 
-        $telescopePriority = static::PRIORITIES[$telescopeLevel] ?? 100;
-        $eventPriority = static::PRIORITIES[$eventLevel] ?? 100;
+        $telescopePriority = static::PRIORITIES[$telescopeLevel] ?? static::PRIORITIES[LogLevel::DEBUG];
+        $eventPriority = static::PRIORITIES[$eventLevel] ?? static::PRIORITIES[LogLevel::DEBUG];
 
         return $eventPriority < $telescopePriority;
     }

--- a/src/Watchers/LogWatcher.php
+++ b/src/Watchers/LogWatcher.php
@@ -80,12 +80,12 @@ class LogWatcher extends Watcher
             return true;
         }
 
-        $telescopeLevel = $this->options['level'] ?? 'debug';
-        $eventLevel = $event->level;
+        $minimumTelescopeLogLevel = static::PRIORITIES[$this->options['level'] ?? 'debug']
+                ?? static::PRIORITIES[LogLevel::DEBUG];
 
-        $telescopePriority = static::PRIORITIES[$telescopeLevel] ?? static::PRIORITIES[LogLevel::DEBUG];
-        $eventPriority = static::PRIORITIES[$eventLevel] ?? static::PRIORITIES[LogLevel::DEBUG];
+        $eventLogLevel = static::PRIORITIES[$event->level]
+                ?? static::PRIORITIES[LogLevel::DEBUG];
 
-        return $eventPriority < $telescopePriority;
+        return $eventLogLevel < $minimumTelescopeLogLevel;
     }
 }

--- a/tests/Watchers/LogWatcherTest.php
+++ b/tests/Watchers/LogWatcherTest.php
@@ -136,7 +136,6 @@ class LogWatcherTest extends FeatureTestCase
         $this->assertNull($entry);
     }
 
-
     /**
      * @dataProvider logLevelProvider
      */

--- a/tests/Watchers/LogWatcherTest.php
+++ b/tests/Watchers/LogWatcherTest.php
@@ -16,8 +16,25 @@ class LogWatcherTest extends FeatureTestCase
 
         $app->get('config')->set('logging.default', 'syslog');
 
+        $config = match ($this->getName(false)) {
+            'test_log_watcher_registers_entry_for_any_level_by_default' => true,
+            'test_log_watcher_only_registers_entries_for_the_specified_error_level_priority' => [
+                'enabled' => true,
+                'level' => 'error',
+            ],
+            'test_log_watcher_only_registers_entries_for_the_specified_debug_level_priority' => [
+                'level' => 'debug',
+            ],
+            'test_log_watcher_do_not_registers_entry_when_disabled_on_the_boolean_format' => false,
+            'test_log_watcher_do_not_registers_entry_when_disabled_on_the_array_format' => [
+                'enabled' => false,
+                'level' => 'error',
+            ],
+            'test_log_watcher_registers_entry_with_exception_key' => true,
+        };
+
         $app->get('config')->set('telescope.watchers', [
-            LogWatcher::class => true,
+            LogWatcher::class => $config,
         ]);
     }
 
@@ -38,7 +55,7 @@ class LogWatcherTest extends FeatureTestCase
     /**
      * @dataProvider logLevelProvider
      */
-    public function test_log_watcher_registers_entry_for_any_level($level)
+    public function test_log_watcher_registers_entry_for_any_level_by_default($level)
     {
         $logger = $this->app->get(LoggerInterface::class);
 
@@ -54,6 +71,87 @@ class LogWatcherTest extends FeatureTestCase
         $this->assertSame("Logging Level [$level].", $entry->content['message']);
         $this->assertSame('Claire Redfield', $entry->content['context']['user']);
         $this->assertSame('Zombie Hunter', $entry->content['context']['role']);
+    }
+
+    /**
+     * @dataProvider logLevelProvider
+     */
+    public function test_log_watcher_only_registers_entries_for_the_specified_error_level_priority($level)
+    {
+        $logger = $this->app->get(LoggerInterface::class);
+
+        $logger->$level("Logging Level [$level].", [
+            'user' => 'Claire Redfield',
+            'role' => 'Zombie Hunter',
+        ]);
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        if (in_array($level, [LogLevel::EMERGENCY, LogLevel::ALERT, LogLevel::CRITICAL, LogLevel::ERROR])) {
+            $this->assertSame(EntryType::LOG, $entry->type);
+            $this->assertSame($level, $entry->content['level']);
+            $this->assertSame("Logging Level [$level].", $entry->content['message']);
+            $this->assertSame('Claire Redfield', $entry->content['context']['user']);
+            $this->assertSame('Zombie Hunter', $entry->content['context']['role']);
+        } else {
+            $this->assertNull($entry);
+        }
+    }
+
+    /**
+     * @dataProvider logLevelProvider
+     */
+    public function test_log_watcher_only_registers_entries_for_the_specified_debug_level_priority($level)
+    {
+        $logger = $this->app->get(LoggerInterface::class);
+
+        $logger->$level("Logging Level [$level].", [
+            'user' => 'Claire Redfield',
+            'role' => 'Zombie Hunter',
+        ]);
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::LOG, $entry->type);
+        $this->assertSame($level, $entry->content['level']);
+        $this->assertSame("Logging Level [$level].", $entry->content['message']);
+        $this->assertSame('Claire Redfield', $entry->content['context']['user']);
+        $this->assertSame('Zombie Hunter', $entry->content['context']['role']);
+    }
+
+    /**
+     * @dataProvider logLevelProvider
+     */
+    public function test_log_watcher_do_not_registers_entry_when_disabled_on_the_boolean_format($level)
+    {
+        $logger = $this->app->get(LoggerInterface::class);
+
+        $logger->$level("Logging Level [$level].", [
+            'user' => 'Claire Redfield',
+            'role' => 'Zombie Hunter',
+        ]);
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertNull($entry);
+    }
+
+
+    /**
+     * @dataProvider logLevelProvider
+     */
+    public function test_log_watcher_do_not_registers_entry_when_disabled_on_the_array_format($level)
+    {
+        $logger = $this->app->get(LoggerInterface::class);
+
+        $logger->$level("Logging Level [$level].", [
+            'user' => 'Claire Redfield',
+            'role' => 'Zombie Hunter',
+        ]);
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertNull($entry);
     }
 
     public function test_log_watcher_registers_entry_with_exception_key()


### PR DESCRIPTION
This merge request adds the `level` option to the `LogWatcher` in Telescope. The default value of the `level` option is debug, for backward compatibility. However, after merging this request, users will begin to use the updated configuration stub with error as the default log level.

It's important to note that regular deprecations are considered as warnings. Therefore, users will only see the deprecations in their telescope table if they set the log level to `warning` or lower.

One thing, up to debate, is that whether the `LOG_LEVEL` environment variable should be utilized in the config/telescope.php stub.