### PR TITLE
Add Hydrated Models Count to Models Table on the Request Details Page

### DIFF
--- a/resources/js/components/RelatedEntries.vue
+++ b/resources/js/components/RelatedEntries.vue
@@ -295,6 +295,7 @@
                 <thead>
                 <tr>
                     <th>Model</th>
+                    <th>Hydrated</th>
                     <th>Action</th>
                     <th></th>
                 </tr>
@@ -303,6 +304,7 @@
                 <tbody>
                 <tr v-for="entry in models">
                     <td :title="entry.content.model">{{truncate(entry.content.model, 100)}}</td>
+                    <td>{{entry.content?.count}}</td>
                     <td class="table-fit">
                         <span class="badge" :class="'badge-'+modelActionClass(entry.content.action)">
                             {{entry.content.action}}


### PR DESCRIPTION
This PR enhances the Models table on the request details page by adding a Hydrated column. This column helps track the number of times a model instance was hydrated from the database.

Changes:
	•	Added a Hydrated column to the Models table.
	•	Displays the count of hydrated model instances for better debugging and performance analysis.
	•	Ensures existing retrieved and created actions remain intact.


Before: No hydrated count available.
	
![image](https://github.com/user-attachments/assets/eee57c55-48ec-49e6-83ff-fd270f5447e9)

After: Hydrated column added, showing counts for retrieved models.

	
![image](https://github.com/user-attachments/assets/4b5994e5-f847-4f9e-b7b6-cf6946c02661)


Why?
	•	Provides better insight into model hydration.
	•	Helps debug and optimize Eloquent queries by identifying excessive hydration.
	•	No need to navigate to Model Action page to get hydration count for particular model