### PR TITLE
Fix PHPStan error in migration `getConnection`

### DIFF
--- a/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -9,9 +9,9 @@ return new class extends Migration
     /**
      * Get the migration connection name.
      */
-    public function getConnection(): ?string
+    public function getConnection(): string
     {
-        return config('telescope.storage.database.connection');
+        return config()->string('telescope.storage.database.connection');
     }
 
     /**


### PR DESCRIPTION
As Larastan/PHPStan becomes more popular, I think it's nice to comply with it "out of the box", so that users won't have to fix the error themselves.

`telescope:install` publishes this migration by default.