### PR TITLE
[4.x] Fixes unexpected jobs on Vapor

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -667,10 +667,13 @@ class Telescope
 
                 $storage->store(static::collectEntries($batchId));
 
-                ($storage->update(static::collectUpdates($batchId)) ?: Collection::make())
-                    ->whenNotEmpty(fn ($pendingUpdates) => rescue(fn () => ProcessPendingUpdates::dispatch(
+                $pendingUpdates = $storage->update(static::collectUpdates($batchId)) ?: Collection::make();
+
+                if (! isset($_ENV['VAPOR_SSM_PATH'])) {
+                    $pendingUpdates->whenNotEmpty(fn ($pendingUpdates) => rescue(fn () => ProcessPendingUpdates::dispatch(
                         $pendingUpdates,
                     )->delay(now()->addSeconds(10))));
+                }
 
                 if ($storage instanceof TerminableRepository) {
                     $storage->terminate();

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -667,10 +667,10 @@ class Telescope
 
                 $storage->store(static::collectEntries($batchId));
 
-                $pendingUpdates = $storage->update(static::collectUpdates($batchId)) ?: Collection::make();
+                $updateResult = $storage->update(static::collectUpdates($batchId)) ?: Collection::make();
 
                 if (! isset($_ENV['VAPOR_SSM_PATH'])) {
-                    $pendingUpdates->whenNotEmpty(fn ($pendingUpdates) => rescue(fn () => ProcessPendingUpdates::dispatch(
+                    $updateResult->whenNotEmpty(fn ($pendingUpdates) => rescue(fn () => ProcessPendingUpdates::dispatch(
                         $pendingUpdates,
                     )->delay(now()->addSeconds(10))));
                 }


### PR DESCRIPTION
Due to the nature of Laravel Vapor, which often processes jobs more quickly than the HTTP response, there is a small likelihood of this change dispatching more jobs than a regular server. Therefore, it would be better to disable this feature on Vapor.