### PR TITLE
chore: Refactor tag query to use join instead of subquery

### DIFF
--- a/src/Storage/EntryModel.php
+++ b/src/Storage/EntryModel.php
@@ -122,7 +122,7 @@ class EntryModel extends Model
                 return $query;
             }
 
-            return $query->join("telescope_entries_tags", function ($query) use ($tags) {
+            return $query->join('telescope_entries_tags', function ($query) use ($tags) {
                 $query->on('entry_uuid', '=', 'uuid')
                     ->whereIn('tag', $tags->all());
             });

--- a/src/Storage/EntryModel.php
+++ b/src/Storage/EntryModel.php
@@ -122,11 +122,9 @@ class EntryModel extends Model
                 return $query;
             }
 
-            return $query->whereIn('uuid', function ($query) use ($tags) {
-                $query->select('entry_uuid')->from('telescope_entries_tags')
-                    ->whereIn('entry_uuid', function ($query) use ($tags) {
-                        $query->select('entry_uuid')->from('telescope_entries_tags')->whereIn('tag', $tags->all());
-                    });
+            return $query->join("telescope_entries_tags", function ($query) use ($tags) {
+                $query->on('entry_uuid', '=', 'uuid')
+                    ->whereIn('tag', $tags->all());
             });
         });
 


### PR DESCRIPTION
Please ready with care, this is my first PR to a open source repository! Be nice!

Changed how to filter entries by tag to have better performance;

Cost with subquery:
<img width="774" height="784" alt="image" src="https://github.com/user-attachments/assets/8126ec42-84db-4755-ae0e-96230e265d99" />

Cost with join:
<img width="775" height="467" alt="image" src="https://github.com/user-attachments/assets/e41cc737-cfd3-490c-b3f9-a924dda8cc7f" />
