### PR TITLE
[5.x] Fix empty avatar on nullable user email

### DIFF
--- a/src/Avatar.php
+++ b/src/Avatar.php
@@ -22,12 +22,12 @@ class Avatar
      */
     public static function url(array $user)
     {
-        if (empty($user['email'])) {
-            return;
-        }
-
         if (isset(static::$callback)) {
             return static::resolve($user);
+        }
+
+        if (empty($user['email'])) {
+            return;
         }
 
         return 'https://www.gravatar.com/avatar/'.md5(Str::lower($user['email'])).'?s=200';
@@ -52,7 +52,7 @@ class Avatar
     protected static function resolve($user)
     {
         if (static::$callback !== null) {
-            return call_user_func(static::$callback, $user['id'], $user['email']);
+            return call_user_func(static::$callback, $user['id'] ?? null, $user['email'] ?? null);
         }
     }
 }


### PR DESCRIPTION
This PR addresses an issue where the avatar is not displayed for users without an email address, even when a custom avatar callback was registered (#1564).

This change ensures that custom avatar implementations (like using user IDs for avatar paths) work properly even when users don't have email addresses while maintaining the existing Gravatar fallback behavior for users with emails.

### Before
![image](https://github.com/user-attachments/assets/0e5831a5-5356-4eca-9989-32eff0e792b3)

### After
![image](https://github.com/user-attachments/assets/9cfdb5eb-3d0f-4aee-9f62-b8e36925c67c)
