### PR TITLE
Enhancement: Multi-Tag Filtering and Search Functionality

### DIFF
--- a/src/Storage/EntryModel.php
+++ b/src/Storage/EntryModel.php
@@ -116,8 +116,17 @@ class EntryModel extends Model
     protected function whereTag($query, EntryQueryOptions $options)
     {
         $query->when($options->tag, function ($query, $tag) {
-            return $query->whereIn('uuid', function ($query) use ($tag) {
-                $query->select('entry_uuid')->from('telescope_entries_tags')->whereTag($tag);
+            $tags = explode(',', $tag);
+            if (empty($tags)) {
+                return $this;
+            }
+            return $query->whereIn('uuid', function ($query) use ($tags) {
+                $query->select('entry_uuid')->from('telescope_entries_tags');
+                foreach ($tags as $tag) {
+                    $query->whereIn('entry_uuid', function ($query) use ($tag) {
+                        $query->select('entry_uuid')->from('telescope_entries_tags')->where('tag', trim($tag));
+                    });
+                }
             });
         });
 

--- a/src/Storage/EntryModel.php
+++ b/src/Storage/EntryModel.php
@@ -120,6 +120,7 @@ class EntryModel extends Model
             if (empty($tags)) {
                 return $this;
             }
+
             return $query->whereIn('uuid', function ($query) use ($tags) {
                 $query->select('entry_uuid')->from('telescope_entries_tags');
                 foreach ($tags as $tag) {

--- a/src/Storage/EntryModel.php
+++ b/src/Storage/EntryModel.php
@@ -123,12 +123,10 @@ class EntryModel extends Model
             }
 
             return $query->whereIn('uuid', function ($query) use ($tags) {
-                $query->select('entry_uuid')->from('telescope_entries_tags');
-                foreach ($tags as $tag) {
-                    $query->whereIn('entry_uuid', function ($query) use ($tag) {
-                        $query->select('entry_uuid')->from('telescope_entries_tags')->where('tag', trim($tag));
+                $query->select('entry_uuid')->from('telescope_entries_tags')
+                    ->whereIn('entry_uuid', function ($query) use ($tags) {
+                        $query->select('entry_uuid')->from('telescope_entries_tags')->whereIn('tag', $tags->all());
                     });
-                }
             });
         });
 

--- a/src/Storage/EntryModel.php
+++ b/src/Storage/EntryModel.php
@@ -118,7 +118,7 @@ class EntryModel extends Model
         $query->when($options->tag, function ($query, $tag) {
             $tags = explode(',', $tag);
             if (empty($tags)) {
-                return $this;
+                return $query;
             }
 
             return $query->whereIn('uuid', function ($query) use ($tags) {

--- a/src/Storage/EntryModel.php
+++ b/src/Storage/EntryModel.php
@@ -116,8 +116,9 @@ class EntryModel extends Model
     protected function whereTag($query, EntryQueryOptions $options)
     {
         $query->when($options->tag, function ($query, $tag) {
-            $tags = explode(',', $tag);
-            if (empty($tags)) {
+            $tags = collect(explode(',', $tag))->map(fn ($tag) => trim($tag));
+
+            if ($tags->isEmpty()) {
                 return $query;
             }
 


### PR DESCRIPTION
### **Description:**

This Pull Request proposes the introduction of a significant enhancement to the existing search functionality in the Telescope. Specifically, it enables users to filter and search using multiple tags simultaneously for requests.

### **Why is this change necessary?**

The current tag-based search and filter system only allows one tag per search. With the new multi-tag search and filtering, users can have more granular control over their search results, allowing for a more thorough and precise search experience.

