### PR TITLE
[4.x] Add primary keys to database tables

### DIFF
--- a/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -42,7 +42,7 @@ return new class extends Migration
             $table->uuid('entry_uuid');
             $table->string('tag');
 
-            $table->index(['entry_uuid', 'tag']);
+            $table->primary(['entry_uuid', 'tag']);
             $table->index('tag');
 
             $table->foreign('entry_uuid')
@@ -52,7 +52,7 @@ return new class extends Migration
         });
 
         $schema->create('telescope_monitoring', function (Blueprint $table) {
-            $table->string('tag');
+            $table->string('tag')->primary();
         });
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

As suggested in #1380, this PR adds Primary keys to the `telescope_entries_tags` and the `telescope_monitoring` tables, to allow HA MySQL deployments.