### PR TITLE
refactor(reflection): remove deprecated setAccessible usage

### DIFF
--- a/src/ExtractProperties.php
+++ b/src/ExtractProperties.php
@@ -19,8 +19,6 @@ class ExtractProperties
     {
         return collect((new ReflectionClass($target))->getProperties())
             ->mapWithKeys(function ($property) use ($target) {
-                $property->setAccessible(true);
-
                 if (PHP_VERSION_ID >= 70400 && ! $property->isInitialized($target)) {
                     return [];
                 }

--- a/src/ExtractProperties.php
+++ b/src/ExtractProperties.php
@@ -19,6 +19,10 @@ class ExtractProperties
     {
         return collect((new ReflectionClass($target))->getProperties())
             ->mapWithKeys(function ($property) use ($target) {
+                if (PHP_VERSION_ID < 80500) {
+                    $property->setAccessible(true);
+                }
+
                 if (PHP_VERSION_ID >= 70400 && ! $property->isInitialized($target)) {
                     return [];
                 }

--- a/src/ExtractTags.php
+++ b/src/ExtractTags.php
@@ -130,6 +130,10 @@ class ExtractTags
     {
         return collect($targets)->map(function ($target) {
             return collect((new ReflectionClass($target))->getProperties())->map(function ($property) use ($target) {
+                if (PHP_VERSION_ID < 80500) {
+                    $property->setAccessible(true);
+                }
+
                 if (PHP_VERSION_ID < 70400 || ! is_object($target) || $property->isInitialized($target)) {
                     return static::resolveValue($property->getValue($target));
                 }

--- a/src/ExtractTags.php
+++ b/src/ExtractTags.php
@@ -130,8 +130,6 @@ class ExtractTags
     {
         return collect($targets)->map(function ($target) {
             return collect((new ReflectionClass($target))->getProperties())->map(function ($property) use ($target) {
-                $property->setAccessible(true);
-
                 if (PHP_VERSION_ID < 70400 || ! is_object($target) || $property->isInitialized($target)) {
                     return static::resolveValue($property->getValue($target));
                 }

--- a/tests/Watchers/EventWatcherTest.php
+++ b/tests/Watchers/EventWatcherTest.php
@@ -127,6 +127,11 @@ class EventWatcherTest extends FeatureTestCase
         Event::listen(DummyEvent::class, $listener);
 
         $method = new \ReflectionMethod(EventWatcher::class, 'formatListeners');
+
+        if (PHP_VERSION_ID < 80500) {
+            $method->setAccessible(true);
+        }
+
         $this->assertSame($formatted, $method->invoke(new EventWatcher, DummyEvent::class)[0]['name']);
     }
 

--- a/tests/Watchers/EventWatcherTest.php
+++ b/tests/Watchers/EventWatcherTest.php
@@ -127,8 +127,6 @@ class EventWatcherTest extends FeatureTestCase
         Event::listen(DummyEvent::class, $listener);
 
         $method = new \ReflectionMethod(EventWatcher::class, 'formatListeners');
-        $method->setAccessible(true);
-
         $this->assertSame($formatted, $method->invoke(new EventWatcher, DummyEvent::class)[0]['name']);
     }
 


### PR DESCRIPTION
Remove deprecated `setAccessible()` calls: refs: https://github.com/laravel/telescope/issues/1660

`setAccessible()` is deprecated in PHP 8.5. Reflection now allows direct access to properties without it, avoiding deprecation warnings.

Reference: https://www.php.net/manual/en/reflectionproperty.setaccessible.php