### PR TITLE
[4.x] Added content search

### DIFF
--- a/resources/js/components/IndexScreen.vue
+++ b/resources/js/components/IndexScreen.vue
@@ -279,7 +279,7 @@
                 </div>
                 <input type="text" class="form-control w-100"
                        id="searchInput"
-                       placeholder="Search Tag or content (with content=)" v-model="tag" @input.stop="search">
+                       placeholder="Search Tag or content (using quotes)" v-model="tag" @input.stop="search">
             </div>
         </div>
 

--- a/resources/js/components/IndexScreen.vue
+++ b/resources/js/components/IndexScreen.vue
@@ -279,7 +279,7 @@
                 </div>
                 <input type="text" class="form-control w-100"
                        id="searchInput"
-                       placeholder="Search Tag or content (using content=)" v-model="tag" @input.stop="search">
+                       placeholder="Search Tag or content (with content=)" v-model="tag" @input.stop="search">
             </div>
         </div>
 

--- a/resources/js/components/IndexScreen.vue
+++ b/resources/js/components/IndexScreen.vue
@@ -279,7 +279,7 @@
                 </div>
                 <input type="text" class="form-control w-100"
                        id="searchInput"
-                       placeholder="Search Tag" v-model="tag" @input.stop="search">
+                       placeholder="Search Tag or content (using content=)" v-model="tag" @input.stop="search">
             </div>
         </div>
 

--- a/src/Storage/EntryModel.php
+++ b/src/Storage/EntryModel.php
@@ -117,7 +117,7 @@ class EntryModel extends Model
     protected function whereTag($query, EntryQueryOptions $options)
     {
         $query->when($options->tag, function ($query, $tag) {
-            $tags = trim(preg_replace('/content=([^\s$]+)/', '', $tag));
+            $tags = trim(preg_replace('/"[^"]+"/', '', $tag));
             $tags = array_filter(array_map('trim', explode(',', $tags)));
 
             if (empty($tags)) {
@@ -177,11 +177,13 @@ class EntryModel extends Model
     protected function whereSearch($query, EntryQueryOptions $options)
     {
         $query->when($options->tag, function ($query, $tag) {
-            if (! preg_match('/content=([^\s$]+)/', $tag, $search)) {
+            if (! preg_match('/"([^"]+)"/', $tag, $search)) {
                 return $query;
             }
 
-            return $query->where('content', 'LIKE', '%'.str_replace(' ', '%', $search[1]).'%');
+            $search = str_replace([' ', '/', '\\'], '%', $search[1]);
+
+            return $query->where('content', 'LIKE', '%'.$search.'%');
         });
 
         return $this;

--- a/src/Storage/EntryQueryOptions.php
+++ b/src/Storage/EntryQueryOptions.php
@@ -42,13 +42,6 @@ class EntryQueryOptions
     public $uuids;
 
     /**
-     * The search string.
-     *
-     * @var mixed
-     */
-    public $search;
-
-    /**
      * The number of entries to retrieve.
      *
      * @var int
@@ -69,7 +62,6 @@ class EntryQueryOptions
                 ->beforeSequence($request->before)
                 ->tag($request->tag)
                 ->familyHash($request->family_hash)
-                ->search($request->search)
                 ->limit($request->take ?? 50);
     }
 
@@ -145,19 +137,6 @@ class EntryQueryOptions
     public function familyHash(?string $familyHash)
     {
         $this->familyHash = $familyHash;
-
-        return $this;
-    }
-
-    /**
-     * Set the search string to retrieved entries.
-     *
-     * @param  string  $search
-     * @return $this
-     */
-    public function search(?string $search)
-    {
-        $this->search = $search;
 
         return $this;
     }

--- a/src/Storage/EntryQueryOptions.php
+++ b/src/Storage/EntryQueryOptions.php
@@ -42,6 +42,13 @@ class EntryQueryOptions
     public $uuids;
 
     /**
+     * The search string.
+     *
+     * @var mixed
+     */
+    public $search;
+
+    /**
      * The number of entries to retrieve.
      *
      * @var int
@@ -62,6 +69,7 @@ class EntryQueryOptions
                 ->beforeSequence($request->before)
                 ->tag($request->tag)
                 ->familyHash($request->family_hash)
+                ->search($request->search)
                 ->limit($request->take ?? 50);
     }
 
@@ -137,6 +145,19 @@ class EntryQueryOptions
     public function familyHash(?string $familyHash)
     {
         $this->familyHash = $familyHash;
+
+        return $this;
+    }
+
+    /**
+     * Set the search string to retrieved entries.
+     *
+     * @param  string  $search
+     * @return $this
+     */
+    public function search(?string $search)
+    {
+        $this->search = $search;
 
         return $this;
     }


### PR DESCRIPTION
After multiple rejected attempts to add a search on content, here is my PR.

In any monitoring system, search is an essential part, hence the insistence on including it as a feature of Telescope.

This PR keeps the original tag search functionality and adds an additional content search simply by using quotation marks: `"text to search"`.

I really consider very very necessary the search inside Telescope, if not with this PR, please, with a native team development.

Thank you very much :)