### PR TITLE
[4.x] add back button to header

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -31,6 +31,21 @@ return [
 
     'path' => env('TELESCOPE_PATH', 'telescope'),
 
+
+    /*
+    |--------------------------------------------------------------------------
+    | Telescope Back to system URL
+    |--------------------------------------------------------------------------
+    | This is the URI path redirect on click "back" button. You
+    | can set value to `null` for hide button on header.
+    | also label shown on hover.
+    |
+    */
+
+    'back_button_url' => config('app.url', null),
+
+    'back_button_label' => 'Back to system',
+
     /*
     |--------------------------------------------------------------------------
     | Telescope Storage Driver

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -31,7 +31,6 @@ return [
 
     'path' => env('TELESCOPE_PATH', 'telescope'),
 
-
     /*
     |--------------------------------------------------------------------------
     | Telescope Back to system URL

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -27,7 +27,7 @@
 
     <div class="container mb-5">
         <div class="d-flex align-items-stretch py-4 header">
-            <a href="{{ config('telescope.back_to_system_url') }}"  v-if="{{ config('telescope.back_to_system_url') ? 1 : 0 }}" class="btn btn-muted mr-3 d-flex align-items-center py-2" title="{{ config('telescope.back_to_system_label') }}">
+            <a href="{{ config('telescope.back_button_url') }}" v-if="{{ config('telescope.back_button_url') ? 1 : 0 }}" class="btn btn-muted mr-3 d-flex align-items-center py-2" title="{{ config('telescope.back_button_label') }}">
                 <svg viewBox="0 0 20 20" fill="currentColor"  class="icon">
                     <path class="fill-primary" d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z"></path>
                 </svg>

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -27,6 +27,12 @@
 
     <div class="container mb-5">
         <div class="d-flex align-items-stretch py-4 header">
+            <a href="{{ config('telescope.back_to_system_url') }}"  v-if="{{ config('telescope.back_to_system_url') ? 1 : 0 }}" class="btn btn-muted mr-3 d-flex align-items-center py-2" title="{{ config('telescope.back_to_system_label') }}">
+                <svg viewBox="0 0 20 20" fill="currentColor"  class="icon">
+                    <path class="fill-primary" d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z"></path>
+                </svg>
+            </a>
+
             <router-link to="/" class="logo d-flex align-items-center">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80">
                     <path class="fill-primary" d="M0 40a39.87 39.87 0 0 1 11.72-28.28A40 40 0 1 1 0 40zm34 10a4 4 0 0 1-4-4v-2a2 2 0 1 0-4 0v2a4 4 0 0 1-4 4h-2a2 2 0 1 0 0 4h2a4 4 0 0 1 4 4v2a2 2 0 1 0 4 0v-2a4 4 0 0 1 4-4h2a2 2 0 1 0 0-4h-2zm24-24a6 6 0 0 1-6-6v-3a3 3 0 0 0-6 0v3a6 6 0 0 1-6 6h-3a3 3 0 0 0 0 6h3a6 6 0 0 1 6 6v3a3 3 0 0 0 6 0v-3a6 6 0 0 1 6-6h3a3 3 0 0 0 0-6h-3zm-4 36a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM21 28a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"></path>


### PR DESCRIPTION
hello,

---
In this pull request, a back button has been added to the header. Additionally, a configuration option has been introduced to modify the redirect URL:

`back_button_url`: This setting defines the redirect URL for the back button. If this value is set to null, the button will be hidden.
`back_button_label`: This setting determines the title of the button.

#### Here's a screenshot for reference:
<img width="1035" alt="image" src="https://github.com/laravel/telescope/assets/26966142/2f4d2204-bc2b-4e71-9eac-9e7c4f9425f5">