### PR TITLE
Add option to hide menu items for disabled watchers

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -121,6 +121,8 @@ return [
         //
     ],
 
+    'hide_disabled_watcher_pages' => env('TELESCOPE_HIDE_DISABLED_WATCHER_PAGES', false),
+
     /*
     |--------------------------------------------------------------------------
     | Telescope Watchers

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -107,10 +107,11 @@
                         </router-link>
                     </li>
                     @endif
-
+                    
+                    <div class="mt-3"/>
 
                     @if (!(config('telescope.hide_disabled_watcher_pages') && !config('telescope.watchers.Laravel\Telescope\Watchers\BatchWatcher')))
-                    <li class="nav-item mt-3">
+                    <li class="nav-item">
                         <router-link active-class="active" to="/batches" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
                                 <path fill-rule="evenodd" d="M2 3.75A.75.75 0 012.75 3h14.5a.75.75 0 010 1.5H2.75A.75.75 0 012 3.75zm0 4.167a.75.75 0 01.75-.75h14.5a.75.75 0 010 1.5H2.75a.75.75 0 01-.75-.75zm0 4.166a.75.75 0 01.75-.75h14.5a.75.75 0 010 1.5H2.75a.75.75 0 01-.75-.75zm0 4.167a.75.75 0 01.75-.75h14.5a.75.75 0 010 1.5H2.75a.75.75 0 01-.75-.75z" clip-rule="evenodd" />

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -67,7 +67,7 @@
         <div class="row mt-4">
             <div class="col-2 sidebar">
                 <ul class="nav flex-column">
-                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\RequestWatcher.enabled')))
+                    @if (!(config('telescope.hide_disabled_watcher_pages') && !config('telescope.watchers.Laravel\Telescope\Watchers\RequestWatcher.enabled')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/requests" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -77,7 +77,7 @@
                         </router-link>
                     </li>
                     @endif
-                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\CommandWatcher.enabled')))
+                    @if (!(config('telescope.hide_disabled_watcher_pages') && !config('telescope.watchers.Laravel\Telescope\Watchers\CommandWatcher.enabled')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/commands" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -87,7 +87,7 @@
                         </router-link>
                     </li>
                     @endif
-                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\ScheduleWatcher')))
+                    @if (!(config('telescope.hide_disabled_watcher_pages') && !config('telescope.watchers.Laravel\Telescope\Watchers\ScheduleWatcher')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/schedule" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -97,7 +97,7 @@
                         </router-link>
                     </li>
                     @endif
-                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\JobWatcher')))
+                    @if (!(config('telescope.hide_disabled_watcher_pages') && !config('telescope.watchers.Laravel\Telescope\Watchers\JobWatcher')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/jobs" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -109,7 +109,7 @@
                     @endif
 
 
-                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\BatchWatcher')))
+                    @if (!(config('telescope.hide_disabled_watcher_pages') && !config('telescope.watchers.Laravel\Telescope\Watchers\BatchWatcher')))
                     <li class="nav-item mt-3">
                         <router-link active-class="active" to="/batches" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -119,7 +119,7 @@
                         </router-link>
                     </li>
                     @endif
-                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\CacheWatcher.enabled')))
+                    @if (!(config('telescope.hide_disabled_watcher_pages') && !config('telescope.watchers.Laravel\Telescope\Watchers\CacheWatcher.enabled')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/cache" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -130,7 +130,7 @@
                         </router-link>
                     </li>
                     @endif
-                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\DumpWatcher.enabled')))
+                    @if (!(config('telescope.hide_disabled_watcher_pages') && !config('telescope.watchers.Laravel\Telescope\Watchers\DumpWatcher.enabled')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/dumps" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -140,7 +140,7 @@
                         </router-link>
                     </li>
                     @endif
-                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\EventWatcher.enabled')))
+                    @if (!(config('telescope.hide_disabled_watcher_pages') && !config('telescope.watchers.Laravel\Telescope\Watchers\EventWatcher.enabled')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/events" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -150,7 +150,7 @@
                         </router-link>
                     </li>
                     @endif
-                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\ExceptionWatcher')))
+                    @if (!(config('telescope.hide_disabled_watcher_pages') && !config('telescope.watchers.Laravel\Telescope\Watchers\ExceptionWatcher')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/exceptions" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -160,7 +160,7 @@
                         </router-link>
                     </li>
                     @endif
-                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\GateWatcher.enabled')))
+                    @if (!(config('telescope.hide_disabled_watcher_pages') && !config('telescope.watchers.Laravel\Telescope\Watchers\GateWatcher.enabled')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/gates" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -170,7 +170,7 @@
                         </router-link>
                     </li>
                     @endif
-                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\ClientRequestWatcher')))
+                    @if (!(config('telescope.hide_disabled_watcher_pages') && !config('telescope.watchers.Laravel\Telescope\Watchers\ClientRequestWatcher')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/client-requests" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -180,7 +180,7 @@
                         </router-link>
                     </li>
                     @endif
-                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\LogWatcher.enabled')))
+                    @if (!(config('telescope.hide_disabled_watcher_pages') && !config('telescope.watchers.Laravel\Telescope\Watchers\LogWatcher.enabled')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/logs" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -191,7 +191,7 @@
                         </router-link>
                     </li>
                     @endif
-                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\MailWatcher')))
+                    @if (!(config('telescope.hide_disabled_watcher_pages') && !config('telescope.watchers.Laravel\Telescope\Watchers\MailWatcher')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/mail" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -202,7 +202,7 @@
                         </router-link>
                     </li>
                     @endif
-                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\ModelWatcher.enabled')))
+                    @if (!(config('telescope.hide_disabled_watcher_pages') && !config('telescope.watchers.Laravel\Telescope\Watchers\ModelWatcher.enabled')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/models" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -212,7 +212,7 @@
                         </router-link>
                     </li>
                     @endif
-                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\NotificationWatcher')))
+                    @if (!(config('telescope.hide_disabled_watcher_pages') && !config('telescope.watchers.Laravel\Telescope\Watchers\NotificationWatcher')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/notifications" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -223,7 +223,7 @@
                         </router-link>
                     </li>
                     @endif
-                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\QueryWatcher.enabled')))
+                    @if (!(config('telescope.hide_disabled_watcher_pages') && !config('telescope.watchers.Laravel\Telescope\Watchers\QueryWatcher.enabled')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/queries" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -233,7 +233,7 @@
                         </router-link>
                     </li>
                     @endif
-                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\RedisWatcher')))
+                    @if (!(config('telescope.hide_disabled_watcher_pages') && !config('telescope.watchers.Laravel\Telescope\Watchers\RedisWatcher')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/redis" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -243,7 +243,7 @@
                         </router-link>
                     </li>
                     @endif
-                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\ViewWatcher')))
+                    @if (!(config('telescope.hide_disabled_watcher_pages') && !config('telescope.watchers.Laravel\Telescope\Watchers\ViewWatcher')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/views" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -67,6 +67,7 @@
         <div class="row mt-4">
             <div class="col-2 sidebar">
                 <ul class="nav flex-column">
+                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\RequestWatcher.enabled')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/requests" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -75,6 +76,8 @@
                             <span>Requests</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\CommandWatcher.enabled')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/commands" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -83,6 +86,8 @@
                             <span>Commands</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\ScheduleWatcher')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/schedule" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -91,6 +96,8 @@
                             <span>Schedule</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\JobWatcher')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/jobs" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -99,8 +106,10 @@
                             <span>Jobs</span>
                         </router-link>
                     </li>
+                    @endif
 
 
+                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\BatchWatcher')))
                     <li class="nav-item mt-3">
                         <router-link active-class="active" to="/batches" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -109,6 +118,8 @@
                             <span>Batches</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\CacheWatcher.enabled')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/cache" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -118,6 +129,8 @@
                             <span>Cache</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\DumpWatcher.enabled')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/dumps" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -126,6 +139,8 @@
                             <span>Dumps</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\EventWatcher.enabled')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/events" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -134,6 +149,8 @@
                             <span>Events</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\ExceptionWatcher')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/exceptions" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -142,6 +159,8 @@
                             <span>Exceptions</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\GateWatcher.enabled')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/gates" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -150,6 +169,8 @@
                             <span>Gates</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\ClientRequestWatcher')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/client-requests" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -158,6 +179,8 @@
                             <span>HTTP Client</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\LogWatcher.enabled')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/logs" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -167,6 +190,8 @@
                             <span>Logs</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\MailWatcher')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/mail" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -176,6 +201,8 @@
                             <span>Mail</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\ModelWatcher.enabled')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/models" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -184,6 +211,8 @@
                             <span>Models</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\NotificationWatcher')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/notifications" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -193,6 +222,8 @@
                             <span>Notifications</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\QueryWatcher.enabled')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/queries" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -201,6 +232,8 @@
                             <span>Queries</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\RedisWatcher')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/redis" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -209,6 +242,8 @@
                             <span>Redis</span>
                         </router-link>
                     </li>
+                    @endif
+                    @if (!(config('telescope.hide_disabled_watcher_pages', false) && !config('telescope.watchers.Laravel\Telescope\Watchers\ViewWatcher')))
                     <li class="nav-item">
                         <router-link active-class="active" to="/views" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -217,6 +252,7 @@
                             <span>Views</span>
                         </router-link>
                     </li>
+                    @endif
                 </ul>
             </div>
 


### PR DESCRIPTION
Implementation for [this feature request](https://github.com/laravel/telescope/issues/542)

I have some watchers disabled because I do not use them that often.
I would like to be able to hide the respective navigation items.
This pull request implements that.
It makes the sidebar a bit less cluttered if you only use a handfull of watchers.

I've implemented this feature as an opt-in feature using a config parameter.
Only if the `hide_disabled_watcher_pages` config is true and if the corosponding watcher is disabled, the menu item will be hidden.

Please let me know if anything needs to be changed.
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->