### PR TITLE
Prevent Memory Leak when using hideRequestParameters and hideRequestHeaders

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -726,10 +726,10 @@ class Telescope
      */
     public static function hideRequestHeaders(array $headers)
     {
-        static::$hiddenRequestHeaders = array_unique(array_merge(
+        static::$hiddenRequestHeaders = array_values(array_unique(array_merge(
             static::$hiddenRequestHeaders,
             $headers
-        ));
+        )));
 
         return new static;
     }
@@ -758,10 +758,10 @@ class Telescope
      */
     public static function hideResponseParameters(array $attributes)
     {
-        static::$hiddenResponseParameters = array_unique(array_merge(
+        static::$hiddenResponseParameters = array_values(array_unique(array_merge(
             static::$hiddenResponseParameters,
             $attributes
-        ));
+        )));
 
         return new static;
     }

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -758,10 +758,10 @@ class Telescope
      */
     public static function hideResponseParameters(array $attributes)
     {
-        static::$hiddenResponseParameters = array_merge(
+        static::$hiddenResponseParameters = array_unique(array_merge(
             static::$hiddenResponseParameters,
             $attributes
-        );
+        ));
 
         return new static;
     }

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -726,10 +726,10 @@ class Telescope
      */
     public static function hideRequestHeaders(array $headers)
     {
-        static::$hiddenRequestHeaders = array_merge(
+        static::$hiddenRequestHeaders = array_unique(array_merge(
             static::$hiddenRequestHeaders,
             $headers
-        );
+        ));
 
         return new static;
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR aims to prevent a memory leak when we call the method `hideRequestHeaders` or/and `hideRequestParameters` multiple times with the same parameters. Ex:

```php
Telescope::hideRequestHeaders(['cookie', 'x-csrf-token']);
Telescope::hideRequestHeaders(['cookie', 'x-csrf-token']);
```

It seems like an inoffensive issue, but it causes a memory leak in tests:
```php
class MemoryLeakTest extends TestCaseUnit
{
    public function test_leaks_memory_on_1000_iterations()
    {
        $this->app->flush();
        $this->app = null;

        for ($i = 1; $i < 500; ++$i) {
            $this->createApplication()
                ->flush();

            if (! ($i % 10)) {
                dump('Using ' . ((int) (memory_get_usage(true) / (1024 * 1024))) . 'MB as ' . $i . ' iterations.');
            }
        }

        $this->app = $this->createApplication();
    }
}
```
> The code above was copied from https://darkghosthunter.medium.com/laravel-fixing-memory-leaks-on-tests-4fe87b87f0ad