### PR TITLE
Added isJob() for consistent entry type checks

### DIFF
--- a/src/IncomingEntry.php
+++ b/src/IncomingEntry.php
@@ -253,6 +253,16 @@ class IncomingEntry
     }
 
     /**
+     * Determine if the incoming entry is a job.
+     *
+     * @return bool
+     */
+    public function isJob()
+    {
+        return $this->type === EntryType::JOB;
+    }
+    
+    /**
      * Determine if the incoming entry is a failed job.
      *
      * @return bool


### PR DESCRIPTION

## Add `isJob()` method usage for entry type checks

Replaced the direct type comparison:

```php
if ($entry->type === EntryType::JOB)
```

with a more expressive and consistent method call:

```
if ($entry->isJob())
```

This aligns with existing patterns like `isRequest()` and improves code readability and consistency.

