### PR TITLE
[5.x] Use match expressions in place of switch statements

### DIFF
--- a/src/ExtractTags.php
+++ b/src/ExtractTags.php
@@ -111,18 +111,13 @@ class ExtractTags
      */
     protected static function targetsFor($job)
     {
-        switch (true) {
-            case $job instanceof BroadcastEvent:
-                return [$job->event];
-            case $job instanceof CallQueuedListener:
-                return [static::extractEvent($job)];
-            case $job instanceof SendQueuedMailable:
-                return [$job->mailable];
-            case $job instanceof SendQueuedNotifications:
-                return [$job->notification];
-            default:
-                return [$job];
-        }
+        return match (true) {
+            $job instanceof BroadcastEvent => [$job->event],
+            $job instanceof CallQueuedListener => [static::extractEvent($job)],
+            $job instanceof SendQueuedMailable => [$job->mailable],
+            $job instanceof SendQueuedNotifications => [$job->notification],
+            default => [$job],
+        };
     }
 
     /**
@@ -178,11 +173,10 @@ class ExtractTags
      */
     protected static function resolveValue($value)
     {
-        switch (true) {
-            case $value instanceof Model:
-                return collect([$value]);
-            case $value instanceof Collection:
-                return $value->flatten();
-        }
+        return match (true) {
+            $value instanceof Model => collect([$value]),
+            $value instanceof Collection => $value->flatten(),
+            default => null,
+        };
     }
 }

--- a/src/IncomingDumpEntry.php
+++ b/src/IncomingDumpEntry.php
@@ -45,17 +45,11 @@ class IncomingDumpEntry extends IncomingEntry
      */
     private function entryPointDescription($entryPoint)
     {
-        switch ($entryPoint->type) {
-            case EntryType::REQUEST:
-                return $entryPoint->content['method'].' '.$entryPoint->content['uri'];
-
-            case EntryType::JOB:
-                return $entryPoint->content['name'];
-
-            case EntryType::COMMAND:
-                return $entryPoint->content['command'];
-        }
-
-        return '';
+        return match ($entryPoint->type) {
+            EntryType::REQUEST => $entryPoint->content['method'] . ' ' . $entryPoint->content['uri'],
+            EntryType::JOB => $entryPoint->content['name'],
+            EntryType::COMMAND => $entryPoint->content['command'],
+            default => '',
+        };
     }
 }

--- a/src/IncomingDumpEntry.php
+++ b/src/IncomingDumpEntry.php
@@ -46,7 +46,7 @@ class IncomingDumpEntry extends IncomingEntry
     private function entryPointDescription($entryPoint)
     {
         return match ($entryPoint->type) {
-            EntryType::REQUEST => $entryPoint->content['method'] . ' ' . $entryPoint->content['uri'],
+            EntryType::REQUEST => $entryPoint->content['method'].' '.$entryPoint->content['uri'],
             EntryType::JOB => $entryPoint->content['name'],
             EntryType::COMMAND => $entryPoint->content['command'],
             default => '',


### PR DESCRIPTION
This PR refactors multiple switch statements into match expressions. Since the Telescope requires PHP 8.0 or higher, it leverages the modern match feature for clearer, more concise code with strict comparisons and better return handling