### PR TITLE
[5.x] Add `isLog` to `IncomingEntry`

### DIFF
--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -190,7 +190,7 @@ class IncomingEntry
     {
         return $this->type === EntryType::LOG;
     }
-    
+
     /**
      * Determine if the incoming entry is a request.
      *

--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -182,16 +182,6 @@ class IncomingEntry
     }
 
     /**
-     * Determine if the incoming entry is a log entry.
-     *
-     * @return bool
-     */
-    public function isLog()
-    {
-        return $this->type === EntryType::LOG;
-    }
-
-    /**
      * Determine if the incoming entry is a request.
      *
      * @return bool
@@ -281,6 +271,16 @@ class IncomingEntry
     public function isDump()
     {
         return false;
+    }
+
+    /**
+     * Determine if the incoming entry is a log entry.
+     *
+     * @return bool
+     */
+    public function isLog()
+    {
+        return $this->type === EntryType::LOG;
     }
 
     /**

--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -182,6 +182,16 @@ class IncomingEntry
     }
 
     /**
+     * Determine if the incoming entry is a log entry.
+     *
+     * @return bool
+     */
+    public function isLog()
+    {
+        return $this->type === EntryType::LOG;
+    }
+    
+    /**
      * Determine if the incoming entry is a request.
      *
      * @return bool


### PR DESCRIPTION
This commit introduces the `isLog` convenience method to check if a Telescope IncomingEntry is of type Log.

This will improve the readability of the code in the application's `TelescopeServiceProvider`

Before:

```
Telescope::filter(function (IncomingEntry $entry) {
    if ($this->app->environment('local')) {
        return true;
    }

    return $entry->type === EntryType::LOG;
});
```

After:

```
Telescope::filter(function (IncomingEntry $entry) {
    if ($this->app->environment('local')) {
        return true;
    }

    return $entry->isLog();
});
```
