### PR TITLE
Speed up multi-tag filtering

### DIFF
--- a/src/Storage/EntryModel.php
+++ b/src/Storage/EntryModel.php
@@ -123,10 +123,7 @@ class EntryModel extends Model
             }
 
             return $query->whereIn('uuid', function ($query) use ($tags) {
-                $query->select('entry_uuid')->from('telescope_entries_tags')
-                    ->whereIn('entry_uuid', function ($query) use ($tags) {
-                        $query->select('entry_uuid')->from('telescope_entries_tags')->whereIn('tag', $tags->all());
-                    });
+                $query->select('entry_uuid')->from('telescope_entries_tags')->whereIn('tag', $tags->all());
             });
         });
 


### PR DESCRIPTION
After making this [change](https://github.com/laravel/telescope/pull/1367), I found that filtering by tag is extremely slow on a "large" database (I have a ~20GB separate Telescope database in MariaDB). The Telescope web interface hits a 504 error (after 1 minute of waiting) when filtering. I found that the database takes a long time to execute this query:

```sql
select 
  * 
from 
  `telescope_entries` 
where 
  `type` = ? 
  and `uuid` in (
    select 
      `entry_uuid` 
    from 
      `telescope_entries_tags` 
    where 
      `entry_uuid` in (
        select 
          `entry_uuid` 
        from 
          `telescope_entries_tags` 
        where 
          `tag` in (?)
      )
  ) 
order by 
  `sequence` desc 
limit 
  50
```

I believe the second `IN` clause contains a redundant subquery, and the resulting query should be optimized and simplified to:

```sql
select 
  * 
from 
  `telescope_entries` 
where 
  `type` = ? 
  and `uuid` in (
    select 
      `entry_uuid` 
    from 
      `telescope_entries_tags` 
    where 
      `tag` in (?)
  ) 
order by 
  `sequence` desc 
limit 
  50
```

This PR removes redundant subquery.