### PR TITLE
[5.x] Include driver in Query content to enable proper formatting

### DIFF
--- a/resources/js/screens/queries/preview.vue
+++ b/resources/js/screens/queries/preview.vue
@@ -1,7 +1,7 @@
 <script type="text/ecmascript-6">
 import hljs from 'highlight.js/lib/core';
 import sql from 'highlight.js/lib/languages/sql';
-import { format } from 'sql-formatter';
+import { format, supportedDialects } from 'sql-formatter';
 
 hljs.registerLanguage('sql', sql);
 
@@ -12,10 +12,16 @@ export default {
                 hljs.highlightElement(this.$refs.sqlcode);
             });
         },
-        formatSql(sql, language) {
+        formatSql(sql, driver) {
             let formatterConfig = {};
-            if (language) {
-                formatterConfig = { language: language }
+            if (driver) {
+                if (driver === 'pgsql') {
+                    driver = 'postgresql';
+                }
+
+                if (supportedDialects.includes(driver)) {
+                    formatterConfig = {language: driver};
+                }
             }
             return format(sql, formatterConfig);
         }

--- a/resources/js/screens/queries/preview.vue
+++ b/resources/js/screens/queries/preview.vue
@@ -14,6 +14,7 @@ export default {
         },
         formatSql(sql, driver) {
             let formatterConfig = {};
+
             if (driver) {
                 if (driver === 'pgsql') {
                     driver = 'postgresql';
@@ -23,6 +24,7 @@ export default {
                     formatterConfig = {language: driver};
                 }
             }
+
             return format(sql, formatterConfig);
         }
     }

--- a/resources/js/screens/queries/preview.vue
+++ b/resources/js/screens/queries/preview.vue
@@ -12,8 +12,12 @@ export default {
                 hljs.highlightElement(this.$refs.sqlcode);
             });
         },
-        formatSql(sql) {
-            return format(sql);
+        formatSql(sql, language) {
+            let formatterConfig = {};
+            if (language) {
+                formatterConfig = { language: language }
+            }
+            return format(sql, formatterConfig);
         }
     }
 }
@@ -54,8 +58,8 @@ export default {
                     </li>
                 </ul>
                 <div class="code-bg p-4 mb-0 text-white">
-                    <copy-clipboard :data="formatSql(slotProps.entry.content.sql)">
-                        <pre class="code-bg text-white" ref="sqlcode">{{ formatSql(slotProps.entry.content.sql) }}</pre>
+                    <copy-clipboard :data="formatSql(slotProps.entry.content.sql, slotProps.entry.content.driver)">
+                        <pre class="code-bg text-white" ref="sqlcode">{{ formatSql(slotProps.entry.content.sql, slotProps.entry.content.driver) }}</pre>
                     </copy-clipboard>
                 </div>
             </div>

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -38,6 +38,7 @@ class QueryWatcher extends Watcher
         if ($caller = $this->getCallerFromStackTrace()) {
             Telescope::recordQuery(IncomingEntry::make([
                 'connection' => $event->connectionName,
+                'driver' => $event->connection->getDriverName(),
                 'bindings' => [],
                 'sql' => $this->replaceBindings($event),
                 'time' => number_format($time, 2, '.', ''),

--- a/tests/Watchers/QueryWatcherTest.php
+++ b/tests/Watchers/QueryWatcherTest.php
@@ -34,6 +34,7 @@ class QueryWatcherTest extends FeatureTestCase
         $this->assertSame(EntryType::QUERY, $entry->type);
         $this->assertSame('select count(*) as aggregate from "telescope_entries"', $entry->content['sql']);
         $this->assertSame('testbench', $entry->content['connection']);
+        $this->assertSame('sqlite', $entry->content['driver']);
         $this->assertFalse($entry->content['slow']);
     }
 


### PR DESCRIPTION
Right now, sql-formatter doesn't know about the connection type of the database query, so non-standard SQL doesn't get the benefit of proper formatting by the DB engine type.

Closes #1617 

I don't know anything about Vue. 🫣 Hopefully I didn't make too much of a mess.

Here is a screenshot of my local testing
<img width="1470" height="845" alt="image" src="https://github.com/user-attachments/assets/c8cb1062-93db-48f8-9f8a-3cb2d980db06" />
