### PR TITLE
[4.x] Fixes jobs saying "pending" forever

### DIFF
--- a/src/Contracts/EntriesRepository.php
+++ b/src/Contracts/EntriesRepository.php
@@ -37,7 +37,7 @@ interface EntriesRepository
      * Store the given entry updates, and return the failed updates.
      *
      * @param  \Illuminate\Support\Collection|\Laravel\Telescope\EntryUpdate[]  $updates
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection|null
      */
     public function update(Collection $updates);
 

--- a/src/Contracts/EntriesRepository.php
+++ b/src/Contracts/EntriesRepository.php
@@ -34,7 +34,7 @@ interface EntriesRepository
     public function store(Collection $entries);
 
     /**
-     * Store the given entry updates, and return the failed updates.
+     * Store the given entry updates and return the failed updates.
      *
      * @param  \Illuminate\Support\Collection|\Laravel\Telescope\EntryUpdate[]  $updates
      * @return \Illuminate\Support\Collection|null

--- a/src/Contracts/EntriesRepository.php
+++ b/src/Contracts/EntriesRepository.php
@@ -34,10 +34,10 @@ interface EntriesRepository
     public function store(Collection $entries);
 
     /**
-     * Store the given entry updates.
+     * Store the given entry updates, and return the failed updates.
      *
      * @param  \Illuminate\Support\Collection|\Laravel\Telescope\EntryUpdate[]  $updates
-     * @return void
+     * @return \Illuminate\Support\Collection
      */
     public function update(Collection $updates);
 

--- a/src/Jobs/ProcessPendingUpdates.php
+++ b/src/Jobs/ProcessPendingUpdates.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Laravel\Telescope\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Laravel\Telescope\Contracts\EntriesRepository;
+
+class ProcessPendingUpdates implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * The number of times the job may be attempted.
+     *
+     * @var int
+     */
+    protected $attempt;
+
+    /**
+     * The pending updates list.
+     *
+     * @var \Illuminate\Support\Collection<int, \Laravel\Telescope\EntryUpdate>
+     */
+    protected $updates;
+
+    /**
+     * Creates a new process pending entry updates instance.
+     *
+     * @param  \Illuminate\Support\Collection  $updates
+     * @param  int  $attempt
+     * @return void
+     */
+    public function __construct($updates, $attempt = 0)
+    {
+        $this->updates = $updates;
+        $this->attempt = $attempt;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle(EntriesRepository $repository)
+    {
+        $this->attempt++;
+
+        $repository->update($this->updates)->whenNotEmpty(
+            fn ($pendingUpdates) => static::dispatchIf(
+                $this->attempt < 3, $pendingUpdates, $this->attempt
+            )->delay(now()->addSeconds(10)),
+        );
+    }
+}

--- a/src/Jobs/ProcessPendingUpdates.php
+++ b/src/Jobs/ProcessPendingUpdates.php
@@ -30,7 +30,7 @@ class ProcessPendingUpdates implements ShouldQueue
     /**
      * Creates a new process pending entry updates instance.
      *
-     * @param  \Illuminate\Support\Collection  $pendingUpdates
+     * @param  \Illuminate\Support\Collection<int, \Laravel\Telescope\EntryUpdate>
      * @param  int  $attempt
      * @return void
      */

--- a/src/Jobs/ProcessPendingUpdates.php
+++ b/src/Jobs/ProcessPendingUpdates.php
@@ -14,13 +14,6 @@ class ProcessPendingUpdates implements ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     /**
-     * The number of times the job may be attempted.
-     *
-     * @var int
-     */
-    public $attempt;
-
-    /**
      * The pending entry updates.
      *
      * @var \Illuminate\Support\Collection<int, \Laravel\Telescope\EntryUpdate>
@@ -28,7 +21,14 @@ class ProcessPendingUpdates implements ShouldQueue
     public $pendingUpdates;
 
     /**
-     * Creates a new process pending entry updates instance.
+     * The number of times the job has been attempted.
+     *
+     * @var int
+     */
+    public $attempt;
+
+    /**
+     * Creates a new job instance.
      *
      * @param  \Illuminate\Support\Collection<int, \Laravel\Telescope\EntryUpdate>
      * @param  int  $attempt

--- a/src/Jobs/ProcessPendingUpdates.php
+++ b/src/Jobs/ProcessPendingUpdates.php
@@ -25,18 +25,18 @@ class ProcessPendingUpdates implements ShouldQueue
      *
      * @var \Illuminate\Support\Collection<int, \Laravel\Telescope\EntryUpdate>
      */
-    protected $updates;
+    protected $pendingUpdates;
 
     /**
      * Creates a new process pending entry updates instance.
      *
-     * @param  \Illuminate\Support\Collection  $updates
+     * @param  \Illuminate\Support\Collection  $pendingUpdates
      * @param  int  $attempt
      * @return void
      */
-    public function __construct($updates, $attempt = 0)
+    public function __construct($pendingUpdates, $attempt = 0)
     {
-        $this->updates = $updates;
+        $this->pendingUpdates = $pendingUpdates;
         $this->attempt = $attempt;
     }
 
@@ -50,9 +50,9 @@ class ProcessPendingUpdates implements ShouldQueue
     {
         $this->attempt++;
 
-        $repository->update($this->updates)->whenNotEmpty(
-            fn ($pending) => static::dispatchIf(
-                $this->attempt < 3, $pending, $this->attempt
+        $repository->update($this->pendingUpdates)->whenNotEmpty(
+            fn ($pendingUpdates) => static::dispatchIf(
+                $this->attempt < 3, $pendingUpdates, $this->attempt
             )->delay(now()->addSeconds(10)),
         );
     }

--- a/src/Jobs/ProcessPendingUpdates.php
+++ b/src/Jobs/ProcessPendingUpdates.php
@@ -28,7 +28,7 @@ class ProcessPendingUpdates implements ShouldQueue
     public $attempt;
 
     /**
-     * Creates a new job instance.
+     * Create a new job instance.
      *
      * @param  \Illuminate\Support\Collection<int, \Laravel\Telescope\EntryUpdate>
      * @param  int  $attempt

--- a/src/Jobs/ProcessPendingUpdates.php
+++ b/src/Jobs/ProcessPendingUpdates.php
@@ -18,14 +18,14 @@ class ProcessPendingUpdates implements ShouldQueue
      *
      * @var int
      */
-    protected $attempt;
+    public $attempt;
 
     /**
      * The pending entry updates.
      *
      * @var \Illuminate\Support\Collection<int, \Laravel\Telescope\EntryUpdate>
      */
-    protected $pendingUpdates;
+    public $pendingUpdates;
 
     /**
      * Creates a new process pending entry updates instance.

--- a/src/Jobs/ProcessPendingUpdates.php
+++ b/src/Jobs/ProcessPendingUpdates.php
@@ -21,7 +21,7 @@ class ProcessPendingUpdates implements ShouldQueue
     protected $attempt;
 
     /**
-     * The pending updates list.
+     * The pending entry updates.
      *
      * @var \Illuminate\Support\Collection<int, \Laravel\Telescope\EntryUpdate>
      */
@@ -43,6 +43,7 @@ class ProcessPendingUpdates implements ShouldQueue
     /**
      * Execute the job.
      *
+     * @param  \Laravel\Telescope\Contracts\EntriesRepository  $repository
      * @return void
      */
     public function handle(EntriesRepository $repository)
@@ -50,8 +51,8 @@ class ProcessPendingUpdates implements ShouldQueue
         $this->attempt++;
 
         $repository->update($this->updates)->whenNotEmpty(
-            fn ($pendingUpdates) => static::dispatchIf(
-                $this->attempt < 3, $pendingUpdates, $this->attempt
+            fn ($pending) => static::dispatchIf(
+                $this->attempt < 3, $pending, $this->attempt
             )->delay(now()->addSeconds(10)),
         );
     }

--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -201,10 +201,10 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
     }
 
     /**
-     * Store the given entry updates.
+     * Store the given entry updates and return the failed updates.
      *
      * @param  \Illuminate\Support\Collection|\Laravel\Telescope\EntryUpdate[]  $updates
-     * @return void
+     * @return \Illuminate\Support\Collection|null
      */
     public function update(Collection $updates)
     {

--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -208,6 +208,8 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
      */
     public function update(Collection $updates)
     {
+        $failedUpdates = [];
+
         foreach ($updates as $update) {
             $entry = $this->table('telescope_entries')
                             ->where('uuid', $update->uuid)
@@ -215,6 +217,8 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
                             ->first();
 
             if (! $entry) {
+                $failedUpdates[] = $update;
+
                 continue;
             }
 
@@ -229,6 +233,8 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
 
             $this->updateTags($update);
         }
+
+        return collect($failedUpdates);
     }
 
     /**

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -666,10 +666,11 @@ class Telescope
                 $batchId = Str::orderedUuid()->toString();
 
                 $storage->store(static::collectEntries($batchId));
+
                 ($storage->update(static::collectUpdates($batchId)) ?: Collection::make())
-                    ->whenNotEmpty(fn ($pendingUpdates) => ProcessPendingUpdates::dispatch(
+                    ->whenNotEmpty(fn ($pendingUpdates) => rescue(fn () => ProcessPendingUpdates::dispatch(
                         $pendingUpdates,
-                    )->delay(now()->addSeconds(10)));
+                    )->delay(now()->addSeconds(10))));
 
                 if ($storage instanceof TerminableRepository) {
                     $storage->terminate();

--- a/src/Watchers/JobWatcher.php
+++ b/src/Watchers/JobWatcher.php
@@ -25,8 +25,8 @@ class JobWatcher extends Watcher
      * @var array<int, class-string>
      */
     protected $ignoredJobClasses = [
-        \Laravel\Telescope\Jobs\ProcessPendingUpdates::class,
         \Laravel\Scout\Jobs\MakeSearchable::class, // @phpstan-ignore-line
+        \Laravel\Telescope\Jobs\ProcessPendingUpdates::class,
     ];
 
     /**

--- a/src/Watchers/JobWatcher.php
+++ b/src/Watchers/JobWatcher.php
@@ -20,6 +20,16 @@ use RuntimeException;
 class JobWatcher extends Watcher
 {
     /**
+     * The list of ignored jobs classes.
+     *
+     * @var array<int, class-string>
+     */
+    protected $ignoredJobClasses = [
+        \Laravel\Telescope\Jobs\ProcessPendingUpdates:: class,
+        \Laravel\Scout\Jobs\MakeSearchable::class, // @phpstan-ignore-line
+    ];
+
+    /**
      * Register the watcher.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
@@ -49,8 +59,7 @@ class JobWatcher extends Watcher
             return;
         }
 
-        // Logging this job can cause extensive memory usage...
-        if (get_class($payload['data']['command']) === 'Laravel\Scout\Jobs\MakeSearchable') {
+        if (in_array(get_class($payload['data']['command']), $this->ignoredJobClasses)) {
             return;
         }
 

--- a/tests/Jobs/ProcessPendingUpdatesTest.php
+++ b/tests/Jobs/ProcessPendingUpdatesTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Laravel\Telescope\Tests\Storage;
+
+use Illuminate\Support\Facades\Bus;
+use Laravel\Telescope\Contracts\EntriesRepository;
+use Laravel\Telescope\Jobs\ProcessPendingUpdates;
+use Laravel\Telescope\Tests\FeatureTestCase;
+use Mockery as m;
+
+class ProcessPendingUpdatesTest extends FeatureTestCase
+{
+    public function test_pending_updates()
+    {
+        Bus::fake();
+
+        $pendingUpdates = collect([
+            ['id' => 1, 'content' => 'foo'],
+            ['id' => 2, 'content' => 'bar'],
+        ]);
+
+        $failedUpdates = collect();
+        $repository = m::mock(EntriesRepository::class);
+
+        $repository
+            ->shouldReceive('update')
+            ->once()
+            ->with($pendingUpdates)
+            ->andReturn($failedUpdates);
+
+        (new ProcessPendingUpdates($pendingUpdates))->handle($repository);
+
+        Bus::assertNothingDispatched();
+    }
+
+    public function test_pending_updates_may_stay_pending()
+    {
+        Bus::fake();
+
+        $pendingUpdates = collect([
+            ['id' => 1, 'content' => 'foo'],
+            ['id' => 2, 'content' => 'bar'],
+        ]);
+        $failedUpdates = collect([
+            $pendingUpdates->get(1),
+        ]);
+
+        $repository = m::mock(EntriesRepository::class);
+
+        $repository
+            ->shouldReceive('update')
+            ->once()
+            ->with($pendingUpdates)
+            ->andReturn($failedUpdates);
+
+        (new ProcessPendingUpdates($pendingUpdates))->handle($repository);
+
+        Bus::assertDispatched(ProcessPendingUpdates::class, function ($job) {
+            return $job->attemp = 1 && $job->pendingUpdates->toArray() == [['id' => 2, 'content' => 'bar']];
+        });
+    }
+
+    public function test_pending_updates_may_stay_pending_only_three_times()
+    {
+        Bus::fake();
+
+        $pendingUpdates = collect([
+            ['id' => 1, 'content' => 'foo'],
+            ['id' => 2, 'content' => 'bar'],
+        ]);
+        $failedUpdates = collect([
+            $pendingUpdates->get(1),
+        ]);
+
+        $repository = m::mock(EntriesRepository::class);
+
+        $repository
+            ->shouldReceive('update')
+            ->once()
+            ->with($pendingUpdates)
+            ->andReturn($failedUpdates);
+
+        (new ProcessPendingUpdates($pendingUpdates, 2))->handle($repository);
+
+        Bus::assertNothingDispatched();
+    }
+}

--- a/tests/Jobs/ProcessPendingUpdatesTest.php
+++ b/tests/Jobs/ProcessPendingUpdatesTest.php
@@ -56,7 +56,7 @@ class ProcessPendingUpdatesTest extends FeatureTestCase
         (new ProcessPendingUpdates($pendingUpdates))->handle($repository);
 
         Bus::assertDispatched(ProcessPendingUpdates::class, function ($job) {
-            return $job->attemp = 1 && $job->pendingUpdates->toArray() == [['id' => 2, 'content' => 'bar']];
+            return $job->attempt == 1 && $job->pendingUpdates->toArray() == [['id' => 2, 'content' => 'bar']];
         });
     }
 


### PR DESCRIPTION
This pull request fixes the "pending" job status (https://github.com/laravel/telescope/issues/1331, https://github.com/laravel/telescope/issues/1113, https://github.com/laravel/telescope/issues/577, https://github.com/laravel/telescope/issues/507, https://github.com/laravel/telescope/issues/543, https://github.com/laravel/telescope/issues/690, https://github.com/laravel/telescope/issues/503, https://github.com/laravel/telescope/issues/411), by simply delaying the "failed" updates to performed a few seconds after via queued job.