### PR TITLE
[5.x] Rewind stream after getting the body

### DIFF
--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -100,7 +100,7 @@ class ClientRequestWatcher extends Watcher
         $stream = $response->toPsrResponse()->getBody();
 
         if (! $stream->isSeekable()) {
-            return 'Stream Response';   
+            return 'Stream Response';
         }
 
         $content = $response->body();

--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -99,12 +99,12 @@ class ClientRequestWatcher extends Watcher
     {
         $stream = $response->toPsrResponse()->getBody();
 
-        if ($stream->isSeekable()) {
-            $content = $response->body();
-            $stream->rewind();
-        } else {
-            return 'Stream Response';
+        if (! $stream->isSeekable()) {
+            return 'Stream Response';   
         }
+        
+        $content = $response->body();
+        $stream->rewind();
 
         if (is_string($content)) {
             if (is_array(json_decode($content, true)) &&

--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -100,12 +100,11 @@ class ClientRequestWatcher extends Watcher
         $stream = $response->toPsrResponse()->getBody();
 
         if ($stream->isSeekable()) {
+            $content = $response->body();
             $stream->rewind();
         } else {
             return 'Stream Response';
         }
-
-        $content = $response->body();
 
         if (is_string($content)) {
             if (is_array(json_decode($content, true)) &&

--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -102,7 +102,7 @@ class ClientRequestWatcher extends Watcher
         if (! $stream->isSeekable()) {
             return 'Stream Response';   
         }
-        
+
         $content = $response->body();
         $stream->rewind();
 

--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -104,6 +104,7 @@ class ClientRequestWatcher extends Watcher
         }
 
         $content = $response->body();
+
         $stream->rewind();
 
         if (is_string($content)) {


### PR DESCRIPTION
Prior to the change in https://github.com/laravel/telescope/pull/1621 the stream was always rewinded after getting the body.

We noticed there was a problem when running locally with Telescope that our HTTP response was just returning a blank string. 😅 

I might suggest this as a hot release if possible.