### PR TITLE
Add option to suppress prune output

### DIFF
--- a/src/Console/PruneCommand.php
+++ b/src/Console/PruneCommand.php
@@ -12,7 +12,7 @@ class PruneCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'telescope:prune {--hours=24 : The number of hours to retain Telescope data}';
+    protected $signature = 'telescope:prune {--hours=24 : The number of hours to retain Telescope data} {--q|quiet : Suppress output}';
 
     /**
      * The console command description.
@@ -29,6 +29,9 @@ class PruneCommand extends Command
      */
     public function handle(PrunableRepository $repository)
     {
-        $this->info($repository->prune(now()->subHours($this->option('hours'))).' entries pruned.');
+        $prunedCount = $repository->prune(now()->subHours($this->option('hours')));
+        if (! $this->option('quiet')) {
+            $this->info($prunedCount.' entries pruned.');
+        }
     }
 }

--- a/tests/Console/PruneCommandTest.php
+++ b/tests/Console/PruneCommandTest.php
@@ -30,4 +30,13 @@ class PruneCommandTest extends FeatureTestCase
 
         $this->assertDatabaseMissing('telescope_entries', ['uuid' => $recent->uuid]);
     }
+
+    public function test_prune_command_can_suppress_output()
+    {
+        $recent = EntryModelFactory::new()->create(['created_at' => now()->subHours(5)]);
+
+        $this->artisan('telescope:prune', ['-q' => ''])->doesntExpectOutput('0 entries pruned.');
+
+        $this->artisan('telescope:prune', ['--hours' => 4, '--quiet' => ''])->doesntExpectOutput('1 entries pruned.');
+    }
 }


### PR DESCRIPTION
`telescope:prune` is often run from cron, and a long-standing cron convention is that scheduled commands should only produce output when something goes wrong. This helps to reduce noise and alert fatigue. Telescope's prune command produces output stating the number of entries deleted, even if there are none, and no error has occurred. This results in (typically) daily emails being sent to admins that don't actually say anything important. Many commands have an option to suppress non-error output using a `--quiet` or `-q` command line switch, and this PR adds that to telescope's prune command like so:

    php artisan telescope:prune --quiet
    php artisan telescope:prune -q

Side note: when writing the tests, I noticed that there doesn't seem to be an assertion/expect option for there to be no output, so I had to work around that by using `doesntExpectOutput()`