### PR TITLE
[4.x] Ignore duplicate tags

### DIFF
--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -3,6 +3,7 @@
 namespace Laravel\Telescope\Storage;
 
 use DateTimeInterface;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Laravel\Telescope\Contracts\ClearableRepository;
@@ -189,14 +190,18 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
     protected function storeTags(Collection $results)
     {
         $results->chunk($this->chunkSize)->each(function ($chunked) {
-            $this->table('telescope_entries_tags')->insert($chunked->flatMap(function ($tags, $uuid) {
-                return collect($tags)->map(function ($tag) use ($uuid) {
-                    return [
-                        'entry_uuid' => $uuid,
-                        'tag' => $tag,
-                    ];
-                });
-            })->all());
+            try {
+                $this->table('telescope_entries_tags')->insert($chunked->flatMap(function ($tags, $uuid) {
+                    return collect($tags)->map(function ($tag) use ($uuid) {
+                        return [
+                            'entry_uuid' => $uuid,
+                            'tag' => $tag,
+                        ];
+                    });
+                })->all());
+            } catch (UniqueConstraintViolationException $e) {
+                // Ignore tags that already exist...
+            }
         });
     }
 
@@ -246,14 +251,18 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
     protected function updateTags($entry)
     {
         if (! empty($entry->tagsChanges['added'])) {
-            $this->table('telescope_entries_tags')->insert(
-                collect($entry->tagsChanges['added'])->map(function ($tag) use ($entry) {
-                    return [
-                        'entry_uuid' => $entry->uuid,
-                        'tag' => $tag,
-                    ];
-                })->toArray()
-            );
+            try {
+                $this->table('telescope_entries_tags')->insert(
+                    collect($entry->tagsChanges['added'])->map(function ($tag) use ($entry) {
+                        return [
+                            'entry_uuid' => $entry->uuid,
+                            'tag' => $tag,
+                        ];
+                    })->toArray()
+                );
+            } catch (UniqueConstraintViolationException $e) {
+                // Ignore tags that already exist...
+            }
         }
 
         collect($entry->tagsChanges['removed'])->each(function ($tag) use ($entry) {


### PR DESCRIPTION
I couldn't immediately figure out why this happens but sometimes Telescopes seems to attempt to insert an entry tag for a uuid and tag combo which already exists. I figured just ignoring the exception here is the best way to handle this as having the entry in the database is what's important.

This problem started to arise after we added the primary key: https://github.com/laravel/telescope/pull/1425. That's a good thing though, since this probably was happening before and filling the database table with duplicate entries, which it now won't anymore.

Fixes https://github.com/laravel/telescope/issues/1430