### PR TITLE
[5.x] Add ignore option to CacheWatcher

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -139,6 +139,7 @@ return [
         Watchers\CacheWatcher::class => [
             'enabled' => env('TELESCOPE_CACHE_WATCHER', true),
             'hidden' => [],
+            'ignore' => [],
         ],
 
         Watchers\ClientRequestWatcher::class => env('TELESCOPE_CLIENT_REQUEST_WATCHER', true),

--- a/src/Watchers/CacheWatcher.php
+++ b/src/Watchers/CacheWatcher.php
@@ -147,10 +147,10 @@ class CacheWatcher extends Watcher
      */
     private function shouldIgnore($event)
     {
-        return Str::is([
+        return Str::is(array_merge($this->options['ignore'] ?? [], [
             'illuminate:queue:restart',
             'framework/schedule*',
             'telescope:*',
-        ], $event->key);
+        ]), $event->key);
     }
 }

--- a/tests/Watchers/CacheWatcherTest.php
+++ b/tests/Watchers/CacheWatcherTest.php
@@ -116,7 +116,7 @@ class CacheWatcherTest extends FeatureTestCase
         $this->assertSame('********', $entry->content['value']);
     }
 
-    public function test_cache_watcher_does_not_record_cache_key_if_ignored()
+    public function test_cache_watcher_skips_recording_ignored_cache_keys()
     {
         $this->app->get(Repository::class)->put('ignored-key', 'laravel');
         $this->app->get(Repository::class)->put('laravel:pulse:restart', 'laravel');

--- a/tests/Watchers/CacheWatcherTest.php
+++ b/tests/Watchers/CacheWatcherTest.php
@@ -125,7 +125,6 @@ class CacheWatcherTest extends FeatureTestCase
         $count = $this->loadTelescopeEntries()->count();
         $entry = $this->loadTelescopeEntries()->first();
 
-
         $this->assertSame(1, $count);
 
         $this->assertSame(EntryType::CACHE, $entry->type);

--- a/tests/Watchers/CacheWatcherTest.php
+++ b/tests/Watchers/CacheWatcherTest.php
@@ -20,6 +20,10 @@ class CacheWatcherTest extends FeatureTestCase
                 'hidden' => [
                     'my-hidden-value-key',
                 ],
+                'ignore' => [
+                    'laravel:pulse:*',
+                    'ignored-key',
+                ],
             ],
         ]);
     }
@@ -110,5 +114,23 @@ class CacheWatcherTest extends FeatureTestCase
         $this->assertSame('hit', $entry->content['type']);
         $this->assertSame('my-hidden-value-key', $entry->content['key']);
         $this->assertSame('********', $entry->content['value']);
+    }
+
+    public function test_cache_watcher_does_not_record_cache_key_if_ignored()
+    {
+        $this->app->get(Repository::class)->put('ignored-key', 'laravel');
+        $this->app->get(Repository::class)->put('laravel:pulse:restart', 'laravel');
+        $this->app->get(Repository::class)->put('my-key', 'laravel');
+
+        $count = $this->loadTelescopeEntries()->count();
+        $entry = $this->loadTelescopeEntries()->first();
+
+
+        $this->assertSame(1, $count);
+
+        $this->assertSame(EntryType::CACHE, $entry->type);
+        $this->assertSame('set', $entry->content['type']);
+        $this->assertSame('my-key', $entry->content['key']);
+        $this->assertSame('laravel', $entry->content['value']);
     }
 }


### PR DESCRIPTION
This pull request enhances the `CacheWatcher` functionality in Telescope by introducing an `ignore` option, allowing specific cache keys to be skipped. This addition provides greater flexibility in controlling which cache events are recorded.

The motivation behind this feature was the realization that Telescope was recording `laravel:pulse:restart` into the database every second, consuming excessive disk space. Unfortunately, these records are not pruned with the `prune` command. Since this type of data is unnecessary for my use case, and there should be other use cases, I developed this option to exclude specific cache keys.