### PR TITLE
[4.x] Feature: Add masking request/response parameters using Closures

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -75,7 +75,7 @@ class Telescope
     /**
      * The list of hidden request headers.
      *
-     * @var array<int|string, string|callable>
+     * @var array<int|string, string|Closure>
      */
     public static $hiddenRequestHeaders = [
         'authorization',
@@ -85,7 +85,7 @@ class Telescope
     /**
      * The list of hidden request parameters.
      *
-     * @var array<int|string, string|callable>
+     * @var array<int|string, string|Closure>
      */
     public static $hiddenRequestParameters = [
         'password',
@@ -95,7 +95,7 @@ class Telescope
     /**
      * The list of hidden response parameters.
      *
-     * @var array<int|string, string|callable>
+     * @var array<int|string, string|Closure>
      */
     public static $hiddenResponseParameters = [];
 
@@ -729,10 +729,18 @@ class Telescope
      */
     public static function hideRequestHeaders(array $headers)
     {
-        static::$hiddenRequestHeaders = array_values(array_unique(array_merge(
-            static::$hiddenRequestHeaders,
-            $headers
-        )));
+        /**
+         * @var Collection<int, string> $regular
+         * @var Collection<string, Closure> $closures
+         */
+        [$closures, $regular] = Collection::wrap($headers)
+            ->merge(static::$hiddenRequestHeaders)
+            ->partition(fn($item) => $item instanceof Closure);
+
+        static::$hiddenRequestHeaders = $regular
+            ->unique()
+            ->merge($closures)
+            ->toArray();
 
         return new static;
     }
@@ -761,10 +769,18 @@ class Telescope
      */
     public static function hideResponseParameters(array $attributes)
     {
-        static::$hiddenResponseParameters = array_values(array_unique(array_merge(
-            static::$hiddenResponseParameters,
-            $attributes
-        )));
+        /**
+         * @var Collection<int, string> $regular
+         * @var Collection<string, Closure> $closures
+         */
+        [$closures, $regular] = Collection::wrap($attributes)
+            ->merge(static::$hiddenResponseParameters)
+            ->partition(fn($item) => $item instanceof Closure);
+
+        static::$hiddenResponseParameters = $regular
+            ->unique()
+            ->merge($closures)
+            ->toArray();
 
         return new static;
     }

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -735,7 +735,7 @@ class Telescope
          */
         [$closures, $regular] = Collection::wrap($headers)
             ->merge(static::$hiddenRequestHeaders)
-            ->partition(fn($item) => $item instanceof Closure);
+            ->partition(fn ($item) => $item instanceof Closure);
 
         static::$hiddenRequestHeaders = $regular
             ->unique()
@@ -775,7 +775,7 @@ class Telescope
          */
         [$closures, $regular] = Collection::wrap($attributes)
             ->merge(static::$hiddenResponseParameters)
-            ->partition(fn($item) => $item instanceof Closure);
+            ->partition(fn ($item) => $item instanceof Closure);
 
         static::$hiddenResponseParameters = $regular
             ->unique()

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -75,7 +75,7 @@ class Telescope
     /**
      * The list of hidden request headers.
      *
-     * @var array
+     * @var array<int|string, string|callable>
      */
     public static $hiddenRequestHeaders = [
         'authorization',
@@ -85,7 +85,7 @@ class Telescope
     /**
      * The list of hidden request parameters.
      *
-     * @var array
+     * @var array<int|string, string|callable>
      */
     public static $hiddenRequestParameters = [
         'password',
@@ -95,7 +95,7 @@ class Telescope
     /**
      * The list of hidden response parameters.
      *
-     * @var array
+     * @var array<int|string, string|callable>
      */
     public static $hiddenResponseParameters = [];
 

--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -162,15 +162,24 @@ class ClientRequestWatcher extends Watcher
     /**
      * Hide the given parameters.
      *
-     * @param  array  $data
-     * @param  array  $hidden
-     * @return mixed
+     * @param  array<string,mixed>  $data
+     * @param  array<int|string, string|callable>  $hidden
+     * @return array<string, mixed>
      */
     protected function hideParameters($data, $hidden)
     {
-        foreach ($hidden as $parameter) {
-            if (Arr::get($data, $parameter)) {
-                Arr::set($data, $parameter, '********');
+        foreach ($hidden as $key => $value) {
+            $hasCallback = is_callable($value);
+            $key = $hasCallback ? $key : $value;
+            $callback = $hasCallback ? $value : null;
+
+            $value = Arr::get($data, $key);
+            if ($value !== null) {
+                $replacement = ($callback !== null)
+                    ? $callback($value, $key)
+                    : '********';
+
+                Arr::set($data, $key, $replacement);
             }
         }
 

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -123,15 +123,24 @@ class RequestWatcher extends Watcher
     /**
      * Hide the given parameters.
      *
-     * @param  array  $data
-     * @param  array  $hidden
-     * @return mixed
+     * @param  array<string,mixed>  $data
+     * @param  array<int|string, string|callable>  $hidden
+     * @return array<string, mixed>
      */
     protected function hideParameters($data, $hidden)
     {
-        foreach ($hidden as $parameter) {
-            if (Arr::get($data, $parameter)) {
-                Arr::set($data, $parameter, '********');
+        foreach ($hidden as $key => $value) {
+            $hasCallback = is_callable($value);
+            $key = $hasCallback ? $key : $value;
+            $callback = $hasCallback ? $value : null;
+
+            $value = Arr::get($data, $key);
+            if ($value !== null) {
+                $replacement = ($callback !== null)
+                    ? $callback($value, $key)
+                    : '********';
+
+                Arr::set($data, $key, $replacement);
             }
         }
 


### PR DESCRIPTION
This PR allows Telescope to customize the way request and response parameters / headers are hidden. By default, Telescope can only hide params by replacing them with `'********'`. With support for `'param' => Closure` syntax, it would be possible to tailor how the params are anonymized. 

Real world example is handling of personal numbers - it might be safe to store first 8 characters (year, month, date) but not the rest.

What is handled:
- [x] request parameters
- [x] request headers
- [x] response parameters 

**Design decision**: 
Closures vs callables: My approach uses closures as not to intruduce any breaking changes. Supporting callables would result in different behaviors for parameters named the same as functions (i.e. 'cookie' is a default parameter and a callable as well - Laravel's CookieJar helper). 




Proposed syntax:

```php
Telescope::hideRequestParameters([
    '_token',
    'personalNumber' => fn($value) => Str::substrReplace($value, '****', -4),
]);
```

Before:
![image](https://github.com/laravel/telescope/assets/20736260/39bd9f53-bea2-45e1-bbd8-41e2efa5ca5d)


After:
![image](https://github.com/laravel/telescope/assets/20736260/813b1b54-a5e1-4164-b2df-8a7e2c26d2b9)

