### PR TITLE
fix: treat sqlsrv as valid 'transactsql' type for sql-formatter

### DIFF
--- a/resources/js/screens/queries/preview.vue
+++ b/resources/js/screens/queries/preview.vue
@@ -20,6 +20,10 @@ export default {
                     driver = 'postgresql';
                 }
 
+                if (driver === 'sqlsrv') {
+                    driver = 'transactsql';
+                }
+
                 if (supportedDialects.includes(driver)) {
                     formatterConfig = {language: driver};
                 }


### PR DESCRIPTION
## The Problem

When you use MSSQL your database driver key is `sqlsrv`. These keys sometimes line up with the name in [sql-formatter](https://github.com/sql-formatter-org/sql-formatter/blob/master/docs/language.md) that its using for dialect. Sometimes they do not. In the case of MSSQL users you'll get a crash viewing a query. This broke after the addition of proper dialect formatting in #1620

```
Error: Parse error: Unexpected "[users" at line 1 column 8.
This likely happens because you're using the default "sql" dialect.
If possible, please select a more specific dialect (like sqlite, postgresql, etc).
    at iX.createParseError (9fcadd56-8880-46d7-8…a45676313fd:99:2350)
```

## The Solution

Much like `pgsql` is mapped to the sql-formatter specific naming of `postgresql`, we do the same for `sqlsrv` which is described by author as proper dialect (`transactsql`) [here](https://github.com/sql-formatter-org/sql-formatter/issues/877#issuecomment-2990129462).

Auditing rest of supported Laravel DBs and we should be set now.

Provided Dialect | Laravel DB Type
-- | --
sqlite | sqlite
mysql | mysql
mariadb | mariadb
postgresql | pgsql
transactsql / tsql | sqlsrv

now fixed :)

<img width="1213" height="375" alt="Screenshot 2025-09-03 at 6 14 32 PM" src="https://github.com/user-attachments/assets/c5558e72-516f-46e2-aead-340aec704bf2" />

## Meta
* I presume merging this automatically rebuild /dist assets.
* fixes: #1632 