### PR TITLE
feat: add N+1 detector watcher

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -206,9 +206,9 @@ return [
         Watchers\ViewWatcher::class => env('TELESCOPE_VIEW_WATCHER', true),
 
         Watchers\NPlusOneWatcher::class => [
-            'enabled'   => env('TELESCOPE_NPLUSONE_WATCHER', true),
+            'enabled' => env('TELESCOPE_NPLUSONE_WATCHER', true),
             'threshold' => 3,
-            'window'    => 1000,
+            'window' => 1000,
         ],
     ],
 ];

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -204,5 +204,11 @@ return [
 
         Watchers\ScheduleWatcher::class => env('TELESCOPE_SCHEDULE_WATCHER', true),
         Watchers\ViewWatcher::class => env('TELESCOPE_VIEW_WATCHER', true),
+
+        Watchers\NPlusOneWatcher::class => [
+            'enabled'   => env('TELESCOPE_NPLUSONE_WATCHER', true),
+            'threshold' => 3,
+            'window'    => 1000,
+        ],
     ],
 ];

--- a/src/Watchers/NPlusOneWatcher.php
+++ b/src/Watchers/NPlusOneWatcher.php
@@ -63,16 +63,16 @@ class NPlusOneWatcher extends Watcher
         $now = (int) (microtime(true) * 1000);
 
         $pattern = $this->normalize($sql);
-        $caller  = $this->caller();
-        $key     = sha1($pattern . '|' . $caller);
+        $caller = $this->caller();
+        $key = sha1($pattern . '|' . $caller);
 
         if (! isset(self::$batches[$key]) || $now - self::$batches[$key]['first'] > $this->windowMs) {
             self::$batches[$key] = [
-                'count'   => 0,
-                'first'   => $now,
+                'count' => 0,
+                'first' => $now,
                 'example' => $sql,
                 'pattern' => $pattern,
-                'caller'  => $caller,
+                'caller' => $caller,
             ];
         }
 
@@ -80,11 +80,11 @@ class NPlusOneWatcher extends Watcher
 
         if (self::$batches[$key]['count'] === $this->threshold) {
             Telescope::recordLog(IncomingEntry::make([
-                'level'   => 'warning',
+                'level' => 'warning',
                 'message' => 'N+1 detected at ' . $caller,
                 'context' => [
-                    'pattern'   => $pattern,
-                    'example'   => self::$batches[$key]['example'],
+                    'pattern' => $pattern,
+                    'example' => self::$batches[$key]['example'],
                     'threshold' => $this->threshold,
                     'window_ms' => $this->windowMs,
                 ],
@@ -105,6 +105,7 @@ class NPlusOneWatcher extends Watcher
         $s = preg_replace('/\b\d+\b/', '?', $s) ?: $s;
         $s = preg_replace('/\'(?:[^\'\\\\]|\\\\.)*\'/', '?', $s) ?: $s;
         $s = preg_replace('/\bin\s*\((?:\s*[^)]+)\)/', ' in (?)', $s) ?: $s;
+
         return trim($s);
     }
 
@@ -119,11 +120,12 @@ class NPlusOneWatcher extends Watcher
             if (! isset($frame['file'])) {
                 continue;
             }
-            if (Str::contains($frame['file'], DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR)) {
+            if (Str::contains($frame['file'], DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR)) {
                 continue;
             }
             $line = isset($frame['line']) ? (int) $frame['line'] : 0;
-            return $frame['file'] . ':' . $line;
+            
+            return $frame['file'].':'.$line;
         }
 
         return 'unknown:0';

--- a/src/Watchers/NPlusOneWatcher.php
+++ b/src/Watchers/NPlusOneWatcher.php
@@ -64,7 +64,7 @@ class NPlusOneWatcher extends Watcher
 
         $pattern = $this->normalize($sql);
         $caller = $this->caller();
-        $key = sha1($pattern . '|' . $caller);
+        $key = sha1($pattern.'|'.$caller);
 
         if (! isset(self::$batches[$key]) || $now - self::$batches[$key]['first'] > $this->windowMs) {
             self::$batches[$key] = [
@@ -81,7 +81,7 @@ class NPlusOneWatcher extends Watcher
         if (self::$batches[$key]['count'] === $this->threshold) {
             Telescope::recordLog(IncomingEntry::make([
                 'level' => 'warning',
-                'message' => 'N+1 detected at ' . $caller,
+                'message' => 'N+1 detected at '.$caller,
                 'context' => [
                     'pattern' => $pattern,
                     'example' => self::$batches[$key]['example'],
@@ -124,7 +124,7 @@ class NPlusOneWatcher extends Watcher
                 continue;
             }
             $line = isset($frame['line']) ? (int) $frame['line'] : 0;
-            
+
             return $frame['file'].':'.$line;
         }
 

--- a/src/Watchers/NPlusOneWatcher.php
+++ b/src/Watchers/NPlusOneWatcher.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Laravel\Telescope\Watchers;
+
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Str;
+use Laravel\Telescope\IncomingEntry;
+use Laravel\Telescope\Telescope;
+
+class NPlusOneWatcher extends Watcher
+{
+    /**
+     * Number of repeats before flagging N+1.
+     *
+     * @var int
+     */
+    protected $threshold = 3;
+
+    /**
+     * Aggregation window in milliseconds.
+     *
+     * @var int
+     */
+    protected $windowMs = 1000;
+
+    /**
+     * Key (pattern|caller) => aggregate.
+     *
+     * @var array<string, array{count:int, first:int, example:string, pattern:string, caller:string}>
+     */
+    protected static $batches = [];
+
+    /**
+     * Register the watcher.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return void
+     */
+    public function register($app)
+    {
+        $app['events']->listen(QueryExecuted::class, [$this, 'recordQuery']);
+    }
+
+    /**
+     * Handle a database query event.
+     *
+     * @param  \Illuminate\Database\Events\QueryExecuted  $event
+     * @return void
+     */
+    public function recordQuery(QueryExecuted $event)
+    {
+        if (! Telescope::isRecording()) {
+            return;
+        }
+
+        $sql = $event->sql;
+
+        // Avoid recursion: ignore Telescope’s own tables.
+        if ($this->isTelescopeSql($sql)) {
+            return;
+        }
+
+        $now = (int) (microtime(true) * 1000);
+
+        $pattern = $this->normalize($sql);
+        $caller  = $this->caller();
+        $key     = sha1($pattern . '|' . $caller);
+
+        if (! isset(self::$batches[$key]) || $now - self::$batches[$key]['first'] > $this->windowMs) {
+            self::$batches[$key] = [
+                'count'   => 0,
+                'first'   => $now,
+                'example' => $sql,
+                'pattern' => $pattern,
+                'caller'  => $caller,
+            ];
+        }
+
+        self::$batches[$key]['count']++;
+
+        if (self::$batches[$key]['count'] === $this->threshold) {
+            Telescope::recordLog(IncomingEntry::make([
+                'level'   => 'warning',
+                'message' => 'N+1 detected at ' . $caller,
+                'context' => [
+                    'pattern'   => $pattern,
+                    'example'   => self::$batches[$key]['example'],
+                    'threshold' => $this->threshold,
+                    'window_ms' => $this->windowMs,
+                ],
+            ]));
+        }
+    }
+
+    /**
+     * Normalize SQL heuristically.
+     *
+     * @param  string  $sql
+     * @return string
+     */
+    protected function normalize($sql)
+    {
+        $s = strtolower($sql);
+        $s = preg_replace('/\s+/', ' ', $s) ?: $s;
+        $s = preg_replace('/\b\d+\b/', '?', $s) ?: $s;
+        $s = preg_replace('/\'(?:[^\'\\\\]|\\\\.)*\'/', '?', $s) ?: $s;
+        $s = preg_replace('/\bin\s*\((?:\s*[^)]+)\)/', ' in (?)', $s) ?: $s;
+        return trim($s);
+    }
+
+    /**
+     * First non-vendor stack frame as "file:line".
+     *
+     * @return string
+     */
+    protected function caller()
+    {
+        foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $frame) {
+            if (! isset($frame['file'])) {
+                continue;
+            }
+            if (Str::contains($frame['file'], DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR)) {
+                continue;
+            }
+            $line = isset($frame['line']) ? (int) $frame['line'] : 0;
+            return $frame['file'] . ':' . $line;
+        }
+
+        return 'unknown:0';
+    }
+
+    /**
+     * Check if query touches Telescope tables.
+     *
+     * @param  string  $sql
+     * @return bool
+     */
+    protected function isTelescopeSql($sql)
+    {
+        $s = strtolower($sql);
+
+        return Str::contains($s, 'telescope_entries')
+            || Str::contains($s, 'telescope_entries_tags')
+            || Str::contains($s, 'telescope_monitoring');
+    }
+}

--- a/tests/Watchers/NPlusOneWatcherTest.php
+++ b/tests/Watchers/NPlusOneWatcherTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Laravel\Telescope\Tests\Watchers;
+
+use Illuminate\Support\Facades\DB;
+use Laravel\Telescope\EntryType;
+use Laravel\Telescope\Tests\FeatureTestCase;
+use Laravel\Telescope\Watchers\NPlusOneWatcher;
+
+class NPlusOneWatcherTest extends FeatureTestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app->get('config')->set('telescope.watchers', [
+            NPlusOneWatcher::class => true,
+        ]);
+    }
+
+    public function testDetectsNPlusOneAndRecordsLog()
+    {
+        $this->app->setBasePath(dirname(__FILE__, 3));
+
+        // Repeat the same query on the same code line.
+        for ($i = 0; $i < 5; $i++) {
+            DB::select('select 1');
+        }
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertNotNull($entry);
+        $this->assertSame(EntryType::LOG, $entry->type);
+        $this->assertStringStartsWith('N+1 detected at ', $entry->content['message']);
+    }
+}


### PR DESCRIPTION
### Summary
Adds a new NPlusOneWatcher that detects repeated queries sharing the same normalized SQL pattern from the same caller within a short time window and records a warning log entry.

### Motivation
N+1 database patterns are a common performance issue. Telescope already surfaces performance via the Query watcher (e.g., "slow" queries). This watcher complements it by flagging N+1 at the point of occurrence. See the Query watcher docs for option style and prior art.

### Implementation
- New file: src/Watchers/NPlusOneWatcher.php
- Config entry in config/telescope.php with `enabled`, `threshold`, `window`
- Test: tests/Watchers/NPlusOneWatcherTest.php

### BC Breaks
None. The watcher is additive and can be disabled via config.

### Tests
Pass locally with `vendor/bin/phpunit` using the package's Testbench setup.
