### PR TITLE
hotfix: prevent duplicate migration creation during telescope:install.

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -38,7 +38,7 @@ class InstallCommand extends Command
         $this->callSilent('vendor:publish', ['--tag' => 'telescope-config']);
 
         $this->comment('Publishing Telescope Migrations...');
-        $this->callSilent('vendor:publish', ['--tag' => 'telescope-migrations']);
+        $this->publishMigrationsIfNotExists();
 
         $this->registerTelescopeServiceProvider();
 
@@ -46,10 +46,40 @@ class InstallCommand extends Command
     }
 
     /**
+     * Publish migrations only if they don't already exist.
+     *
+     * @return void
+     */
+    protected function publishMigrationsIfNotExists()
+    {
+        $migrationPath = database_path('migrations');
+        $telescopeMigrationExists = false;
+
+        if (is_dir($migrationPath)) {
+            $files = scandir($migrationPath);
+            foreach ($files as $file) {
+                if (str_contains($file, 'create_telescope_entries_table')) {
+                    $telescopeMigrationExists = true;
+                    break;
+                }
+            }
+        }
+
+        if (!$telescopeMigrationExists) {
+            $this->callSilent('vendor:publish', ['--tag' => 'telescope-migrations']);
+            $this->info('Telescope migrations published.');
+        } else {
+            $this->comment('Telescope migrations already exist. Skipping migration publishing.');
+        }
+    }
+
+
+    /**
      * Register the Telescope service provider in the application configuration file.
      *
      * @return void
      */
+    
     protected function registerTelescopeServiceProvider()
     {
         if (method_exists(ServiceProvider::class, 'addProviderToBootstrapFile') &&
@@ -85,4 +115,6 @@ class InstallCommand extends Command
             file_get_contents(app_path('Providers/TelescopeServiceProvider.php'))
         ));
     }
+
+
 }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -65,7 +65,7 @@ class InstallCommand extends Command
             }
         }
 
-        if (!$telescopeMigrationExists) {
+        if (! $telescopeMigrationExists) {
             $this->callSilent('vendor:publish', ['--tag' => 'telescope-migrations']);
             $this->info('Telescope migrations published.');
         } else {
@@ -73,13 +73,11 @@ class InstallCommand extends Command
         }
     }
 
-
     /**
      * Register the Telescope service provider in the application configuration file.
      *
      * @return void
-     */
-    
+     */    
     protected function registerTelescopeServiceProvider()
     {
         if (method_exists(ServiceProvider::class, 'addProviderToBootstrapFile') &&
@@ -115,6 +113,4 @@ class InstallCommand extends Command
             file_get_contents(app_path('Providers/TelescopeServiceProvider.php'))
         ));
     }
-
-
 }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -77,7 +77,7 @@ class InstallCommand extends Command
      * Register the Telescope service provider in the application configuration file.
      *
      * @return void
-     */    
+     */
     protected function registerTelescopeServiceProvider()
     {
         if (method_exists(ServiceProvider::class, 'addProviderToBootstrapFile') &&


### PR DESCRIPTION
**What does this PR do?**
This pull request fixes the issue where Telescope migrations were getting duplicated. The change ensures that migrations are created and executed only once, preventing conflicts and repeated entries.

**Problem**
Previously, Telescope migration files could be generated or run multiple times, leading to duplicate records and migration conflicts.

**Solution**
- Added proper checks to prevent duplicate Telescope migrations
- Ensured migration runs only when required
- Improved overall migration stability

**Impact**
- Prevents migration conflicts
- Keeps the database clean and consistent
- Safe change with no breaking impact on existing data

**🧪 Testing**
- Verified migrations run successfully without duplication
- Tested on a fresh setup and existing database