### PR TITLE
Resolve #1579

### DIFF
--- a/src/Avatar.php
+++ b/src/Avatar.php
@@ -22,6 +22,10 @@ class Avatar
      */
     public static function url(array $user)
     {
+        if (empty($user['id'])) {
+            return;
+        }
+
         if (isset(static::$callback)) {
             return static::resolve($user);
         }
@@ -52,7 +56,7 @@ class Avatar
     protected static function resolve($user)
     {
         if (static::$callback !== null) {
-            return call_user_func(static::$callback, $user['id'] ?? null, $user['email'] ?? null);
+            return call_user_func(static::$callback, $user['id'], $user['email'] ?? null);
         }
     }
 }

--- a/tests/Http/AvatarTest.php
+++ b/tests/Http/AvatarTest.php
@@ -192,9 +192,9 @@ class AvatarTest extends FeatureTestCase
             ->assertJsonMissing([
                 'entry' => [
                     'content' => [
-                        'user'
-                    ]
-                ]
+                        'user',
+                    ],
+                ],
             ]);
     }
 }

--- a/tests/Http/AvatarTest.php
+++ b/tests/Http/AvatarTest.php
@@ -156,6 +156,47 @@ class AvatarTest extends FeatureTestCase
                 ],
             ]);
     }
+
+    /**
+     * @test
+     */
+    public function it_should_not_call_the_custom_avatar_when_no_user_was_authenticated_during_the_error()
+    {
+        $user = null;
+
+        Telescope::withoutRecording(function () use (&$user) {
+            $this->loadLaravelMigrations();
+
+            $user = UserEloquent::create([
+                'id' => 1,
+                'name' => 'Telescope',
+                'email' => 'telescope@laravel.com',
+                'password' => 'secret',
+            ]);
+        });
+
+        Telescope::avatar(function (string $id, ?string $email) {
+            return UserEloquent::find($id)->email;
+        });
+
+        $this->app->get(LoggerInterface::class)->error('Avatar path will be generated.', [
+            'exception' => 'Some error message',
+        ]);
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->actingAs($user);
+
+        $this->get("/telescope/telescope-api/logs/{$entry->uuid}")
+            ->assertOk()
+            ->assertJsonMissing([
+                'entry' => [
+                    'content' => [
+                        'user'
+                    ]
+                ]
+            ]);
+    }
 }
 
 class UserEloquent extends Model implements Authenticatable


### PR DESCRIPTION
## Description

When using the custom Avatar callback, we ran into issues with the newest version of Telescope. See #1579

### Issue  

Since version v5.6.0, it is possible to get a nullable `$id` and nullable `$email`. Which comes with unexpected behaviour compared to what the Laravel docs show.

```php
Telescope::avatar(function (string $id, string $email) {
    return '/avatars/'.User::find($id)->avatar_path;
});
```

## Solution 

As far as i have found the moment the users object is null in the payload the UI does not show information about the user. So the idea behind this fix is to disallow nullable `$id` and return before any callback is triggerd.

while keeping the requested feature added in #1565 

Once this is merged, I'll also create a pull request to update the Laravel docs to reflect this.
Let me know if any additional changes are need! 😊  

