### PR TITLE
add support for non-standard PDOs

### DIFF
--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -119,7 +119,11 @@ class QueryWatcher extends Watcher
     protected function quoteStringBinding($event, $binding)
     {
         try {
-            return $event->connection->getPdo()->quote($binding);
+            $pdo = $event->connection->getPdo();
+
+            if ($pdo instanceof \PDO) {
+                return $pdo->quote($binding);
+            }
         } catch (\PDOException $e) {
             throw_if('IM001' !== $e->getCode(), $e);
         }

--- a/tests/Watchers/QueryWatcherTest.php
+++ b/tests/Watchers/QueryWatcherTest.php
@@ -120,7 +120,7 @@ Data: {
 }
 SQL,
             ['kp_id' => '=ABC001'],
-            fake()->numberBetween(100, 999),
+            500,
             new Connection('filemaker'),
         );
 


### PR DESCRIPTION
I’m using a mysql database for my app, as well as this package to access a FileMaker database for some additional data: https://github.com/gearbox-solutions/eloquent-filemaker

That package is firing a `\Illuminate\Database\Events\QueryExecuted` event for logging purposes.

However, that results in `ERROR  Call to a member function quote() on string in vendor/laravel/telescope/src/Watchers/QueryWatcher.php on line 122.` in Telescope because [this line](https://github.com/laravel/telescope/blob/a678a14018f27df566b5478804b530fdf618c812/src/Watchers/QueryWatcher.php#L122) is trying to get a `PDO` instance. Because FileMaker databases are accessible via a REST API and not an actual database connection, there is no PDO instance available.

This PR addresses that by detecting whether the app has an actual `PDO` instance before trying to call the `quote()` method.