### PR TITLE
[4.x] Show list of headers when present

### DIFF
--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -135,9 +135,9 @@ class ClientRequestWatcher extends Watcher
             return strtolower($headerName);
         })->toArray();
 
-        $headerValues = collect($headers)->map(function ($value) {
-            return $value[0];
-        })->toArray();
+        $headerValues = collect($headers)
+            ->map(fn ($header) => implode(', ', $header))
+            ->all();
 
         $headers = array_combine($headerNames, $headerValues);
 

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -98,9 +98,9 @@ class RequestWatcher extends Watcher
      */
     protected function headers($headers)
     {
-        $headers = collect($headers)->map(function ($header) {
-            return $header[0];
-        })->toArray();
+        $headers = collect($headers)
+            ->map(fn ($header) => implode(', ', $header))
+            ->all();
 
         return $this->hideParameters($headers,
             Telescope::$hiddenRequestHeaders

--- a/tests/Watchers/ClientRequestWatcherTest.php
+++ b/tests/Watchers/ClientRequestWatcherTest.php
@@ -250,4 +250,19 @@ class ClientRequestWatcherTest extends FeatureTestCase
         $this->assertSame(($image->getSize() / 1000).'KB', $entry->content['payload']['image']['size']);
         $this->assertSame(['foo' => 'bar'], $entry->content['payload']['image']['headers']);
     }
+
+    public function test_it_stores_and_displays_array_of_request_headers()
+    {
+        Http::fake(['*' => '']);
+
+        Http::withHeaders(['X-Foo' => 'first'])
+            ->withHeaders(['X-Foo' => 'second'])
+            ->withHeaders(['X-Bar' => 'single'])
+            ->get('https://laravel.com');
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame('first, second', $entry->content['headers']['x-foo']);
+        $this->assertSame('single', $entry->content['headers']['x-bar']);
+    }
 }

--- a/tests/Watchers/RequestWatchersTest.php
+++ b/tests/Watchers/RequestWatchersTest.php
@@ -109,6 +109,24 @@ class RequestWatchersTest extends FeatureTestCase
         $this->assertSame('********', $entry->content['headers']['php-auth-pw']);
     }
 
+    public function test_it_stores_and_displays_array_of_request_headers()
+    {
+        Route::post('/dashboard', function () {
+            return response('success')->withHeaders([
+                'X-Foo' => ['first', 'second'],
+            ]);
+        });
+
+        $this->post('/dashboard', [], [
+            'X-Bar' => ['first', 'second'],
+        ]);
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::REQUEST, $entry->type);
+        $this->assertSame('first, second', $entry->content['headers']['x-bar']);
+    }
+
     public function test_request_watcher_handles_file_uploads()
     {
         $image = UploadedFile::fake()->image('avatar.jpg');


### PR DESCRIPTION
When an array of headers is present, we now show the array rather than only the first value.

## Incoming Application Request

<img width="1205" alt="Screen Shot 2023-06-03 at 11 57 03 am" src="https://github.com/laravel/telescope/assets/24803032/524fce95-2577-4f66-92ed-180d9739d3c6">


## Outgoing HTTP Client Request

Request see "x-foo"

<img width="1209" alt="Screen Shot 2023-06-03 at 11 32 43 am" src="https://github.com/laravel/telescope/assets/24803032/bf6cd239-77d8-42c8-8357-2694a097f27a">

Response see "set-cookie"

<img width="1210" alt="Screen Shot 2023-06-03 at 11 53 28 am" src="https://github.com/laravel/telescope/assets/24803032/a91193f9-4710-433a-954d-01a5a0425992">


Went wit comma separated list instead of an actual array, as it creates consistency between those that already use the comma as a list mechanism and those that do not.