### PR TITLE
Fix crash when saving models with composite primary keys

### DIFF
--- a/src/FormatModel.php
+++ b/src/FormatModel.php
@@ -22,11 +22,19 @@ class FormatModel
                 $model->getAttribute($model->getRelatedKey()),
             ];
         } else {
-            $keys = $model->getKey();
+            // FIX START: Check if the key is composite (array)
+            if (is_array($model->getKeyName())) {
+                $keys = array_map(function ($key) use ($model) {
+                    return $model->getAttribute($key);
+                }, $model->getKeyName());
+            } else {
+                $keys = $model->getKey();
+            }
+            // FIX END
         }
 
         return get_class($model).':'.implode('_', array_map(function ($value) {
-            return $value instanceof BackedEnum ? $value->value : $value;
-        }, Arr::wrap($keys)));
+                return $value instanceof BackedEnum ? $value->value : $value;
+            }, Arr::wrap($keys)));
     }
 }


### PR DESCRIPTION
## Description
This PR fixes an issue where Telescope throws a `TypeError` when saving a model that uses a composite primary key (e.g., `protected $primaryKey = ['id_a', 'id_b']`).

The crash occurs in `FormatModel::given`, where `$model->getKey()` returns an array for composite keys. The previous logic attempted to use this array in a way that caused `array_key_exists` failures or invalid array offsets.

## Fix
I updated `FormatModel::given` to explicitly check if `getKeyName()` is an array. If it is, we map over the keys to retrieve the attribute values individually, preventing the crash.

## Related Issue
Fixes #1654 

## Steps to Reproduce (Fixed)
1. Create a model with a composite key:
   ```php
   protected $primaryKey = ['first_id', 'second_id'];
   public $incrementing = false;