### PR TITLE
[5.x] Config for queue delay

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -77,6 +77,7 @@ return [
 
     'queue' => [
         'connection' => env('TELESCOPE_QUEUE_CONNECTION', null),
+        'delay' => env('TELESCOPE_QUEUE_DELAY', 10),
         'queue' => env('TELESCOPE_QUEUE', null),
     ],
 

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -77,8 +77,8 @@ return [
 
     'queue' => [
         'connection' => env('TELESCOPE_QUEUE_CONNECTION', null),
-        'delay' => env('TELESCOPE_QUEUE_DELAY', 10),
         'queue' => env('TELESCOPE_QUEUE', null),
+        'delay' => env('TELESCOPE_QUEUE_DELAY', 10),
     ],
 
     /*

--- a/src/Jobs/ProcessPendingUpdates.php
+++ b/src/Jobs/ProcessPendingUpdates.php
@@ -57,7 +57,7 @@ class ProcessPendingUpdates implements ShouldQueue
                 config('telescope.queue.connection')
             )->onQueue(
                 config('telescope.queue.queue')
-            )->delay(now()->addSeconds(10)),
+            )->delay(config('telescope.queue.delay') ? now()->addSeconds(config('telescope.queue.delay')) : null),
         );
     }
 }

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -669,7 +669,7 @@ class Telescope
                         config('telescope.queue.connection')
                     )->onQueue(
                         config('telescope.queue.queue')
-                    )->delay(now()->addSeconds(10))));
+                    )->delay(config('telescope.queue.delay') ? now()->addSeconds(config('telescope.queue.delay')) : null)));
                 }
 
                 if ($storage instanceof TerminableRepository) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Problem:
Amazon SQS FIFO queues don't allow setting a delay per message, which causes exceptions when using SQS endpoints.

Solution:
This PR adds a configuration option to handle cases where no delay should be applied, ensuring compatibility with SQS FIFO queues.

Related Issue:
#1554