### PR TITLE
[5.x] Removed redundant default values from config file

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -76,8 +76,8 @@ return [
     */
 
     'queue' => [
-        'connection' => env('TELESCOPE_QUEUE_CONNECTION', null),
-        'queue' => env('TELESCOPE_QUEUE', null),
+        'connection' => env('TELESCOPE_QUEUE_CONNECTION'),
+        'queue' => env('TELESCOPE_QUEUE'),
         'delay' => env('TELESCOPE_QUEUE_DELAY', 10),
     ],
 


### PR DESCRIPTION
PhpStorm Inspector pointed this out.

Similar to previous @ https://github.com/laravel/telescope/pull/1323
