### PR TITLE
Refactor(QueryWatcher): Consider only identical queries as duplicates

### DIFF
--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -68,7 +68,7 @@ class QueryWatcher extends Watcher
      */
     public function familyHash($event)
     {
-        return md5($event->sql);
+        return md5($this->replaceBindings($event));
     }
 
     /**

--- a/tests/Watchers/QueryWatcherTest.php
+++ b/tests/Watchers/QueryWatcherTest.php
@@ -105,23 +105,23 @@ SQL
     public function test_query_watcher_considers_identical_queries_as_duplicates()
     {
         $query = 'select * from telescope_entries where type = ?';
-        
+
         $bindings = ['query'];
         $differentBindings = ['request'];
 
         $this->app->get('db')->select($query, $bindings);
         $this->app->get('db')->select($query, $bindings);
         $this->app->get('db')->select($query, $differentBindings);
-        
+
         $entries = $this->loadTelescopeEntries();
-        
+
         $this->assertCount(3, $entries);
-        
+
         $hashes = $entries->pluck('content.hash')->toArray();
-        
+
         // Ensure the hashes are the same for the queries with the same bindings.
         $this->assertEquals($hashes[0], $hashes[1]);
-        
+
         // Ensure the hashes are different for the queries with different bindings.
         $this->assertNotEquals($hashes[0], $hashes[2]);
         $this->assertNotEquals($hashes[1], $hashes[2]);

--- a/tests/Watchers/QueryWatcherTest.php
+++ b/tests/Watchers/QueryWatcherTest.php
@@ -101,4 +101,29 @@ SQL
 
         $this->assertSame('testbench', $entry->content['connection']);
     }
+
+    public function test_query_watcher_considers_identical_queries_as_duplicates()
+    {
+        $query = 'select * from telescope_entries where type = ?';
+        
+        $bindings = ['query'];
+        $differentBindings = ['request'];
+
+        $this->app->get('db')->select($query, $bindings);
+        $this->app->get('db')->select($query, $bindings);
+        $this->app->get('db')->select($query, $differentBindings);
+        
+        $entries = $this->loadTelescopeEntries();
+        
+        $this->assertCount(3, $entries);
+        
+        $hashes = $entries->pluck('content.hash')->toArray();
+        
+        // Ensure the hashes are the same for the queries with the same bindings.
+        $this->assertEquals($hashes[0], $hashes[1]);
+        
+        // Ensure the hashes are different for the queries with different bindings.
+        $this->assertNotEquals($hashes[0], $hashes[2]);
+        $this->assertNotEquals($hashes[1], $hashes[2]);
+    }
 }


### PR DESCRIPTION
**Summary**

This pull request addresses a potential issue of defining duplicated queries in the Telescope package. Currently, the definition of a "duplicated" query includes queries with the same structure but different bindings. This PR proposes a change so that only queries that are exactly the same will be considered duplicated. This aligns with a stricter definition of duplicated queries, focusing on identical SQL statements.

**Changes Made**

- Updated the logic in the QueryWatcher to generate the same hash only if they are exactly the same.
- Added new unit tests to ensure that only queries with identical structures and bindings are treated as duplicated.

**Motivation**

The current approach includes queries with similar structures but different bindings as duplicates, which might not accurately reflect redundant database calls. By considering only identical queries as duplicated, we provide a more accurate representation of query duplication, enabling developers to optimize database interactions more effectively.