### PR TITLE
[4.x] Support named query bindings with multiple occurrences

### DIFF
--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -103,7 +103,10 @@ class QueryWatcher extends Watcher
                 $binding = $this->quoteStringBinding($event, $binding);
             }
 
-            $sql = preg_replace($regex, $binding, $sql, 1);
+            // To support named binding with multiple occurrences
+            $limit = is_numeric($key) ? 1 : -1;
+
+            $sql = preg_replace($regex, $binding, $sql, $limit);
         }
 
         return $sql;

--- a/tests/Watchers/QueryWatcherTest.php
+++ b/tests/Watchers/QueryWatcherTest.php
@@ -80,7 +80,7 @@ SQL
     public function test_query_watcher_can_prepare_named_bindings()
     {
         $this->app->get('db')->statement(<<<'SQL'
-update "telescope_entries" set "content" = :content, "should_display_on_index" = :index_new where "type" = :type and "should_display_on_index" = :index_old and "family_hash" is null and "sequence" > :sequence and "created_at" < :created_at
+update "telescope_entries" set "content" = :content, "should_display_on_index" = :index_new where "type" = :type and "should_display_on_index" = :index_old and "family_hash" is null and "sequence" > :sequence and "created_at" < :created_at  and "created_at" <> :created_at
 SQL
             , [
                 'sequence' => 100,
@@ -95,7 +95,7 @@ SQL
 
         $this->assertSame(EntryType::QUERY, $entry->type);
         $this->assertSame(<<<'SQL'
-update "telescope_entries" set "content" = null, "should_display_on_index" = 0 where "type" = 'query' and "should_display_on_index" = 1 and "family_hash" is null and "sequence" > 100 and "created_at" < '2019-01-01 00:00:00'
+update "telescope_entries" set "content" = null, "should_display_on_index" = 0 where "type" = 'query' and "should_display_on_index" = 1 and "family_hash" is null and "sequence" > 100 and "created_at" < '2019-01-01 00:00:00' and "created_at" <> '2019-01-01 00:00:00'
 SQL
             , $entry->content['sql']);
 

--- a/tests/Watchers/QueryWatcherTest.php
+++ b/tests/Watchers/QueryWatcherTest.php
@@ -80,7 +80,7 @@ SQL
     public function test_query_watcher_can_prepare_named_bindings()
     {
         $this->app->get('db')->statement(<<<'SQL'
-update "telescope_entries" set "content" = :content, "should_display_on_index" = :index_new where "type" = :type and "should_display_on_index" = :index_old and "family_hash" is null and "sequence" > :sequence and "created_at" < :created_at  and "created_at" <> :created_at
+update "telescope_entries" set "content" = :content, "should_display_on_index" = :index_new where "type" = :type and "should_display_on_index" = :index_old and "family_hash" is null and "sequence" > :sequence and "created_at" < :created_at and "created_at" <> :created_at
 SQL
             , [
                 'sequence' => 100,


### PR DESCRIPTION
To enhance the support for named query bindings with multiple occurrences, I have modified the `preg_replace()` function. Currently, it only replaces the first occurrence of the named query binding, which is limiting for our requirements.

So I have updated the function to replace all occurrences of the named query binding.

## Query

```sql
SELECT user_id FROM user_credit_log
WHERE points > :minimum_points_user
    AND event = :event_user
    AND created_at BETWEEN :start_date AND :end_date
UNION
SELECT user_id FROM user_credit_log
WHERE points > :minimum_points_admin
    AND event = :event_admin
    AND created_at BETWEEN :start_date AND :end_date
```

## Bindings

```php
[
    'minimum_points_user' => 10,
    'event_user' => 'user',
    'minimum_points_admin' => 100,
    'event_admin' => 'admin',
    'start_date' => '2020-01-01 00:00:00',
    'end_date' => '2022-01-01 00:00:00',
]
```

## Output

![telescope-named-bindings](https://github.com/laravel/telescope/assets/6076800/f693cc2e-9a07-40cc-8bff-96a2ebcaeef7)
