### PR TITLE
Add duplicated query indicator

### DIFF
--- a/resources/js/components/RelatedEntries.vue
+++ b/resources/js/components/RelatedEntries.vue
@@ -27,8 +27,15 @@
          */
         mounted(){
             this.activateFirstTab();
+            this.registerDocumentClickListener();
         },
 
+        /**
+         * Remove the previously added listeners
+         */
+        beforeUnmount() {
+            this.unregisterDocumentClickListener()
+        },
 
         watch: {
             entry(){
@@ -94,6 +101,15 @@
                 if(entryElement) {
                     entryElement.scrollIntoView({ behavior: "smooth", block: "center", inline: "center"});
                 }
+            },
+            blurHighlightedEntry() {
+                this.highlightedEntry = null;
+            },
+            registerDocumentClickListener() {
+                document.addEventListener('click', this.blurHighlightedEntry)
+            },
+            unregisterDocumentClickListener() {
+                document.removeEventListener('click', this.blurHighlightedEntry)
             }
         },
 
@@ -310,7 +326,7 @@
                     <td :title="entry.content.sql"><a :id="entry.id"></a><code>{{truncate(entry.content.sql, 110)}}</code></td>
 
                     <td class="table-fit text-right">
-                        <a @click="scrollToEntry(getDuplicatedOrigin(entry))" class="badge badge-warning mr-2"
+                        <a @click.stop.prevent="scrollToEntry(getDuplicatedOrigin(entry))" class="badge badge-warning mr-2"
                            v-if="isDuplicated(entry)" role="button">
                             duplicated
                         </a>
@@ -681,10 +697,5 @@
 <style scoped>
     td {
         vertical-align: middle !important;
-    }
-
-    .table-hover tbody tr.highlight {
-        color: #111827;
-        background-color: #f3f4f6;
     }
 </style>

--- a/resources/sass/base.scss
+++ b/resources/sass/base.scss
@@ -144,6 +144,13 @@ svg.icon {
             width: 1%;
             white-space: nowrap;
         }
+
+        tr {
+            &.highlight {
+                color: $table-hover-color;
+                background-color: $table-hover-bg;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Added a badge to indicate which queries were duplicated, in the "Related Queries" tabs. The badge can be clicked on, to scroll to the first instance of the query, which will be highlighted. The first instance of a duplicated query is not marked with a badge, since it's not technically duplicated yet. 

## Screenshots
Light theme:
![image](https://github.com/user-attachments/assets/91e6d645-9dd7-481d-a85e-0789516b9738)

Dark theme:
![image](https://github.com/user-attachments/assets/c798f6a3-fca6-44ea-b2d7-8a19d7660d64)

An example of the badge with a badge for a long query:
![image](https://github.com/user-attachments/assets/ed58f126-1ca2-471d-b2b5-68a973ab8d70)

## Motivation
This feature came from a need to know which queries were duplicated, when looking at the queries for a given http request. Knowing exactly which queries are duplicated can be very useful when attempting to optimize a request with eager loading. Also, know which instance of the query is the first one can help to identify when this query come from and how to prevent further duplication. 

There was quite a few issue regarding this problem, and even a few attempt, but it never got fixed. So here I am, throwing my solution into the ring. 

Here are a list of the related issue 
#603 
#786 
#1326 

And a PR to fix the issue
#1328 

## Testing
I wanted to write a complete test suite for this feature. However, since this is a front-end only fix, I could not use the regular phpunit framework. I would have needed to install jest, and setup everything needed to even be able to run a single test. I felt like this was not my place, and I did not want to do more than necessary on that feature.

If, at some point, a testing framework is added to the front-end part of telescope, I will gladly come back and write some tests.
