### PR TITLE
[5.x] Record plain/text request content

### DIFF
--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -199,8 +199,8 @@ class ClientRequestWatcher extends Watcher
             return $request->data();
         }
 
-        if ($this->hasHeader('Content-Type') &&
-            str_contains($this->header('Content-Type')[0], 'text/plain')) {
+        if ($request->hasHeader('Content-Type') &&
+            str_contains($request->header('Content-Type')[0], 'text/plain')) {
 
             return $request->body();
         }

--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -155,11 +155,15 @@ class ClientRequestWatcher extends Watcher
     /**
      * Format the given payload.
      *
-     * @param  array  $payload
-     * @return array
+     * @param  array|string  $payload
+     * @return array|string
      */
     protected function payload($payload)
     {
+        if (is_string($payload)) {
+            return $payload;
+        }
+
         return $this->hideParameters($payload,
             Telescope::$hiddenRequestParameters
         );
@@ -187,12 +191,18 @@ class ClientRequestWatcher extends Watcher
      * Extract the input from the given request.
      *
      * @param  \Illuminate\Http\Client\Request  $request
-     * @return array
+     * @return array|string
      */
     protected function input(Request $request)
     {
         if (! $request->isMultipart()) {
             return $request->data();
+        }
+
+        if ($this->hasHeader('Content-Type') &&
+            str_contains($this->header('Content-Type')[0], 'text/plain')) {
+
+            return $request->body();
         }
 
         return collect($request->data())->mapWithKeys(function ($data) {

--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -199,7 +199,7 @@ class ClientRequestWatcher extends Watcher
             return $request->data();
         }
 
-        if (Str::startsWith(strtolower($request->header('Content-Type') ?? ''), 'text/plain')) {
+        if ($contentType = $request->header('Content-Type') && Str::startsWith(strtolower($contentType[0] ?? ''), 'text/plain')) {
             $content = $request->body();
 
             return $this->contentWithinLimits($content) ? $content : 'Purged By Telescope';

--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -199,10 +199,10 @@ class ClientRequestWatcher extends Watcher
             return $request->data();
         }
 
-        if ($request->hasHeader('Content-Type') &&
-            str_contains($request->header('Content-Type')[0], 'text/plain')) {
+        if (Str::startsWith(strtolower($request->header('Content-Type') ?? ''), 'text/plain')) {
+            $content = $request->body();
 
-            return $request->body();
+            return $this->contentWithinLimits($content) ? $content : 'Purged By Telescope';
         }
 
         return collect($request->data())->mapWithKeys(function ($data) {

--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -155,15 +155,11 @@ class ClientRequestWatcher extends Watcher
     /**
      * Format the given payload.
      *
-     * @param  array|string  $payload
-     * @return array|string
+     * @param  array  $payload
+     * @return array
      */
     protected function payload($payload)
     {
-        if (is_string($payload)) {
-            return $payload;
-        }
-
         return $this->hideParameters($payload,
             Telescope::$hiddenRequestParameters
         );
@@ -191,18 +187,12 @@ class ClientRequestWatcher extends Watcher
      * Extract the input from the given request.
      *
      * @param  \Illuminate\Http\Client\Request  $request
-     * @return array|string
+     * @return array
      */
     protected function input(Request $request)
     {
         if (! $request->isMultipart()) {
             return $request->data();
-        }
-
-        if ($contentType = $request->header('Content-Type') && Str::startsWith(strtolower($contentType[0] ?? ''), 'text/plain')) {
-            $content = $request->body();
-
-            return $this->contentWithinLimits($content) ? $content : 'Purged By Telescope';
         }
 
         return collect($request->data())->mapWithKeys(function ($data) {

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -111,11 +111,15 @@ class RequestWatcher extends Watcher
     /**
      * Format the given payload.
      *
-     * @param  array  $payload
-     * @return array
+     * @param  array|string  $payload
+     * @return array|string
      */
     protected function payload($payload)
     {
+        if (is_string($payload)) {
+            return $payload;
+        }
+
         return $this->hideParameters($payload,
             Telescope::$hiddenRequestParameters
         );
@@ -154,10 +158,14 @@ class RequestWatcher extends Watcher
      * Extract the input from the given request.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return array
+     * @return array|string
      */
     private function input(Request $request)
     {
+        if (Str::startsWith(strtolower($request->headers->get('Content-Type') ?? ''), 'text/plain')) {
+            return (string) $request->getContent();
+        }
+
         $files = $request->files->all();
 
         array_walk_recursive($files, function (&$file) {

--- a/tests/Watchers/RequestWatchersTest.php
+++ b/tests/Watchers/RequestWatchersTest.php
@@ -178,6 +178,25 @@ class RequestWatchersTest extends FeatureTestCase
         $this->assertSame('plain telescope response', $entry->content['response']);
     }
 
+    public function test_request_watcher_records_plain_text_payload()
+    {
+        Route::post('/receive-plain-text', function () {
+            return response()->json(['ok' => 'yeah']);
+        });
+
+        $this->call(
+            'POST',
+            '/receive-plain-text',
+            server: $this->transformHeadersToServerVars(['Content-type' => 'text/plain']),
+            content: 'plain-text-content'
+        );
+
+        $entry = $this->loadTelescopeEntries()->first();
+        $this->assertSame(EntryType::REQUEST, $entry->type);
+        $this->assertSame('POST', $entry->content['method']);
+        $this->assertSame('plain-text-content', $entry->content['payload']);
+    }
+
     public function test_request_watcher_calls_format_for_telescope_method_if_it_exists()
     {
         View::addNamespace('tests', __DIR__.'/../stubs/views');


### PR DESCRIPTION
To close https://github.com/laravel/telescope/issues/1569

Requests were predicated on being a JSON body or form input. Now, if we receive a payload with content-type: text/plain, it will record the body.

Before:
<img width="1322" alt="image" src="https://github.com/user-attachments/assets/c4a14554-2208-4a47-99b1-735e85d4b4ca" />

After:
<img width="1384" alt="image" src="https://github.com/user-attachments/assets/86d10566-3cac-4bfb-9d50-9b2dcaf38fd7" />
