### PR TITLE
Issue with Incomplete Log Clearance in clear() Method Due to Disabled Foreign Key Constraints

### DIFF
--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -381,8 +381,8 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
     public function clear()
     {
         try {
-            $this->table('telescope_entries')->truncate();
-            $this->table('telescope_monitoring')->truncate();
+            $this->table('telescope_entries')->delete();
+            $this->table('telescope_monitoring')->delete();
         } catch (QueryException) {
             do {
                 $deleted = $this->table('telescope_entries')->take($this->chunkSize)->delete();

--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -381,8 +381,6 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
     public function clear()
     {
         try {
-            Schema::disableForeignKeyConstraints();
-
             $this->table('telescope_entries')->truncate();
             $this->table('telescope_monitoring')->truncate();
         } catch (QueryException) {
@@ -393,8 +391,6 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
             do {
                 $deleted = $this->table('telescope_monitoring')->take($this->chunkSize)->delete();
             } while ($deleted !== 0);
-        } finally {
-            Schema::enableForeignKeyConstraints();
         }
     }
 


### PR DESCRIPTION
Dear Laravel Telescope Maintainers,

I’ve encountered a significant issue related to log clearance in the Laravel Telescope. The recent commit from pull request #1507 that disables foreign key constraints within the `DatabaseEntriesRepository::class@clear()` method has resulted in incomplete log deletion. Specifically, records in the telescope_entries_tag table are not being cleared, leading to unnecessary database growth over time.

This oversight can result in substantial database bloat, especially in environments with high logging activity. I believe addressing this would greatly benefit the efficiency and performance of the package.

Thank you for your attention to this matter.

Best regards