### PR TITLE
Fix that multiple use of the same binding is only replaced once in the query

### DIFF
--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -103,7 +103,12 @@ class QueryWatcher extends Watcher
                 $binding = $this->quoteStringBinding($event, $binding);
             }
 
-            $sql = preg_replace($regex, $binding, $sql, 1);
+            $sql = preg_replace(
+                $regex,
+                $binding,
+                $sql,
+                is_numeric($key) ? 1 : -1
+            );
         }
 
         return $sql;

--- a/tests/Watchers/QueryWatcherTest.php
+++ b/tests/Watchers/QueryWatcherTest.php
@@ -81,8 +81,11 @@ SQL
 
     public function test_query_watcher_can_prepare_named_bindings()
     {
+        // using the "sequence"-condition twice is intentional
+        // to test whether named parameters can be used multiple times.
+
         $this->app->get('db')->statement(<<<'SQL'
-update "telescope_entries" set "content" = :content, "should_display_on_index" = :index_new where "type" = :type and "should_display_on_index" = :index_old and "family_hash" is null and "sequence" > :sequence and "created_at" < :created_at
+update "telescope_entries" set "content" = :content, "should_display_on_index" = :index_new where "type" = :type and "should_display_on_index" = :index_old and "family_hash" is null and "sequence" > :sequence and "sequence" > :sequence and "created_at" < :created_at
 SQL
             , [
                 'sequence' => 100,
@@ -97,7 +100,7 @@ SQL
 
         $this->assertSame(EntryType::QUERY, $entry->type);
         $this->assertSame(<<<'SQL'
-update "telescope_entries" set "content" = null, "should_display_on_index" = 0 where "type" = 'query' and "should_display_on_index" = 1 and "family_hash" is null and "sequence" > 100 and "created_at" < '2019-01-01 00:00:00'
+update "telescope_entries" set "content" = null, "should_display_on_index" = 0 where "type" = 'query' and "should_display_on_index" = 1 and "family_hash" is null and "sequence" > 100 and "sequence" > 100 and "created_at" < '2019-01-01 00:00:00'
 SQL
             , $entry->content['sql']);
 


### PR DESCRIPTION
Named Query-bindings can be used multiple times in one query, but Telescope explicitly only replaces the first use of a binding. This is due to the fact that the preg_replace doesn't distinguish between unnamed parameters (where only the match hit must be replaced) and named parameters.

This makes rerunning queries in a console cumbersome, because it's always necessary to dump the bindings and replace further uses manually.