### PR TITLE
Add crossorigin anonymus to the mix configuration because it's not possible to use with a CDN for all the resources #1468

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -14,7 +14,7 @@
     <!-- Style sheets-->
     <link rel="preconnect" href="https://fonts.bunny.net">
     <link href="https://fonts.bunny.net/css?family=figtree:300,400,500,600" rel="stylesheet" />
-    <link href="{{ asset(mix($cssFile, 'vendor/telescope')) }}" rel="stylesheet" type="text/css">
+    <link href="{{ asset(mix($cssFile, 'vendor/telescope')) }}" rel="stylesheet" type="text/css" crossorigin="anonymous">
 </head>
 <body>
 <div id="telescope" v-cloak>
@@ -232,6 +232,6 @@
     window.Telescope = @json($telescopeScriptVariables);
 </script>
 
-<script src="{{ asset(mix('app.js', 'vendor/telescope')) }}"></script>
+<script src="{{ asset(mix('app.js', 'vendor/telescope')) }}" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -41,4 +41,7 @@ mix.options({
                 contextRegExp: /moment$/,
             }),
         ],
+        output: {
+            crossOriginLoading: "anonymous"
+        }
     });


### PR DESCRIPTION
Fixing #1468 and this is a small fix to enable the telescope to serve from CDN, very useful for distributing public folder into S3/Cloudfront 
