### PR TITLE
Fix: Record IncomingExceptionEntry with binary content

### DIFF
--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -172,9 +172,10 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
 
                 return array_merge($exception->toArray(), [
                     'family_hash' => $exception->familyHash(),
-                    'content' => json_encode(array_merge(
-                        $exception->content, ['occurrences' => $occurrences + 1]
-                    )),
+                    'content' => json_encode(
+                        array_merge($exception->content, ['occurrences' => $occurrences + 1]),
+                        JSON_INVALID_UTF8_SUBSTITUTE
+                    ),
                 ]);
             })->toArray());
         });

--- a/tests/Storage/DatabaseEntriesRepositoryTest.php
+++ b/tests/Storage/DatabaseEntriesRepositoryTest.php
@@ -2,10 +2,14 @@
 
 namespace Laravel\Telescope\Tests\Storage;
 
-use Laravel\Telescope\Database\Factories\EntryModelFactory;
+use Illuminate\Support\Str;
+use Laravel\Telescope\EntryType;
 use Laravel\Telescope\EntryUpdate;
-use Laravel\Telescope\Storage\DatabaseEntriesRepository;
+use Laravel\Telescope\IncomingEntry;
 use Laravel\Telescope\Tests\FeatureTestCase;
+use Laravel\Telescope\IncomingExceptionEntry;
+use Laravel\Telescope\Storage\DatabaseEntriesRepository;
+use Laravel\Telescope\Database\Factories\EntryModelFactory;
 
 class DatabaseEntriesRepositoryTest extends FeatureTestCase
 {
@@ -41,5 +45,31 @@ class DatabaseEntriesRepositoryTest extends FeatureTestCase
 
         $this->assertCount(1, $failedUpdates);
         $this->assertSame('missing-id', $failedUpdates->first()->uuid);
+    }
+
+    public function test_store_binary_content()
+    {
+        $batchId = Str::uuid();
+        $exception = new \Exception('message');
+
+        $entries = collect([
+            (new IncomingEntry(['message' => gzcompress('message')]))->batchId($batchId)->type(EntryType::LOG),
+            (new IncomingExceptionEntry($exception, [
+                'file' => $exception->getFile(), 
+                'line' => $exception->getLine(), 
+                'message' => gzcompress($exception->getMessage())
+            ]))->batchId($batchId)->type(EntryType::EXCEPTION)
+        ]);
+
+        $repository = new DatabaseEntriesRepository('testbench');
+
+        $repository->store($entries);
+
+        $entries->each(function ($entry) {
+            $this->assertDatabaseMissing('telescope_entries', [
+                'uuid' => $entry->uuid,
+                'content' => false
+            ]);
+        });
     }
 }


### PR DESCRIPTION
This is an extension of PR #1266. The addition of the `JSON_INVALID_UTF8_SUBSTITUTE` flag on `DatabaseEntriesRepository:146` works when storing new `IncomingEntry` records, but fails for `IncomingExceptionEntry` records because the flag was not added to `DatabaseEntriesRepository::storeExceptions`. This PR adds the flag to allow binary content for all entry types, and includes a new test that ensures the entry content is not silently dropped.
