### PR TITLE
fix: octane listeners registered only if actually running with octane

### DIFF
--- a/src/ListensForStorageOpportunities.php
+++ b/src/ListensForStorageOpportunities.php
@@ -27,7 +27,9 @@ trait ListensForStorageOpportunities
      */
     public static function listenForStorageOpportunities($app)
     {
-        static::manageRecordingStateForOctane($app);
+        if (Telescope::runningWithinOctane($app)) {
+            static::manageRecordingStateForOctane($app);
+        }
         static::storeEntriesBeforeTermination($app);
         static::storeEntriesAfterWorkerLoop($app);
     }


### PR DESCRIPTION
I found those listeners in my app dispatcher even though my application wasn't running within octane, hence my pr