### PR TITLE
Check implementation instead of assuming it is View

### DIFF
--- a/src/Watchers/ViewWatcher.php
+++ b/src/Watchers/ViewWatcher.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
+use Illuminate\Contracts\View\View as ViewContract;
 use Laravel\Telescope\IncomingEntry;
 use Laravel\Telescope\Telescope;
 use ReflectionFunction;
@@ -38,15 +39,17 @@ class ViewWatcher extends Watcher
             return;
         }
 
-        /** @var View $view */
+        /** @var ViewContract $view */
         $view = $data[0];
 
-        Telescope::recordView(IncomingEntry::make(array_filter([
-            'name' => $view->getName(),
-            'path' => $this->extractPath($view),
-            'data' => $this->extractKeysFromData($view),
-            'composers' => $this->formatComposers($view),
-        ])));
+        if ($view instanceof View) {
+            Telescope::recordView(IncomingEntry::make(array_filter([
+                'name' => $view->getName(),
+                'path' => $this->extractPath($view),
+                'data' => $this->extractKeysFromData($view),
+                'composers' => $this->formatComposers($view),
+            ])));
+        }
     }
 
     /**

--- a/src/Watchers/ViewWatcher.php
+++ b/src/Watchers/ViewWatcher.php
@@ -4,9 +4,9 @@ namespace Laravel\Telescope\Watchers;
 
 use Closure;
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
-use Illuminate\Contracts\View\View as ViewContract;
 use Laravel\Telescope\IncomingEntry;
 use Laravel\Telescope\Telescope;
 use ReflectionFunction;


### PR DESCRIPTION
### Summary
This PR ensures that Laravel Telescope does not crash when handling views that implement `Illuminate\Contracts\View\View` but are not instances of `Illuminate\View\View`. Currently, Telescope assumes all views are `Illuminate\View\View` and calls methods like `getPath()` and `getName()` that are not part of the contract, leading to errors in applications with custom view implementations.

### Changes
- Added a check to ensure the view is an instance of `Illuminate\View\View` before calling `getPath()` and `getName()`.  
- This prevents Telescope from attempting to call methods that may not exist on valid view implementations, avoiding application crashes.

### Future Considerations
While this PR only prevents crashes, a more complete solution could involve:
- Using `name()` instead of `getName()`, as `name()` is part of the contract.  
- Expanding `extractPath()` to resolve paths from `name()` when `getPath()` is unavailable.  
- Updating `Illuminate\Contracts\View\View` in Laravel to include `getPath()` in the future.  

This PR does not implement these changes but suggests them as potential improvements for broader compatibility.