### PR TITLE
[4.x] Don't use constructor injection in console commands, and inject into handle() instead

### DIFF
--- a/src/Console/PauseCommand.php
+++ b/src/Console/PauseCommand.php
@@ -22,34 +22,15 @@ class PauseCommand extends Command
     protected $description = 'Pause all Telescope watchers';
 
     /**
-     * The cache repository implementation.
-     *
-     * @var \Illuminate\Contracts\Cache\Repository
-     */
-    protected $cache;
-
-    /**
-     * Create a new command instance.
+     * Execute the console command.
      *
      * @param  \Illuminate\Contracts\Cache\Repository  $cache
      * @return void
      */
-    public function __construct(CacheRepository $cache)
+    public function handle(CacheRepository $cache)
     {
-        parent::__construct();
-
-        $this->cache = $cache;
-    }
-
-    /**
-     * Execute the console command.
-     *
-     * @return void
-     */
-    public function handle()
-    {
-        if (! $this->cache->get('telescope:pause-recording')) {
-            $this->cache->put('telescope:pause-recording', true, now()->addDays(30));
+        if (! $cache->get('telescope:pause-recording')) {
+            $cache->put('telescope:pause-recording', true, now()->addDays(30));
         }
 
         $this->info('Telescope watchers paused successfully.');

--- a/src/Console/ResumeCommand.php
+++ b/src/Console/ResumeCommand.php
@@ -22,34 +22,15 @@ class ResumeCommand extends Command
     protected $description = 'Unpause all Telescope watchers';
 
     /**
-     * The cache repository implementation.
-     *
-     * @var \Illuminate\Contracts\Cache\Repository
-     */
-    protected $cache;
-
-    /**
-     * Create a new command instance.
+     * Execute the console command.
      *
      * @param  \Illuminate\Contracts\Cache\Repository  $cache
      * @return void
      */
-    public function __construct(CacheRepository $cache)
+    public function handle(CacheRepository $cache)
     {
-        parent::__construct();
-
-        $this->cache = $cache;
-    }
-
-    /**
-     * Execute the console command.
-     *
-     * @return void
-     */
-    public function handle()
-    {
-        if ($this->cache->get('telescope:pause-recording')) {
-            $this->cache->forget('telescope:pause-recording');
+        if ($cache->get('telescope:pause-recording')) {
+            $cache->forget('telescope:pause-recording');
         }
 
         $this->info('Telescope watchers resumed successfully.');


### PR DESCRIPTION
When using a custom cache driver that depends on runtime context, this causes `php artisan package:discover` to fail as that context is not available, when it would be when `handle()` injection is performed.

Other telescope commands are using `handle()` injection aswell so this makes it more consistent throughout.