### PR TITLE
[5.x] Ability to override how objects are serialized

### DIFF
--- a/src/ExtractProperties.php
+++ b/src/ExtractProperties.php
@@ -31,7 +31,9 @@ class ExtractProperties
                     return [
                         $property->getName() => [
                             'class' => get_class($value),
-                            'properties' => json_decode(json_encode($value), true),
+                            'properties' => method_exists($value, 'formatForTelescope')
+                                ? $value->formatForTelescope()
+                                : json_decode(json_encode($value), true),
                         ],
                     ];
                 } else {

--- a/src/Watchers/GateWatcher.php
+++ b/src/Watchers/GateWatcher.php
@@ -99,7 +99,15 @@ class GateWatcher extends Watcher
     private function formatArguments($arguments)
     {
         return collect($arguments)->map(function ($argument) {
-            return $argument instanceof Model ? FormatModel::given($argument) : $argument;
+            if (is_object($argument) && method_exists($argument, 'formatForTelescope')) {
+                return $argument->formatForTelescope();
+            }
+
+            if ($argument instanceof Model) {
+                return FormatModel::given($argument);
+            }
+
+            return $argument;
         })->toArray();
     }
 }

--- a/tests/Watchers/EventWatcherTest.php
+++ b/tests/Watchers/EventWatcherTest.php
@@ -5,7 +5,10 @@ namespace Laravel\Telescope\Tests\Watchers;
 use Dummies\DummyEvent;
 use Dummies\DummyEventListener;
 use Dummies\DummyEventSubscriber;
+use Dummies\DummyEventWithFormatForTelescope;
+use Dummies\DummyEventWithObject;
 use Dummies\DummyInvokableEventListener;
+use Dummies\DummyObject;
 use Dummies\IgnoredEvent;
 use Illuminate\Support\Facades\Event;
 use Laravel\Telescope\EntryType;
@@ -58,6 +61,25 @@ class EventWatcherTest extends FeatureTestCase
         $this->assertContains('Telescope', $entry->content['payload']['data']);
         $this->assertContains('Laravel', $entry->content['payload']['data']);
         $this->assertContains('PHP', $entry->content['payload']['data']);
+    }
+
+    public function test_event_watcher_with_object_property_calls_format_for_telescope_method_if_it_exists()
+    {
+        Event::listen(DummyEventWithObject::class, function ($payload) {
+            //
+        });
+
+        event(new DummyEventWithObject());
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::EVENT, $entry->type);
+        $this->assertSame(DummyEventWithObject::class, $entry->content['name']);
+        $this->assertArrayHasKey('thing', $entry->content['payload']);
+        $this->assertSame(DummyObject::class, $entry->content['payload']['thing']['class']);
+        $this->assertContains('Telescope', $entry->content['payload']['thing']['properties']);
+        $this->assertContains('Laravel', $entry->content['payload']['thing']['properties']);
+        $this->assertContains('PHP', $entry->content['payload']['thing']['properties']);
     }
 
     public function test_event_watcher_registers_events_and_stores_payloads_with_subscriber_methods()
@@ -171,6 +193,26 @@ class DummyEvent
     public function handle()
     {
         //
+    }
+}
+
+class DummyEventWithObject
+{
+    public $thing;
+
+    public function __construct()
+    {
+        $this->thing = new DummyObject;
+    }
+}
+
+class DummyObject
+{
+    public function formatForTelescope(): array
+    {
+        return [
+            'Telescope', 'Laravel', 'PHP',
+        ];
     }
 }
 

--- a/tests/Watchers/EventWatcherTest.php
+++ b/tests/Watchers/EventWatcherTest.php
@@ -5,7 +5,6 @@ namespace Laravel\Telescope\Tests\Watchers;
 use Dummies\DummyEvent;
 use Dummies\DummyEventListener;
 use Dummies\DummyEventSubscriber;
-use Dummies\DummyEventWithFormatForTelescope;
 use Dummies\DummyEventWithObject;
 use Dummies\DummyInvokableEventListener;
 use Dummies\DummyObject;

--- a/tests/Watchers/GateWatcherTest.php
+++ b/tests/Watchers/GateWatcherTest.php
@@ -113,7 +113,7 @@ class GateWatcherTest extends FeatureTestCase
 
         $this->assertSame(EntryType::GATE, $entry->type);
         $this->assertSame(__FILE__, $entry->content['file']);
-        $this->assertSame(271, $entry->content['line']);
+        $this->assertSame(303, $entry->content['line']);
         $this->assertSame('create', $entry->content['ability']);
         $this->assertSame('allowed', $entry->content['result']);
         $this->assertSame([[]], $entry->content['arguments']);
@@ -156,10 +156,32 @@ class GateWatcherTest extends FeatureTestCase
 
         $this->assertSame(EntryType::GATE, $entry->type);
         $this->assertSame(__FILE__, $entry->content['file']);
-        $this->assertSame(276, $entry->content['line']);
+        $this->assertSame(308, $entry->content['line']);
         $this->assertSame('update', $entry->content['ability']);
         $this->assertSame('denied', $entry->content['result']);
         $this->assertSame([[]], $entry->content['arguments']);
+    }
+
+    public function test_gate_watcher_calls_format_for_telescope_method_if_it_exists()
+    {
+        $this->app->setBasePath(dirname(__FILE__, 3));
+
+        Gate::policy(TestResourceWithFormatForTelescope::class, TestPolicy::class);
+
+        try {
+            (new TestController())->update(new TestResourceWithFormatForTelescope());
+        } catch (\Exception $ex) {
+            // ignore
+        }
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::GATE, $entry->type);
+        $this->assertSame(__FILE__, $entry->content['file']);
+        $this->assertSame(308, $entry->content['line']);
+        $this->assertSame('update', $entry->content['ability']);
+        $this->assertSame('denied', $entry->content['result']);
+        $this->assertSame([['Telescope', 'Laravel', 'PHP']], $entry->content['arguments']);
     }
 
     public function test_gate_watcher_registers_allowed_response_policy_entries()
@@ -178,7 +200,7 @@ class GateWatcherTest extends FeatureTestCase
 
         $this->assertSame(EntryType::GATE, $entry->type);
         $this->assertSame(__FILE__, $entry->content['file']);
-        $this->assertSame(266, $entry->content['line']);
+        $this->assertSame(298, $entry->content['line']);
         $this->assertSame('view', $entry->content['ability']);
         $this->assertSame('allowed', $entry->content['result']);
         $this->assertSame([[]], $entry->content['arguments']);
@@ -200,7 +222,7 @@ class GateWatcherTest extends FeatureTestCase
 
         $this->assertSame(EntryType::GATE, $entry->type);
         $this->assertSame(__FILE__, $entry->content['file']);
-        $this->assertSame(281, $entry->content['line']);
+        $this->assertSame(313, $entry->content['line']);
         $this->assertSame('delete', $entry->content['ability']);
         $this->assertSame('denied', $entry->content['result']);
         $this->assertSame([[]], $entry->content['arguments']);
@@ -255,6 +277,16 @@ class User implements Authenticatable
 class TestResource
 {
     //
+}
+
+class TestResourceWithFormatForTelescope
+{
+    public function formatForTelescope(): array
+    {
+        return [
+            'Telescope', 'Laravel', 'PHP',
+        ];
+    }
 }
 
 class TestController


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pull request introduces a `formatForTelescope` method, allowing developers to override how Telescope formats/serializes their objects.

By default, Telescope uses `json_decode(json_encode($object), true)` to format/serialize objects, which takes the object's properties and attempts to JSON serialize them.

However, in our case, where `->jsonSerialize()` may return objects which reference the current object, that isn't ideal as it causes an infinite loop.

Instead, we'd like to take control of the serialization logic and return an array without any of the "circular relationships".

Related: https://github.com/statamic/cms/issues/10782