### PR TITLE
Enable watchers only in local environment

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -62,7 +62,7 @@ return [
     |
     */
 
-    'enabled' => env('TELESCOPE_ENABLED', true),
+    'enabled' => env('TELESCOPE_ENABLED', (config('app.env') == 'local')),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -62,7 +62,7 @@ return [
     |
     */
 
-    'enabled' => env('TELESCOPE_ENABLED', (config('app.env') == 'local')),
+    'enabled' => env('TELESCOPE_ENABLED', config('app.env') == 'local'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
In case the project environment is set to production and a developer neglects to disable **TELESCOPE_ENABLED** by not adding "**TELESCOPE_ENABLED=FALSE"** to the **.env** file, it could lead to a major problem with Telescope watchers. The **create** method in Eloquent is unable to return the **id** after storing data in the database. To prevent such issues from occurring, we can use the code **'enabled' => env('TELESCOPE_ENABLED', (config('app.env') == 'local')),**. This checks if **TELESCOPE_ENABLED** is present, and if it is not found and the environment is not local, the default value will be set to **false**.