### PR TITLE
[4.x] Add `use` to closure to pass in environment condition

### DIFF
--- a/stubs/TelescopeServiceProvider.stub
+++ b/stubs/TelescopeServiceProvider.stub
@@ -18,14 +18,11 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
 
         $this->hideSensitiveRequestDetails();
 
-        $is_local = $this->app->environment('local');
+        $isLocal = $this->app->environment('local');
 
-        Telescope::filter(function (IncomingEntry $entry) use ($is_local) {
-            if ($is_local) {
-                return true;
-            }
-
-            return $entry->isReportableException() ||
+        Telescope::filter(function (IncomingEntry $entry) use ($isLocal) {
+            return $isLocal ||
+                   $entry->isReportableException() ||
                    $entry->isFailedRequest() ||
                    $entry->isFailedJob() ||
                    $entry->isScheduledTask() ||

--- a/stubs/TelescopeServiceProvider.stub
+++ b/stubs/TelescopeServiceProvider.stub
@@ -18,8 +18,10 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
 
         $this->hideSensitiveRequestDetails();
 
-        Telescope::filter(function (IncomingEntry $entry) {
-            if ($this->app->environment('local')) {
+        $is_local = $this->app->environment('local');
+
+        Telescope::filter(function (IncomingEntry $entry) use ($is_local) {
+            if ($is_local) {
                 return true;
             }
 


### PR DESCRIPTION
I came across this bug when running the Dusk test suite in a new project with Telescope installed. (Local dev environment running on macOS using sail)

Accessing `$this` inside the closure results in the following error: `Target class [env] does not exist.`

This can be fixed by calculating whether the environment is `local` before the filter colsure and passing the value in.

Full error log:

```
   FAIL  Tests\Browser\RegistrationTest
  ✓ register valid user                                                                                  2.58s
  ⨯ register password mismatch
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────
   FAILED  Tests\Browser\RegistrationTest > register password mismatch             BindingResolutionException
  Target class [env] does not exist.

  at vendor/laravel/framework/src/Illuminate/Container/Container.php:914
    910▕
    911▕         try {
    912▕             $reflector = new ReflectionClass($concrete);
    913▕         } catch (ReflectionException $e) {
  ➜ 914▕             throw new BindingResolutionException("Target class [$concrete] does not exist.", 0, $e);
    915▕         }
    916▕
    917▕         // If the type is not instantiable, the developer is attempting to resolve
    918▕         // an abstract type such as an Interface or Abstract Class and there is

      +9 vendor frames
  10  app/Providers/TelescopeServiceProvider.php:24
      +20 vendor frames
  31  tests/Browser/RegistrationTest.php:23


  Tests:    1 failed, 1 passed (3 assertions)
  Duration: 2.84s
```

`RegistrationTest.php`:

```php
...
    public function setUp(): void
    {
        parent::setUp(); // line 23
        $this->faker = Factory::create();
    }
...
```