### PR TITLE
ignore laravel boost routes

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -116,6 +116,7 @@ return [
         'livewire*',
         'nova-api*',
         'pulse*',
+        '_boost*',
     ],
 
     'ignore_commands' => [


### PR DESCRIPTION
It's better to ignore these ?

<img width="1543" height="390" alt="image" src="https://github.com/user-attachments/assets/fb5ca97f-9a0d-4ad4-bb0b-fb8cf6328f1c" />

