### PR TITLE
Retry updating data that cannot be queried in JobWatcher

### DIFF
--- a/src/Contracts/EntriesRepository.php
+++ b/src/Contracts/EntriesRepository.php
@@ -42,6 +42,14 @@ interface EntriesRepository
     public function update(Collection $updates);
 
     /**
+     * return update failed entries.
+     *
+     * @param  \Laravel\Telescope\IncomingEntry[]  $entries
+     * @return \Laravel\Telescope\EntryUpdate[]  $updates
+     */
+    public function getFailedEntries(array $entries);
+
+    /**
      * Load the monitored tags from storage.
      *
      * @return void

--- a/src/ListensForStorageOpportunities.php
+++ b/src/ListensForStorageOpportunities.php
@@ -62,7 +62,7 @@ trait ListensForStorageOpportunities
     protected static function storeEntriesBeforeTermination($app)
     {
         $app->terminating(function () use ($app) {
-            static::store($app[EntriesRepository::class]);
+            static::store($app[EntriesRepository::class],true);
         });
     }
 


### PR DESCRIPTION
Fixed bug [#577](https://github.com/laravel/telescope/issues/577)

Reason [ look this #1336](https://github.com/laravel/telescope/pull/1336#issue-1670345439)

We will not use the queue  worker to update them in this time,but update them after the original request queued it finishes.
