### PR TITLE
[5.x] Suggestion : Modify `storage` variable in default config file

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -36,17 +36,18 @@ return [
     | Telescope Storage Driver
     |--------------------------------------------------------------------------
     |
-    | This configuration options determines the storage driver that will
-    | be used to store Telescope's data. In addition, you may set any
-    | custom options as needed by the particular driver you choose.
+    | This configuration option determines which storage driver will be used
+    | while storing entries from Telescope's recorders. In addition, you also
+    | may provide any options to configure the selected storage driver.
     |
     */
 
-    'driver' => env('TELESCOPE_DRIVER', 'database'),
 
     'storage' => [
+        'driver' => env('TELESCOPE_STORAGE_DRIVER', 'database'),
+
         'database' => [
-            'connection' => env('DB_CONNECTION', 'mysql'),
+            'connection' => env('TELESCOPE_DB_CONNECTION', 'mysql'),
             'chunk' => 1000,
         ],
     ],

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -42,7 +42,6 @@ return [
     |
     */
 
-
     'storage' => [
         'driver' => env('TELESCOPE_STORAGE_DRIVER', 'database'),
 

--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -131,7 +131,7 @@ class TelescopeServiceProvider extends ServiceProvider
      */
     protected function registerStorageDriver()
     {
-        $driver = config('telescope.driver');
+        $driver = config('telescope.storage.driver');
 
         if (method_exists($this, $method = 'register'.ucfirst($driver).'Driver')) {
             $this->$method();


### PR DESCRIPTION
During the Laravel 11 update, I encountered a minor issue. Since I have a dedicated database for data from Pulse or Telescope, I needed to redirect connections to this database when loading the Pulse and Telescope dashboards.

For Pulse, it's straightforward to implement this using an environment variable called 'PULSE_DB_CONNECTION.' However, Telescope has a similar configuration with the environment variable 'DB_CONNECTION,' which is the `database.default` connection env variable.

A workaround could be to rewrite this in a dedicated config file, of course. However, I still thought it would be beneficial to suggest this pull request due to the current behavior of Pulse.

Pulse's default `config` file `storage` value : 

```
'storage' => [
    'driver' => env('PULSE_STORAGE_DRIVER', 'database'),

    'database' => [
        'connection' => env('PULSE_DB_CONNECTION', null),
        'chunk' => 1000,
    ],
],
```

Telescope's default `config` file `driver` and `storage` values : 

```
'driver' => env('TELESCOPE_DRIVER', 'database'),

'storage' => [
    'database' => [
        'connection' => env('DB_CONNECTION', 'mysql'),
        'chunk' => 1000,
    ],
],
```

P.S.: The description has been copied and pasted from the Pulse description and used for Telescope.