### PR TITLE
Ensure `formatForTelescope` method is used in request watcher

### DIFF
--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -238,7 +238,9 @@ class RequestWatcher extends Watcher
             } elseif (is_object($value)) {
                 return [
                     'class' => get_class($value),
-                    'properties' => json_decode(json_encode($value), true),
+                    'properties' => method_exists($value, 'formatForTelescope')
+                        ? $value->formatForTelescope()
+                        : json_decode(json_encode($value), true),
                 ];
             } else {
                 return json_decode(json_encode($value), true);

--- a/tests/stubs/views/fake-view.blade.php
+++ b/tests/stubs/views/fake-view.blade.php
@@ -1,0 +1,3 @@
+@foreach($items as $item)
+    <div>{{ $item }}</div>
+@endforeach


### PR DESCRIPTION
In #1562, I made it possible for developers to hook into how objects are seralized by Telescope by adding a `formatForTelescope` method to your objects.

```php
public function formatForTelescope(): array
{
    // Returns a different representation of this class
}
```

In our case, this method allows us to prevent infinite loops.

However, during some additional testing on our end, I realised that I forgot to implement this hook for the `RequestWatcher` which serialized the variables available in Blade views. 

I've provided a test for this change.