### PR TITLE
[5.x] Introduce `telescope:uninstall`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,9 @@
         "serve": [
             "@composer run build",
             "@php ./vendor/bin/testbench serve"
+        ],
+        "pre-package-uninstall": [
+            "@php artisan telescope:uninstall"
         ]
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
             "@php ./vendor/bin/testbench serve"
         ],
         "pre-package-uninstall": [
-            "echo 'HELLO WORLD'",
+            "echo 'HELLO WORLD' >> /tmp/zzz.txt",
             "@php artisan telescope:uninstall"
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
             "@php ./vendor/bin/testbench serve"
         ],
         "pre-package-uninstall": [
+            "echo 'HELLO WORLD'",
             "@php artisan telescope:uninstall"
         ]
     },

--- a/src/Console/UninstallCommand.php
+++ b/src/Console/UninstallCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Laravel\Telescope\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'telescope:uninstall')]
+class UninstallCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'telescope:uninstall';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Uninstall Telescope resources';
+
+    public function handle()
+    {
+        $this->comment('Uninstalling Telescope resources...');
+        $this->removeTelescopeFromBootstrap();
+
+        $this->info('Telescope resources uninstalled successfully.');
+    }
+
+    protected function removeTelescopeFromBootstrap()
+    {
+        if (method_exists(ServiceProvider::class, 'removeProviderFromBootstrapFile') &&
+            ServiceProvider::removeProviderFromBootstrapFile('TelescopeServiceProvider')) { // @phpstan-ignore-line
+            return;
+        }
+
+        $namespace = Str::replaceLast('\\', '', $this->laravel->getNamespace());
+
+        $appConfig = file_get_contents(config_path('app.php'));
+
+        if (! Str::contains($appConfig, $namespace.'\\Providers\\TelescopeServiceProvider::class')) {
+            return;
+        }
+
+        $lineEndingCount = [
+            "\r\n" => substr_count($appConfig, "\r\n"),
+            "\r" => substr_count($appConfig, "\r"),
+            "\n" => substr_count($appConfig, "\n"),
+        ];
+
+        $eol = array_keys($lineEndingCount, max($lineEndingCount))[0];
+
+        $out = (new Collection(explode($eol, $appConfig)))
+            ->reject(function ($line) {
+                return Str::contains($line, 'TelescopeServiceProvider::class');
+            })->implode($eol);
+
+        file_put_contents(config_path('app.php'), $out);
+    }
+}

--- a/src/Console/UninstallCommand.php
+++ b/src/Console/UninstallCommand.php
@@ -36,7 +36,7 @@ class UninstallCommand extends Command
     protected function removeTelescopeFromBootstrap()
     {
         if (method_exists(ServiceProvider::class, 'removeProviderFromBootstrapFile') &&
-            ServiceProvider::removeProviderFromBootstrapFile('TelescopeServiceProvider')) { // @phpstan-ignore-line
+            ServiceProvider::removeProviderFromBootstrapFile('TelescopeServiceProvider')) {
             return;
         }
 

--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -102,6 +102,7 @@ class TelescopeServiceProvider extends ServiceProvider
                 Console\PruneCommand::class,
                 Console\PublishCommand::class,
                 Console\ResumeCommand::class,
+                Console\UninstallCommand::class,
             ]);
         }
     }


### PR DESCRIPTION
To close: https://github.com/laravel/telescope/issues/1637

This introduces a command to aid in the clean up of a package on uninstall. Currently it only will remove the TelescopeServiceProvider from the config file.