### PR TITLE
[5.x] fix implicitly marking parameter as nullable

### DIFF
--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -44,7 +44,7 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
      * @param  int  $chunkSize
      * @return void
      */
-    public function __construct(string $connection, int $chunkSize = null)
+    public function __construct(string $connection, ?int $chunkSize = null)
     {
         $this->connection = $connection;
 


### PR DESCRIPTION
`Laravel\Telescope\Storage\DatabaseEntriesRepository::__construct()`: Implicitly marking parameter $chunkSize as nullable is deprecated, the explicit nullable type must be used instead

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
