### PR TITLE
add config option for queue

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -53,6 +53,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Telescope Queue Config
+    |--------------------------------------------------------------------------
+    |
+    | This configuration options determines the queue config that will be
+    | used for ProcessPendingUpdates job, by passing the null value
+    | we use the default queue or change it to a custom queue.
+    |
+    */
+    'queue'=>[
+        'connection' => env('TELESCOPE_QUEUE_CONNECTION', null),
+        'queue' => env('TELESCOPE_QUEUE', null),
+    ],
+    /*
+    |--------------------------------------------------------------------------
     | Telescope Master Switch
     |--------------------------------------------------------------------------
     |

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -7,6 +7,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Telescope Master Switch
+    |--------------------------------------------------------------------------
+    |
+    | This option may be used to disable all Telescope watchers regardless
+    | of their individual configuration, which simply provides a single
+    | and convenient way to enable or disable Telescope data storage.
+    |
+    */
+
+    'enabled' => env('TELESCOPE_ENABLED', true),
+
+    /*
+    |--------------------------------------------------------------------------
     | Telescope Domain
     |--------------------------------------------------------------------------
     |
@@ -53,30 +66,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Telescope Queue Config
+    | Telescope Queue
     |--------------------------------------------------------------------------
     |
-    | This configuration options determines the queue config that will be
-    | used for ProcessPendingUpdates job, by passing the null value
-    | we use the default queue or change it to a custom queue.
+    | This configuration options determines the queue connection and queue
+    | which will be used to process ProcessPendingUpdate jobs. This can
+    | be changed if you would prefer to use a non-default connection.
     |
     */
+
     'queue'=>[
         'connection' => env('TELESCOPE_QUEUE_CONNECTION', null),
         'queue' => env('TELESCOPE_QUEUE', null),
     ],
-    /*
-    |--------------------------------------------------------------------------
-    | Telescope Master Switch
-    |--------------------------------------------------------------------------
-    |
-    | This option may be used to disable all Telescope watchers regardless
-    | of their individual configuration, which simply provides a single
-    | and convenient way to enable or disable Telescope data storage.
-    |
-    */
-
-    'enabled' => env('TELESCOPE_ENABLED', true),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -665,7 +665,7 @@ class Telescope
                 if (! isset($_ENV['VAPOR_SSM_PATH'])) {
                     $updateResult->whenNotEmpty(fn ($pendingUpdates) => rescue(fn () => ProcessPendingUpdates::dispatch(
                         $pendingUpdates,
-                    )->delay(now()->addSeconds(10))));
+                    )->onQueue(config('telescope.queue.queue',null))->onConnection(config('telescope.queue.connection',null))->delay(now()->addSeconds(10))));
                 }
 
                 if ($storage instanceof TerminableRepository) {

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -665,7 +665,11 @@ class Telescope
                 if (! isset($_ENV['VAPOR_SSM_PATH'])) {
                     $updateResult->whenNotEmpty(fn ($pendingUpdates) => rescue(fn () => ProcessPendingUpdates::dispatch(
                         $pendingUpdates,
-                    )->onQueue(config('telescope.queue.queue',null))->onConnection(config('telescope.queue.connection',null))->delay(now()->addSeconds(10))));
+                    )->onConnection(
+                        config('telescope.queue.connection')
+                    )->onQueue(
+                        config('telescope.queue.queue')
+                    )->delay(now()->addSeconds(10))));
                 }
 
                 if ($storage instanceof TerminableRepository) {


### PR DESCRIPTION
In V4 telescope introduces a new job that uses the queue system to fix the pending jobs problem https://github.com/laravel/telescope/pull/1349

This job uses the default queue of your application. 

Sometimes this JOB can make thousands of pending jobs in your queue. and block your important jobs.

With this PR we can change the telescope queue and connection to something else and manage this jobs in a separate queue.

There are multiple request about this feature before here:
https://github.com/laravel/telescope/issues/1459
https://github.com/laravel/telescope/issues/1392
https://github.com/laravel/telescope/pull/1393
https://github.com/laravel/telescope/issues/1377