### PR TITLE
[5.x] Simplify control flow

### DIFF
--- a/src/Actions/UninstallAction.php
+++ b/src/Actions/UninstallAction.php
@@ -8,9 +8,8 @@ class UninstallAction
 {
     public function handle(): void
     {
-        if (method_exists(ServiceProvider::class, 'removeProviderFromBootstrapFile') &&
-            ServiceProvider::removeProviderFromBootstrapFile('TelescopeServiceProvider')) {
-            return;
+        if (method_exists(ServiceProvider::class, 'removeProviderFromBootstrapFile')) {
+            ServiceProvider::removeProviderFromBootstrapFile('TelescopeServiceProvider');
         }
     }
 }


### PR DESCRIPTION
Description
---
- Since the return value isn't used and the intent is simply to remove the provider if the method exists, this change simplifies the logic by directly calling the method when available.
- No need to return early; just call the method if it exists.