### PR TITLE
Feat:ability to copy a request as curl

### DIFF
--- a/resources/js/components/PreviewScreen.vue
+++ b/resources/js/components/PreviewScreen.vue
@@ -22,6 +22,7 @@ export default {
 
             updateEntryTimeout: null,
             updateEntryTimer: 2500,
+            copiedSuccessfully: false,
         };
     },
 
@@ -122,6 +123,22 @@ export default {
 
                 this.updateEntry();
             }, this.updateEntryTimer);
+        },
+
+        /**
+        * Copy the request as cURL
+        */
+        copyCurl(){
+            axios.post(Telescope.basePath + '/telescope-api/' + this.resource + '/' + this.id + '/copy-curl')
+                .then(res => {
+                    navigator.clipboard.writeText(res.data.curl)
+                        .then(() => {
+                            this.copiedSuccessfully = true
+
+                            setTimeout(() => this.copiedSuccessfully = false, 1000)
+                        })
+                })
+                .catch(() => console.log('An error occured while copying cURL'))
         }
     }
 }
@@ -132,6 +149,15 @@ export default {
         <div class="card overflow-hidden">
             <div class="card-header d-flex align-items-center justify-content-between">
                 <h2 class="h6 m-0">{{ this.title }}</h2>
+                
+                <div v-if="ready && entry && (this.resource === 'requests')" class="text-end">
+                    <button style="min-width: 110px;" @click="copyCurl" class="btn btn-muted">
+                        <span v-if="!this.copiedSuccessfully">Copy cURL</span>
+                        <svg v-else xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="icon" fill="currentColor" aria-hidden="true">
+                            <path d="M16.707 5.293a1 1 0 00-1.414-1.414L7 12.172l-2.293-2.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l8-8z"/>
+                        </svg>
+                    </button>
+                </div>
             </div>
 
             <div

--- a/routes/web.php
+++ b/routes/web.php
@@ -55,6 +55,7 @@ Route::get('/telescope-api/models/{telescopeEntryId}', 'ModelsController@show');
 // Requests entries...
 Route::post('/telescope-api/requests', 'RequestsController@index');
 Route::get('/telescope-api/requests/{telescopeEntryId}', 'RequestsController@show');
+Route::post('/telescope-api/requests/{telescopeEntryId}/copy-curl', 'RequestsController@copyCurl');
 
 // View entries...
 Route::post('/telescope-api/views', 'ViewsController@index');

--- a/src/Http/Controllers/EntryController.php
+++ b/src/Http/Controllers/EntryController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Telescope\Contracts\EntriesRepository;
 use Laravel\Telescope\Storage\EntryQueryOptions;
+use Illuminate\Support\Facades\Http;
 
 abstract class EntryController extends Controller
 {
@@ -55,6 +56,41 @@ abstract class EntryController extends Controller
         return response()->json([
             'entry' => $entry,
             'batch' => $storage->get(null, EntryQueryOptions::forBatchId($entry->batchId)->limit(-1)),
+        ]);
+    }
+
+    public function copyCurl(EntriesRepository $storage, $id)
+    {
+        $entry = $storage->find($id);
+
+        if (! $entry) {
+            abort(404);
+        }
+
+        $method = strtoupper($entry->content['method']);
+        $url = url($entry->content['uri']);
+        $headers = $entry->content['headers'] ?? [];
+        $payload = $entry->content['payload'] ?? null;
+
+        $curl = "curl -X {$method}";
+
+        foreach ($headers as $key => $value) {
+            $v = is_array($value) ? implode(', ', $value) : $value;
+            $curl .= " -H " . escapeshellarg("$key: $v");
+        }
+
+        if (! empty($payload)) {
+            if (is_array($payload)) {
+                $payload = json_encode($payload);
+            }
+
+            $curl .= " --data " . escapeshellarg($payload);
+        }
+
+        $curl .= " $url";
+
+        return response()->json([
+            'curl' => $curl
         ]);
     }
 

--- a/src/Http/Controllers/EntryController.php
+++ b/src/Http/Controllers/EntryController.php
@@ -6,7 +6,6 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Telescope\Contracts\EntriesRepository;
 use Laravel\Telescope\Storage\EntryQueryOptions;
-use Illuminate\Support\Facades\Http;
 
 abstract class EntryController extends Controller
 {
@@ -76,7 +75,7 @@ abstract class EntryController extends Controller
 
         foreach ($headers as $key => $value) {
             $v = is_array($value) ? implode(', ', $value) : $value;
-            $curl .= " -H " . escapeshellarg("$key: $v");
+            $curl .= ' -H '.escapeshellarg("$key: $v");
         }
 
         if (! empty($payload)) {
@@ -84,13 +83,13 @@ abstract class EntryController extends Controller
                 $payload = json_encode($payload);
             }
 
-            $curl .= " --data " . escapeshellarg($payload);
+            $curl .= ' --data '.escapeshellarg($payload);
         }
 
         $curl .= " $url";
 
         return response()->json([
-            'curl' => $curl
+            'curl' => $curl,
         ]);
     }
 


### PR DESCRIPTION
<img width="1280" height="636" alt="image" src="https://github.com/user-attachments/assets/a25e8cfe-4545-4335-a245-b476924469ae" />


# Usage

This PR adds a new “Copy as cURL” action to the Laravel Telescope request inspector.
It allows developers to instantly copy any captured HTTP request as a fully-formed cURL command that can be executed directly in the terminal.

When debugging APIs or replicating complex HTTP interactions, developers often need to manually reconstruct a request—including method, headers, payload, and URL. Manually building this cURL command is time-consuming and error-prone, especially when requests contain nested JSON payloads or multiple headers.

Telescope already captures all the necessary request metadata, so adding a one-click copy option significantly improves debugging workflow.

# What this PR adds

- A “Copy cURL” button in the Request entry screen.

- Backend logic that converts a Telescope request entry into a properly escaped and formatted cURL command.

### Support for:

- HTTP method (GET, POST, etc.)

- Full URL

- All headers recorded by Telescope

- Raw payload body (string, JSON, or form data)

- Frontend clipboard integration using navigator.clipboard.writeText.

# Benefits to end users

Greatly improves productivity when debugging or reproducing API requests.

Eliminates manual reconstruction of headers, tokens, and payloads.

Ensures cURL commands exactly match the original request.

### Useful for:

- API developers

- Backend debugging

- Reproducing issues reported in logs

- Security auditing

# Backward compatibility

This PR does not modify any existing Telescope behavior or internal structures.
All changes are additive and scoped to the Request entry UI and controller.
No breaking changes are introduced.