### PR TITLE
Add ignore paths option for request watcher

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -181,6 +181,7 @@ return [
             'size_limit' => env('TELESCOPE_RESPONSE_SIZE_LIMIT', 64),
             'ignore_http_methods' => [],
             'ignore_status_codes' => [],
+            'ignore_paths' => [],
         ],
 
         Watchers\ScheduleWatcher::class => env('TELESCOPE_SCHEDULE_WATCHER', true),

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -37,6 +37,7 @@ class RequestWatcher extends Watcher
     public function recordRequest(RequestHandled $event)
     {
         if (! Telescope::isRecording() ||
+            $this->shouldIgnoreRequestUri($event) ||
             $this->shouldIgnoreHttpMethod($event) ||
             $this->shouldIgnoreStatusCode($event)) {
             return;
@@ -58,6 +59,19 @@ class RequestWatcher extends Watcher
             'duration' => $startTime ? floor((microtime(true) - $startTime) * 1000) : null,
             'memory' => round(memory_get_peak_usage(true) / 1024 / 1024, 1),
         ]));
+    }
+
+    /**
+     * Determine if the request uri should be ignored based on ignored paths.
+     *
+     * @param  mixed  $event
+     * @return bool
+     */
+    protected function shouldIgnoreRequestUri($event)
+    {
+        return $event->request->is(
+            $this->options['ignore_paths'] ?? []
+        );
     }
 
     /**


### PR DESCRIPTION
This pull request introduces a new configuration option, `ignore_paths`, to the `RequestWatcher` class in Telescope.

**Motivation:**
Currently, Telescope provides a global configuration option to specify paths to be ignored, but there isn't a way to ignore specific request URIs at the level of the `RequestWatcher` class. Consequently, when we configure `ignore_paths` globally, it applies to all watchers except `QueryWatcher`. This limitation prevents monitoring of other watchers such as `JobWatcher`.

By default, Telescope ignores certain paths like
```php
 'ignore_paths' => [
        'livewire*',
        'nova-api*',
        'pulse*',
    ],
```    
However, this global setting ignores all livewire request so we can't monitor `Event`, `Job` or `Job Batch` dispatched in livewire request.
This pull request resolves this issue by allowing for more granular control over ignored paths within the `RequestWatcher`.