### PR TITLE
fix: ignore track chrome devtools route

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -117,6 +117,7 @@ return [
         'nova-api*',
         'pulse*',
         '_boost*',
+        '.well-known*',
     ],
 
     'ignore_commands' => [


### PR DESCRIPTION
Ignore track the chrome devtools route: /.well-known/XXXXX

When press F12 (or open chrome developer tools). Chrome call a request like this image below.

**Screenshot:**
<img width="1414" height="586" alt="image" src="https://github.com/user-attachments/assets/e1edd672-9b69-46e4-8cd1-e78097e7508f" />

**More info**: [https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md](https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md#solution)

**The reasons it does not break any existing features:** updated 'ignore_paths' config only

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
