### PR TITLE
modified moment-timezone package version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "laravel-mix": "^6.0.6",
         "lodash": "^4.17.19",
         "moment": "^2.29.4",
-        "moment-timezone": "^0.5.35",
+        "moment-timezone": "^0.5.40",
         "popper.js": "^1.12",
         "resolve-url-loader": "^5.0.0",
         "sass": "^1.15.2",


### PR DESCRIPTION
# This is a fix to JS dependancies of the Telescope project
### The problem
I installed Telescope on one of the laravel projects I was working on and while watching for activities in Telescope web app I found out that the committed time of the app activities (cache, queries, requests, etc.) in the list is the wrong time for Asia/Tehran timezone.
### No more daylight saving time in Iran (Tehran)
Tehran used to have a daylight saving time. After returning to the standard time on 22 September 2022, the Iran Government elected to remain permanently in the standard time, cancelling daylight saving time. Hence, Iran will permanently remain at UTC +3:30 time zone going forward.
### Why this pull request is important
Moment.js uses a dependancy moment-timezone to convert time based on the custom timezone not the browser's Intl obejct. so that's why we need to update this dependancy in package.json
### Not a backend issue!
I checked the records in database saved in `telescope_entries` table and the time inserted in that column seemed fine. I checked the  `telescope_entries` created_at with Carbon diffForHumans() and it was fine.
### This is a frontend issue
I checked the js code and saw that Telescope is using moment package to convert and show the time in record tables. That's why I am seeing '1h ago' for an action which is committed less than a minute ago !
## The change I made
I merely just modified on line in package.json file changing the moment-timezone version from 0.5.35 to [0.5.40](https://github.com/moment/moment-timezone/releases/tag/0.5.40) which includes a patch for new timzone changes worldwide (including new timezone config for Asia/Tehran). the latest version is [0.5.43](https://github.com/moment/moment-timezone/releases/tag/0.5.43) but as I saw the **somehow huge release notes on the previous 0.5.41** and as 0.5.40 is just an update patch for timezones, the very version would satisfy this issue and that's why I didn't force the latest version.
You may see the release notes on moment-timezone [here](https://github.com/moment/moment-timezone/releases). 