### PR TITLE
Skip migrations when Telescope is disabled

### DIFF
--- a/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -19,6 +19,10 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (! config('telescope.enabled')) {
+            return;
+        }
+
         $schema = Schema::connection($this->getConnection());
 
         $schema->create('telescope_entries', function (Blueprint $table) {
@@ -61,6 +65,10 @@ return new class extends Migration
      */
     public function down(): void
     {
+        if (! config('telescope.enabled')) {
+            return;
+        }
+
         $schema = Schema::connection($this->getConnection());
 
         $schema->dropIfExists('telescope_entries_tags');


### PR DESCRIPTION
Hi,

My project uses an in-memory SQLite database for testing in CI, and `RefreshDatabase` tests stopped working after upgrading to v5 and publishing the Telescope migration file. In my case, the tests were failing as the `telescope.storage.database.connection` config value had not been updated to point to the SQLite database.

This change skips Telescope migrations when the `TELESCOPE_ENABLED` flag is false, such as when running tests using the standard Laravel PHPUnit config. However, it's not a great solution as migrations will sometimes need to be re-run after enabling Telescope.

Related:
https://github.com/laravel/telescope/issues/1476