### PR TITLE
[5.x] Enhance Telescope Clear Method

### DIFF
--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -380,11 +380,15 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
     public function clear()
     {
         try {
-            Schema::withoutForeignKeyConstraints(function () {
-                $this->table('telescope_entries')->truncate();
-                $this->table('telescope_monitoring')->truncate();
-            });
-        } catch (\PDOException) {
+            Schema::disableForeignKeyConstraints();
+
+            $this->table('telescope_entries')->truncate();
+            $this->table('telescope_monitoring')->truncate();
+
+            Schema::enableForeignKeyConstraints();
+        } finally {
+            Schema::enableForeignKeyConstraints();
+
             do {
                 $deleted = $this->table('telescope_entries')->take($this->chunkSize)->delete();
             } while ($deleted !== 0);

--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -386,9 +386,6 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
             $this->table('telescope_entries')->truncate();
             $this->table('telescope_monitoring')->truncate();
         } catch (QueryException) {
-            // Fallback to chunked deletion if truncation fails due to database restrictions or errors
-            // This ensures that the tables are still cleared, even if truncation is not possible
-
             do {
                 $deleted = $this->table('telescope_entries')->take($this->chunkSize)->delete();
             } while ($deleted !== 0);

--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -390,10 +390,11 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
             // This ensures that the tables are still cleared, even if truncation is not possible
 
             do {
-                // Delete rows in chunks from both tables to avoid hitting database limits on large deletions
-
                 $deleted = $this->table('telescope_entries')->take($this->chunkSize)->delete();
-                $deleted += $this->table('telescope_monitoring')->take($this->chunkSize)->delete();
+            } while ($deleted !== 0);
+
+            do {
+                $deleted = $this->table('telescope_monitoring')->take($this->chunkSize)->delete();
             } while ($deleted !== 0);
         } finally {
             Schema::enableForeignKeyConstraints();

--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -3,6 +3,7 @@
 namespace Laravel\Telescope\Storage;
 
 use DateTimeInterface;
+use Illuminate\Database\QueryException;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -384,11 +385,7 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
 
             $this->table('telescope_entries')->truncate();
             $this->table('telescope_monitoring')->truncate();
-
-            Schema::enableForeignKeyConstraints();
-        } finally {
-            Schema::enableForeignKeyConstraints();
-
+        } catch (QueryException) {
             do {
                 $deleted = $this->table('telescope_entries')->take($this->chunkSize)->delete();
             } while ($deleted !== 0);
@@ -396,6 +393,8 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
             do {
                 $deleted = $this->table('telescope_monitoring')->take($this->chunkSize)->delete();
             } while ($deleted !== 0);
+        } finally {
+            Schema::enableForeignKeyConstraints();
         }
     }
 


### PR DESCRIPTION
This PR enhances the `clear` method in Laravel Telescope's `DatabaseEntriesRepository` to improve the efficiency and reliability of clearing the `telescope_entries` and `telescope_monitoring` tables.

#### Key Improvements:
- **Safe Truncate:** The method begins by disabling foreign key constraints using `Schema::disableForeignKeyConstraints()` before attempting to truncate the tables. This avoids foreign key conflicts during truncation.
- **Fallback to Chunked Deletion:** If a `QueryException` occurs during truncation, the method catches the exception and reverts to chunked deletion. This ensures the tables are cleared even if truncation isn't possible due to database constraints or limitations.
- **Performance Enhancement:** Truncation is much faster than deletion in chunks, making this approach optimal for performance while still retaining compatibility with databases that have row deletion limits.

#### References:
- This PR addresses issues caused by #991, where unhandled foreign keys during truncation led to failures.
- It also preserves the chunked deletion logic introduced in #1415 and #1410, ensuring support for databases with row deletion constraints.