### PR TITLE
Add Sleep while pruning and clearing telescope entries

### DIFF
--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -13,6 +13,7 @@ use Laravel\Telescope\Contracts\TerminableRepository;
 use Laravel\Telescope\EntryResult;
 use Laravel\Telescope\EntryType;
 use Laravel\Telescope\IncomingEntry;
+use Illuminate\Support\Sleep;
 
 class DatabaseEntriesRepository implements Contract, ClearableRepository, PrunableRepository, TerminableRepository
 {
@@ -360,6 +361,8 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
         do {
             $deleted = $query->take($this->chunkSize)->delete();
 
+            Sleep::for(1)->second();
+
             $totalDeleted += $deleted;
         } while ($deleted !== 0);
 
@@ -375,10 +378,14 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
     {
         do {
             $deleted = $this->table('telescope_entries')->take($this->chunkSize)->delete();
+
+            Sleep::for(1)->second();
         } while ($deleted !== 0);
 
         do {
             $deleted = $this->table('telescope_monitoring')->take($this->chunkSize)->delete();
+
+            Sleep::for(1)->second();
         } while ($deleted !== 0);
     }
 


### PR DESCRIPTION
If we are using Telescope in a production environment and have lots of telescope entries. Running the prune or. clear command fires too many queries together which can cause too many connections to be used for the job.

Adding a sleep will ensure that there are not too many queries being fired together.

If we might want to control the sleep based on the option I will be happy to create a PR for that as well.



