### PR TITLE
[5.x] Added `isEvent` and `isCache` methods to `IncomingEntry`

### DIFF
--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -284,6 +284,26 @@ class IncomingEntry
     }
 
     /**
+     * Determine if the incoming entry is a event entry.
+     *
+     * @return bool
+     */
+    public function isEvent()
+    {
+        return $this->type === EntryType::EVENT;
+    }
+
+    /**
+     * Determine if the incoming entry is a cache entry.
+     *
+     * @return bool
+     */
+    public function isCache()
+    {
+        return $this->type === EntryType::CACHE;
+    }
+
+    /**
      * Determine if the incoming entry is a scheduled task.
      *
      * @return bool

--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -223,6 +223,26 @@ class IncomingEntry
     }
 
     /**
+     * Determine if the incoming entry is a event entry.
+     *
+     * @return bool
+     */
+    public function isEvent()
+    {
+        return $this->type === EntryType::EVENT;
+    }
+
+    /**
+     * Determine if the incoming entry is a cache entry.
+     *
+     * @return bool
+     */
+    public function isCache()
+    {
+        return $this->type === EntryType::CACHE;
+    }
+
+    /**
      * Determine if the incoming entry is an authorization gate check.
      *
      * @return bool
@@ -281,26 +301,6 @@ class IncomingEntry
     public function isLog()
     {
         return $this->type === EntryType::LOG;
-    }
-
-    /**
-     * Determine if the incoming entry is a event entry.
-     *
-     * @return bool
-     */
-    public function isEvent()
-    {
-        return $this->type === EntryType::EVENT;
-    }
-
-    /**
-     * Determine if the incoming entry is a cache entry.
-     *
-     * @return bool
-     */
-    public function isCache()
-    {
-        return $this->type === EntryType::CACHE;
     }
 
     /**


### PR DESCRIPTION
In my projects i encountered frequent use of  `$this->type === EntryType::EVENT` and `$this->type === EntryType::CACHE` in `TelescopeServiceProvider` for filtering. To simplify this, i added methods `isEvent` and `isCache` in the IncomingEntry.

Happy to add similar methods for all EntryType types if needed.