### PR TITLE
Call shouldIgnore method in every watchers

### DIFF
--- a/src/Watchers/BatchWatcher.php
+++ b/src/Watchers/BatchWatcher.php
@@ -29,7 +29,7 @@ class BatchWatcher extends Watcher
      */
     public function recordBatch(BatchDispatched $event)
     {
-        if (! Telescope::isRecording()) {
+        if (! Telescope::isRecording() || $this->shouldIgnore($event)) {
             return;
         }
 

--- a/src/Watchers/CacheWatcher.php
+++ b/src/Watchers/CacheWatcher.php
@@ -147,10 +147,10 @@ class CacheWatcher extends Watcher
      */
     protected function shouldIgnore($event)
     {
-        return Str::is([
+        return Str::is(array_merge($this->options['ignore'] ?? [], [
             'illuminate:queue:restart',
             'framework/schedule*',
             'telescope:*',
-        ], $event->key);
+        ]), $event->key);
     }
 }

--- a/src/Watchers/CacheWatcher.php
+++ b/src/Watchers/CacheWatcher.php
@@ -145,7 +145,7 @@ class CacheWatcher extends Watcher
      * @param  mixed  $event
      * @return bool
      */
-    private function shouldIgnore($event)
+    protected function shouldIgnore($event)
     {
         return Str::is([
             'illuminate:queue:restart',

--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -34,7 +34,7 @@ class ClientRequestWatcher extends Watcher
      */
     public function recordFailedRequest(ConnectionFailed $event)
     {
-        if (! Telescope::isRecording()) {
+        if (! Telescope::isRecording() || $this->shouldIgnore($event)) {
             return;
         }
 
@@ -54,7 +54,7 @@ class ClientRequestWatcher extends Watcher
      */
     public function recordResponse(ResponseReceived $event)
     {
-        if (! Telescope::isRecording()) {
+        if (! Telescope::isRecording() || $this->shouldIgnore($event)) {
             return;
         }
 

--- a/src/Watchers/CommandWatcher.php
+++ b/src/Watchers/CommandWatcher.php
@@ -45,7 +45,7 @@ class CommandWatcher extends Watcher
      * @param  mixed  $event
      * @return bool
      */
-    private function shouldIgnore($event)
+    protected function shouldIgnore($event)
     {
         return in_array($event->command, array_merge($this->options['ignore'] ?? [], [
             'schedule:run',

--- a/src/Watchers/ExceptionWatcher.php
+++ b/src/Watchers/ExceptionWatcher.php
@@ -75,7 +75,7 @@ class ExceptionWatcher extends Watcher
      * @param  mixed  $event
      * @return bool
      */
-    private function shouldIgnore($event)
+    protected function shouldIgnore($event)
     {
         return ! isset($event->context['exception']) ||
             ! $event->context['exception'] instanceof Throwable;

--- a/src/Watchers/GateWatcher.php
+++ b/src/Watchers/GateWatcher.php
@@ -70,7 +70,7 @@ class GateWatcher extends Watcher
      * @param  string  $ability
      * @return bool
      */
-    private function shouldIgnore($ability)
+    protected function shouldIgnore($ability)
     {
         return Str::is($this->options['ignore_abilities'] ?? [], $ability);
     }

--- a/src/Watchers/JobWatcher.php
+++ b/src/Watchers/JobWatcher.php
@@ -56,7 +56,7 @@ class JobWatcher extends Watcher
      */
     public function recordJob($connection, $queue, array $payload)
     {
-        if (! Telescope::isRecording()) {
+        if (! Telescope::isRecording() || $this->shouldIgnore([$connection, $queue, $payload])) {
             return;
         }
 
@@ -89,7 +89,7 @@ class JobWatcher extends Watcher
      */
     public function recordProcessedJob(JobProcessed $event)
     {
-        if (! Telescope::isRecording()) {
+        if (! Telescope::isRecording() || $this->shouldIgnore($event)) {
             return;
         }
 
@@ -114,7 +114,7 @@ class JobWatcher extends Watcher
      */
     public function recordFailedJob(JobFailed $event)
     {
-        if (! Telescope::isRecording()) {
+        if (! Telescope::isRecording() || $this->shouldIgnore($event)) {
             return;
         }
 

--- a/src/Watchers/LogWatcher.php
+++ b/src/Watchers/LogWatcher.php
@@ -74,7 +74,7 @@ class LogWatcher extends Watcher
      * @param  mixed  $event
      * @return bool
      */
-    private function shouldIgnore($event)
+    protected function shouldIgnore($event)
     {
         if (isset($event->context['exception']) && $event->context['exception'] instanceof Throwable) {
             return true;

--- a/src/Watchers/MailWatcher.php
+++ b/src/Watchers/MailWatcher.php
@@ -29,7 +29,7 @@ class MailWatcher extends Watcher
      */
     public function recordMail(MessageSent $event)
     {
-        if (! Telescope::isRecording()) {
+        if (! Telescope::isRecording() || $this->shouldIgnore($event)) {
             return;
         }
 

--- a/src/Watchers/ModelWatcher.php
+++ b/src/Watchers/ModelWatcher.php
@@ -41,7 +41,7 @@ class ModelWatcher extends Watcher
      */
     public function recordAction($event, $data)
     {
-        if (! Telescope::isRecording() || ! $this->shouldRecord($event)) {
+        if (! Telescope::isRecording() || ! $this->shouldRecord($event) || $this->shouldIgnore($event)) {
             return;
         }
 

--- a/src/Watchers/NotificationWatcher.php
+++ b/src/Watchers/NotificationWatcher.php
@@ -32,7 +32,7 @@ class NotificationWatcher extends Watcher
      */
     public function recordNotification(NotificationSent $event)
     {
-        if (! Telescope::isRecording()) {
+        if (! Telescope::isRecording() || $this->shouldIgnore($event)) {
             return;
         }
 

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -29,7 +29,7 @@ class QueryWatcher extends Watcher
      */
     public function recordQuery(QueryExecuted $event)
     {
-        if (! Telescope::isRecording()) {
+        if (! Telescope::isRecording() || $this->shouldIgnore($event)) {
             return;
         }
 

--- a/src/Watchers/RedisWatcher.php
+++ b/src/Watchers/RedisWatcher.php
@@ -80,7 +80,7 @@ class RedisWatcher extends Watcher
      * @param  mixed  $event
      * @return bool
      */
-    private function shouldIgnore($event)
+    protected function shouldIgnore($event)
     {
         return in_array($event->command, [
             'pipeline', 'transaction',

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -38,7 +38,7 @@ class RequestWatcher extends Watcher
     {
         if (! Telescope::isRecording() ||
             $this->shouldIgnoreHttpMethod($event) ||
-            $this->shouldIgnoreStatusCode($event) || 
+            $this->shouldIgnoreStatusCode($event) ||
             $this->shouldIgnore($event)) {
             return;
         }

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -38,7 +38,8 @@ class RequestWatcher extends Watcher
     {
         if (! Telescope::isRecording() ||
             $this->shouldIgnoreHttpMethod($event) ||
-            $this->shouldIgnoreStatusCode($event)) {
+            $this->shouldIgnoreStatusCode($event) || 
+            $this->shouldIgnore($event)) {
             return;
         }
 

--- a/src/Watchers/ScheduleWatcher.php
+++ b/src/Watchers/ScheduleWatcher.php
@@ -30,9 +30,7 @@ class ScheduleWatcher extends Watcher
      */
     public function recordCommand(CommandStarting $event)
     {
-        if (! Telescope::isRecording() ||
-            $event->command !== 'schedule:run' &&
-            $event->command !== 'schedule:finish') {
+        if (! Telescope::isRecording() || $this->shouldIgnore($event)) {
             return;
         }
 
@@ -66,5 +64,16 @@ class ScheduleWatcher extends Watcher
         }
 
         return trim(file_get_contents($event->output));
+    }
+
+    /**
+     * Determine if the event should be ignored.
+     *
+     * @param  mixed  $event
+     * @return bool
+     */
+    protected function shouldIgnore($event)
+    {
+        return $event->command !== 'schedule:run' && $event->command !== 'schedule:finish' ;
     }
 }

--- a/src/Watchers/ScheduleWatcher.php
+++ b/src/Watchers/ScheduleWatcher.php
@@ -74,6 +74,6 @@ class ScheduleWatcher extends Watcher
      */
     protected function shouldIgnore($event)
     {
-        return $event->command !== 'schedule:run' && $event->command !== 'schedule:finish' ;
+        return $event->command !== 'schedule:run' && $event->command !== 'schedule:finish';
     }
 }

--- a/src/Watchers/ViewWatcher.php
+++ b/src/Watchers/ViewWatcher.php
@@ -34,7 +34,7 @@ class ViewWatcher extends Watcher
      */
     public function recordAction($event, $data)
     {
-        if (! Telescope::isRecording()) {
+        if (! Telescope::isRecording() || $this->shouldIgnore($event)) {
             return;
         }
 

--- a/src/Watchers/Watcher.php
+++ b/src/Watchers/Watcher.php
@@ -29,4 +29,15 @@ abstract class Watcher
      * @return void
      */
     abstract public function register($app);
+
+    /**
+     * Determine if the event should be ignored.
+     *
+     * @param  mixed  $event
+     * @return bool
+     */
+    protected function shouldIgnore($event)
+    {
+        return false ;
+    }
 }

--- a/src/Watchers/Watcher.php
+++ b/src/Watchers/Watcher.php
@@ -38,6 +38,6 @@ abstract class Watcher
      */
     protected function shouldIgnore($event)
     {
-        return false ;
+        return false;
     }
 }


### PR DESCRIPTION
Today, the package sometimes defines the shouldIgnore method as protected, sometimes as private. Sometimes the method is even not defined. This is sad, it would clearly help adding custom ignoring logic.
I faced this issue, so I suppose I'm not the only one.

This PR defines a shouldIgnore method at the base Watcher in `Laravel\Telescope\Watchers\Watcher`, and call this method in every watchers. Power is given back to developers to override the method.