### PR TITLE
[4.x] fix: json_encode gives 502 Bad Gateway in EventWatcher

### DIFF
--- a/src/Watchers/EventWatcher.php
+++ b/src/Watchers/EventWatcher.php
@@ -68,7 +68,9 @@ class EventWatcher extends Watcher
         return collect($payload)->map(function ($value) {
             return is_object($value) ? [
                 'class' => get_class($value),
-                'properties' => json_decode(json_encode($value), true),
+                'properties' => $value instanceof \JsonSerializable
+                    ? $value
+                    : json_decode(json_encode($value), true),
             ] : $value;
         })->toArray();
     }


### PR DESCRIPTION
When an event payload has a JsonSerializable class, there is no need to decode and encode the object. It will fail by throwing 502 errors if the object has something like the service container as a property.

In my case, this fix solves the problem.