### PR TITLE
Return callable output on Telescope::withoutRecording

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -279,7 +279,7 @@ class Telescope
      * Execute the given callback without recording Telescope entries.
      *
      * @param  callable  $callback
-     * @return void
+     * @return mixed
      */
     public static function withoutRecording($callback)
     {
@@ -288,7 +288,7 @@ class Telescope
         static::$shouldRecord = false;
 
         try {
-            call_user_func($callback);
+            return call_user_func($callback);
         } finally {
             static::$shouldRecord = $shouldRecord;
         }


### PR DESCRIPTION
This PR allows method Telescope::withoutRecording to return output of the passed callable method thus allowing to make cleaner code & more in line with what is already used for database transactions in Eloquent.

I came accross this when trying to disable telescope logging on one particular command.

**Before:**
```php
Telescope::stopRecording();

if(/* Some condition */)
    Telescope::startRecording();
    return self::SUCCESS;
}

Telescope::startRecording();
return self::FAILURE;
```

**After:**
```php
return Telescope::withoutRecording(function() {
    if(/* Some condition */)
        return self::SUCCESS;
    }
    
    return self::FAILURE;
});
```