### PR TITLE
[4.x] Avoids serialialisation of exception traces

### DIFF
--- a/src/Watchers/JobWatcher.php
+++ b/src/Watchers/JobWatcher.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Queue;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Laravel\Telescope\EntryType;
 use Laravel\Telescope\EntryUpdate;
@@ -124,7 +125,7 @@ class JobWatcher extends Watcher
                 'status' => 'failed',
                 'exception' => [
                     'message' => $event->exception->getMessage(),
-                    'trace' => $event->exception->getTrace(),
+                    'trace' => collect($event->exception->getTrace())->map(fn ($trace) => Arr::except($trace, ['args']))->all(),
                     'line' => $event->exception->getLine(),
                     'line_preview' => ExceptionContext::get($event->exception),
                 ],

--- a/tests/Watchers/JobWatcherTest.php
+++ b/tests/Watchers/JobWatcherTest.php
@@ -94,6 +94,10 @@ class JobWatcherTest extends FeatureTestCase
         $this->assertSame('default', $entry->content['queue']);
         $this->assertSame('I never watched Star Wars.', $entry->content['data']['message']);
         $this->assertArrayHasKey('exception', $entry->content);
+
+        $this->assertArrayNotHasKey('args', $entry->content['exception']['trace'][0]);
+        $this->assertSame(MyFailedDatabaseJob::class, $entry->content['exception']['trace'][0]['class']);
+        $this->assertSame('handle', $entry->content['exception']['trace'][0]['function']);
     }
 
     private function createJobsTable(): void

--- a/tests/Watchers/NotificationWatcherTest.php
+++ b/tests/Watchers/NotificationWatcherTest.php
@@ -44,7 +44,7 @@ class NotificationWatcherTest extends FeatureTestCase
         $this->assertFalse($entry->content['queued']);
         $this->assertStringContainsString(is_array($route) ? implode(',', $route) : $route, $entry->content['notifiable']);
         $this->assertSame($channel, $entry->content['channel']);
-        $this->assertNull($entry->content['response']);
+        $this->assertEmpty($entry->content['response']);
     }
 }
 


### PR DESCRIPTION
This pull request addresses the problem described in issue https://github.com/laravel/telescope/issues/1353. Currently, when a job fails, we attempt to queue an "update" for the failed job status through ProcessPendingUpdates even before it exists in Telescope. However, there is an issue with this approach. The update may include a stack trace that contains references to closures, which, as we are aware, cannot be serialized.

Note that, the arguments are not even used on the Telescope UI, so we can remove them safely.