### PR TITLE
Make catch syntax backwards compatible

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -260,7 +260,7 @@ class Telescope
 
         try {
             $recordingPaused = cache('telescope:pause-recording');
-        } catch (Exception) {
+        } catch (Exception $e) {
             //
         }
 


### PR DESCRIPTION
Without passing a variable name, this breaks PHP 7.3.