### PR TITLE
add queue connection customization to the Job self dispatch

### DIFF
--- a/src/Jobs/ProcessPendingUpdates.php
+++ b/src/Jobs/ProcessPendingUpdates.php
@@ -53,9 +53,11 @@ class ProcessPendingUpdates implements ShouldQueue
         $repository->update($this->pendingUpdates)->whenNotEmpty(
             fn ($pendingUpdates) => static::dispatchIf(
                 $this->attempt < 3, $pendingUpdates, $this->attempt
-            )->onConnection(config('telescope.queue.connection'))
-                ->onQueue(config('telescope.queue.queue'))
-                ->delay(now()->addSeconds(10)),
+            )->onConnection(
+                config('telescope.queue.connection')
+            )->onQueue(
+                config('telescope.queue.queue')
+            )->delay(now()->addSeconds(10)),
         );
     }
 }

--- a/src/Jobs/ProcessPendingUpdates.php
+++ b/src/Jobs/ProcessPendingUpdates.php
@@ -53,7 +53,9 @@ class ProcessPendingUpdates implements ShouldQueue
         $repository->update($this->pendingUpdates)->whenNotEmpty(
             fn ($pendingUpdates) => static::dispatchIf(
                 $this->attempt < 3, $pendingUpdates, $this->attempt
-            )->delay(now()->addSeconds(10)),
+            )->onConnection(config('telescope.queue.connection'))
+                ->onQueue(config('telescope.queue.queue'))
+                ->delay(now()->addSeconds(10)),
         );
     }
 }


### PR DESCRIPTION
In the `src/Jobs/ProcessPendingUpdates.php` we conditionally dispatch the job but we don't use the queue options introduced in https://github.com/laravel/telescope/pull/1469 This PR fixes this.