### PR TITLE
Fix issue with empty Telescope/Horizon path disables recording

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -231,11 +231,13 @@ class Telescope
             collect([
                 'telescope-api*',
                 'vendor/telescope*',
-                (config('horizon.path') ?? 'horizon').'*',
                 'vendor/horizon*',
             ])
             ->merge(config('telescope.ignore_paths', []))
-            ->unless(is_null(config('telescope.path')), function ($paths) {
+            ->unless(blank(config('horizon.path')), function ($paths) {
+                return $paths->prepend(config('horizon.path').'*');
+            })
+            ->unless(blank(config('telescope.path')), function ($paths) {
                 return $paths->prepend(config('telescope.path').'*');
             })
             ->all()


### PR DESCRIPTION
Fixes #1300.

This pull request fixes issue #1300. The issue caused recording to be disabled when the Telescope or Horizon path was set to an empty string `''`. With this fix, it's now possible to host Telescope and Horizon at different subdomains, without disabling recording.
