### PR TITLE
CS Fixing to align with the default laravel preset for Pint

### DIFF
--- a/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -9,7 +9,7 @@ return new class extends Migration
     /**
      * Get the migration connection name.
      */
-    public function getConnection(): string|null
+    public function getConnection(): ?string
     {
         return config('telescope.storage.database.connection');
     }
@@ -46,9 +46,9 @@ return new class extends Migration
             $table->index('tag');
 
             $table->foreign('entry_uuid')
-                  ->references('uuid')
-                  ->on('telescope_entries')
-                  ->onDelete('cascade');
+                ->references('uuid')
+                ->on('telescope_entries')
+                ->onDelete('cascade');
         });
 
         $schema->create('telescope_monitoring', function (Blueprint $table) {


### PR DESCRIPTION
Using Laravel Pint with the default `laravel` preset, then installed Telescope, but Pint suggest these changes.
I think the Laravel packages should follow the Laravel coding standards by default. So Pint will not be angry about generated files by Laravel packages.
