### PR TITLE
Handle plain text body in client requests

### DIFF
--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -193,6 +193,10 @@ class ClientRequestWatcher extends Watcher
      */
     protected function input(Request $request)
     {
+        if ($request->hasHeader('Content-Type', 'text/plain')) {
+            return explode("\n", $request->body());
+        }
+        
         if (! $request->isMultipart()) {
             return $request->data();
         }


### PR DESCRIPTION
Without this change, recorded client requests with plain text bodies are always empty.
