### PR TITLE
feat: add shouldIgnoreHosts method to filter HTTP client requests by host

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -143,7 +143,10 @@ return [
             'ignore' => [],
         ],
 
-        Watchers\ClientRequestWatcher::class => env('TELESCOPE_CLIENT_REQUEST_WATCHER', true),
+        Watchers\ClientRequestWatcher::class => [
+            env('TELESCOPE_CLIENT_REQUEST_WATCHER', true),
+            'ignore_hosts' => [],
+        ],
 
         Watchers\CommandWatcher::class => [
             'enabled' => env('TELESCOPE_COMMAND_WATCHER', true),

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -144,7 +144,7 @@ return [
         ],
 
         Watchers\ClientRequestWatcher::class => [
-            env('TELESCOPE_CLIENT_REQUEST_WATCHER', true),
+            'enabled' => env('TELESCOPE_CLIENT_REQUEST_WATCHER', true),
             'ignore_hosts' => [],
         ],
 

--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -58,7 +58,7 @@ class ClientRequestWatcher extends Watcher
     public function recordResponse(ResponseReceived $event)
     {
         if (! Telescope::isRecording() ||
-            $this->shouldIgnoreHosts($event)) {
+            $this->shouldIgnoreHost($event)) {
             return;
         }
 
@@ -83,12 +83,11 @@ class ClientRequestWatcher extends Watcher
      * @param  mixed  $event
      * @return bool
      */
-    protected function shouldIgnoreHosts($event)
+    protected function shouldIgnoreHost($event)
     {
         $host = $event->request->toPsrRequest()->getUri()->getHost();
-        $ignoreHosts = Arr::get($this->options, 'ignore_hosts', []);
 
-        return in_array($host, $ignoreHosts);
+        return in_array($host, Arr::get($this->options, 'ignore_hosts', []));
     }
 
     /**

--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -57,7 +57,8 @@ class ClientRequestWatcher extends Watcher
      */
     public function recordResponse(ResponseReceived $event)
     {
-        if (! Telescope::isRecording()) {
+        if (! Telescope::isRecording()||
+            $this->shouldIgnoreHosts($event)) {
             return;
         }
 
@@ -74,6 +75,20 @@ class ClientRequestWatcher extends Watcher
             ])
             ->tags([$event->request->toPsrRequest()->getUri()->getHost()])
         );
+    }
+
+    /**
+     * Determine whether to ignore this request based on its host.
+     *
+     * @param  mixed  $event
+     * @return bool
+     */
+    protected function shouldIgnoreHosts($event)
+    {
+        $host = $event->request->toPsrRequest()->getUri()->getHost();
+        $ignoreHosts = Arr::get($this->options, 'ignore_hosts', []);
+
+        return in_array($host, $ignoreHosts);
     }
 
     /**

--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -57,7 +57,7 @@ class ClientRequestWatcher extends Watcher
      */
     public function recordResponse(ResponseReceived $event)
     {
-        if (! Telescope::isRecording()||
+        if (! Telescope::isRecording() ||
             $this->shouldIgnoreHosts($event)) {
             return;
         }


### PR DESCRIPTION
Added new functionality to allow configuring host-based ignore rules (e.g., CDNs) in the ClientRequestWatcher.