### PR TITLE
Excluding SQL Statements in QueryWatcher for Improved Productivity

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -169,6 +169,7 @@ return [
             'enabled' => env('TELESCOPE_QUERY_WATCHER', true),
             'ignore_packages' => true,
             'ignore_paths' => [],
+            'ignore_queries' => ['SELECT'],
             'slow' => 100,
         ],
 

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -152,6 +152,7 @@ class QueryWatcher extends Watcher
             return false;
         }
         $regex = '/^('.implode('|', $this->options['ignore_queries']).')/i';
+
         return preg_match($regex, trim($sql));
     }
 }

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -148,6 +148,9 @@ class QueryWatcher extends Watcher
      */
     protected function isSqlStatementExcluded(string $sql): bool
     {
+        if (!array_key_exists('ignore_queries', $this->options)) {
+            return false;
+        }
         $regex = "/^(" . implode("|", $this->options['ignore_queries']) . ")/i";
         return preg_match($regex, trim($sql));
     }

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -141,17 +141,17 @@ class QueryWatcher extends Watcher
     }
 
     /**
-     * Checks if the SQL statement was excluded
+     * Checks if the SQL statement was excluded.
      *
      * @param  string  $sql
      * @return bool
      */
     protected function isSqlStatementExcluded(string $sql): bool
     {
-        if (!array_key_exists('ignore_queries', $this->options)) {
+        if (! array_key_exists('ignore_queries', $this->options)) {
             return false;
         }
-        $regex = "/^(" . implode("|", $this->options['ignore_queries']) . ")/i";
+        $regex = '/^('.implode('|', $this->options['ignore_queries']).')/i';
         return preg_match($regex, trim($sql));
     }
 }

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -33,6 +33,10 @@ class QueryWatcher extends Watcher
             return;
         }
 
+        if ($this->isSqlStatementExcluded($event->sql)) {
+            return;
+        }
+
         $time = $event->time;
 
         if ($caller = $this->getCallerFromStackTrace()) {
@@ -134,5 +138,17 @@ class QueryWatcher extends Watcher
         ]);
 
         return "'".$binding."'";
+    }
+
+    /**
+     * Checks if the SQL statement was excluded
+     *
+     * @param  string  $sql
+     * @return bool
+     */
+    protected function isSqlStatementExcluded(string $sql): bool
+    {
+        $regex = "/^(" . implode("|", $this->options['ignore_queries']) . ")/i";
+        return preg_match($regex, trim($sql));
     }
 }


### PR DESCRIPTION
Since I started using Telescope, I noticed a missing feature to exclude SQL statements. I only want to see changes to my database in my productive area (INSERT/CREATE/DELETE), so I filtered out all SELECT statements. It is easy to select multiple SQL keywords at the beginning of an SQL statement and exclude them from showing/storing in the QueryWatcher.