### PR TITLE
feat: Added `laravel:reverb:restart` to CacheWatcher default ignore list

### DIFF
--- a/src/Watchers/CacheWatcher.php
+++ b/src/Watchers/CacheWatcher.php
@@ -150,8 +150,8 @@ class CacheWatcher extends Watcher
         return Str::is(array_merge($this->options['ignore'] ?? [], [
             'illuminate:queue:restart',
             'framework/schedule*',
-            'telescope:*',
             'laravel:reverb:restart',
+            'telescope:*',
         ]), $event->key);
     }
 }

--- a/src/Watchers/CacheWatcher.php
+++ b/src/Watchers/CacheWatcher.php
@@ -151,6 +151,7 @@ class CacheWatcher extends Watcher
             'illuminate:queue:restart',
             'framework/schedule*',
             'telescope:*',
+            'laravel:reverb:restart',
         ]), $event->key);
     }
 }


### PR DESCRIPTION
It's a minor change, but I believe it is best to have it ignored by default.

![image](https://github.com/user-attachments/assets/7075c484-86c6-4088-9800-c3032256c56d)
