### PR TITLE
Add attachments support to telescope

### DIFF
--- a/resources/js/screens/mail/index.vue
+++ b/resources/js/screens/mail/index.vue
@@ -24,11 +24,18 @@ export default {
 
         <template slot="row" slot-scope="slotProps">
             <td>
-                <span :title="slotProps.entry.content.mailable">{{
-                    truncate(slotProps.entry.content.mailable || '-', 70)
+                <span :title="slotProps.entry.content.mailable || slotProps.entry.content.subject">{{
+                    truncate(slotProps.entry.content.mailable || slotProps.entry.content.subject || '-', 70)
                 }}</span>
 
                 <span class="badge badge-secondary ml-2" v-if="slotProps.entry.content.queued"> Queued </span>
+
+                <span class="badge badge-secondary ml-2" v-if="slotProps.entry.content.attachments && slotProps.entry.content.attachments.length">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" width="12" height="12" fill="currentColor" style="vertical-align: -1px;">
+                        <path fill-rule="evenodd" d="M15.621 4.379a3 3 0 0 0-4.242 0l-7 7a3 3 0 0 0 4.241 4.243h.001l.497-.5a.75.75 0 0 1 1.064 1.057l-.498.501-.002.002a4.5 4.5 0 0 1-6.364-6.364l7-7a4.5 4.5 0 0 1 6.368 6.36l-3.455 3.553A2.625 2.625 0 1 1 9.52 9.52l3.45-3.451a.75.75 0 1 1 1.061 1.06l-3.45 3.451a1.125 1.125 0 0 0 1.587 1.595l3.454-3.553a3 3 0 0 0 0-4.242Z" clip-rule="evenodd" />
+                    </svg>
+                    {{ slotProps.entry.content.attachments.length }}
+                </span>
 
                 <br />
 

--- a/resources/js/screens/mail/preview.vue
+++ b/resources/js/screens/mail/preview.vue
@@ -10,14 +10,25 @@ export default {
             return _.chain(addresses).map((name, email) => {
                 return (name ? "<" + name + "> " : '') + email;
             }).join(', ').value()
-        }
-    },
+        },
 
-    data(){
-        return {
-            entry: null,
-            batch: [],
-        };
+        /**
+         * Format bytes into a human-readable string.
+         */
+        formatBytes(bytes) {
+            if (bytes === 0) return '0 Bytes';
+            const k = 1024;
+            const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+            const i = Math.floor(Math.log(bytes) / Math.log(k));
+            return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+        },
+
+        /**
+         * Get the download URL for an attachment.
+         */
+        attachmentUrl(index) {
+            return Telescope.basePath + '/telescope-api/mail/' + this.$route.params.id + '/attachments/' + index;
+        }
     },
 }
 </script>
@@ -48,21 +59,21 @@ export default {
                 </td>
             </tr>
 
-            <tr v-if="slotProps.entry.replyTo">
+            <tr v-if="slotProps.entry.content.replyTo">
                 <td class="table-fit text-muted">Reply-To</td>
                 <td>
                     {{ formatAddresses(slotProps.entry.content.replyTo) }}
                 </td>
             </tr>
 
-            <tr v-if="slotProps.entry.cc">
+            <tr v-if="slotProps.entry.content.cc">
                 <td class="table-fit text-muted">CC</td>
                 <td>
                     {{ formatAddresses(slotProps.entry.content.cc) }}
                 </td>
             </tr>
 
-            <tr v-if="slotProps.entry.bcc">
+            <tr v-if="slotProps.entry.content.bcc">
                 <td class="table-fit text-muted">BCC</td>
                 <td>
                     {{ formatAddresses(slotProps.entry.content.bcc) }}
@@ -82,6 +93,28 @@ export default {
                     <a :href="Telescope.basePath + '/telescope-api/mail/' + $route.params.id + '/download'"
                         >Download .eml file</a
                     >
+                </td>
+            </tr>
+
+            <tr v-if="slotProps.entry.content.attachments && slotProps.entry.content.attachments.length">
+                <td class="table-fit text-muted">Attachments</td>
+                <td>
+                    <table class="table table-sm mb-0">
+                        <thead>
+                            <tr>
+                                <th>Filename</th>
+                                <th>Size</th>
+                                <th>Type</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr v-for="(attachment, index) in slotProps.entry.content.attachments" :key="index">
+                                <td><a :href="attachmentUrl(index)">{{ attachment.filename }}</a></td>
+                                <td>{{ formatBytes(attachment.size) }}</td>
+                                <td>{{ attachment.mime_type }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </td>
             </tr>
         </template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ Route::post('/telescope-api/mail', 'MailController@index');
 Route::get('/telescope-api/mail/{telescopeEntryId}', 'MailController@show');
 Route::get('/telescope-api/mail/{telescopeEntryId}/preview', 'MailHtmlController@show');
 Route::get('/telescope-api/mail/{telescopeEntryId}/download', 'MailEmlController@show');
+Route::get('/telescope-api/mail/{telescopeEntryId}/attachments/{index}', 'MailAttachmentController@show');
 
 // Exception entries...
 Route::post('/telescope-api/exceptions', 'ExceptionController@index');

--- a/src/Http/Controllers/MailAttachmentController.php
+++ b/src/Http/Controllers/MailAttachmentController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Laravel\Telescope\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+use Laravel\Telescope\Contracts\EntriesRepository;
+use Symfony\Component\HttpFoundation\HeaderUtils;
+
+class MailAttachmentController extends Controller
+{
+    /**
+     * Download a mail attachment.
+     *
+     * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
+     * @param  int  $id
+     * @param  int  $index
+     * @return mixed
+     */
+    public function show(EntriesRepository $storage, $id, $index)
+    {
+        $attachments = $storage->find($id)->content['attachments'] ?? [];
+
+        if (! isset($attachments[$index])) {
+            abort(404);
+        }
+
+        $attachment = $attachments[$index];
+
+        $content = base64_decode($attachment['content']);
+
+        return response($content, 200, [
+            'Content-Type' => $attachment['mime_type'],
+            'Content-Disposition' => HeaderUtils::makeDisposition('attachment', $attachment['filename']),
+            'Content-Length' => strlen($content),
+        ]);
+    }
+}

--- a/src/Watchers/MailWatcher.php
+++ b/src/Watchers/MailWatcher.php
@@ -138,9 +138,17 @@ class MailWatcher extends Watcher
         return collect($attachments)->map(function ($attachment) {
             $body = $attachment->getBody();
 
+            $filename = method_exists($attachment, 'getFilename')
+                ? $attachment->getFilename()
+                : $attachment->getName();
+
+            $contentType = method_exists($attachment, 'getContentType')
+                ? $attachment->getContentType()
+                : $attachment->getMediaType().'/'.$attachment->getMediaSubtype();
+
             return [
-                'filename' => $attachment->getFilename(),
-                'mime_type' => $attachment->getContentType(),
+                'filename' => $filename,
+                'mime_type' => $contentType,
                 'size' => strlen($body),
                 'content' => base64_encode($body),
             ];

--- a/src/Watchers/MailWatcher.php
+++ b/src/Watchers/MailWatcher.php
@@ -46,6 +46,7 @@ class MailWatcher extends Watcher
             'subject' => $event->message->getSubject(),
             'html' => $body instanceof AbstractPart ? ($event->message->getHtmlBody() ?? $event->message->getTextBody()) : $body,
             'raw' => $event->message->toString(),
+            'attachments' => $this->formatAttachments($event->message->getAttachments()),
         ])->tags($this->tags($event->message, $event->data)));
     }
 
@@ -101,9 +102,29 @@ class MailWatcher extends Watcher
     }
 
     /**
+     * Format the attachments for the given message.
+     *
+     * @param  array  $attachments
+     * @return array
+     */
+    protected function formatAttachments(array $attachments)
+    {
+        return collect($attachments)->map(function ($attachment) {
+            $body = $attachment->getBody();
+
+            return [
+                'filename' => $attachment->getFilename(),
+                'mime_type' => $attachment->getContentType(),
+                'size' => strlen($body),
+                'content' => base64_encode($body),
+            ];
+        })->all();
+    }
+
+    /**
      * Extract the tags from the message.
      *
-     * @param  \Swift_Message  $message
+     * @param  \Symfony\Component\Mime\Email  $message
      * @param  array  $data
      * @return array
      */

--- a/src/Watchers/MailWatcher.php
+++ b/src/Watchers/MailWatcher.php
@@ -46,9 +46,7 @@ class MailWatcher extends Watcher
             'subject' => $event->message->getSubject(),
             'html' => $body instanceof AbstractPart ? ($event->message->getHtmlBody() ?? $event->message->getTextBody()) : $body,
             'raw' => $event->message->toString(),
-            'attachments' => method_exists($event->message, 'getAttachments')
-                ? $this->formatAttachments($event->message->getAttachments())
-                : [],
+            'attachments' => $this->extractAttachments($event->message),
         ])->tags($this->tags($event->message, $event->data)));
     }
 
@@ -101,6 +99,32 @@ class MailWatcher extends Watcher
 
             return [$key => $address];
         })->all();
+    }
+
+    /**
+     * Extract attachments from the message.
+     *
+     * @param  mixed  $message
+     * @return array
+     */
+    protected function extractAttachments($message)
+    {
+        // Symfony Mailer (Laravel 9+)
+        if (method_exists($message, 'getAttachments')) {
+            return $this->formatAttachments($message->getAttachments());
+        }
+
+        // SwiftMailer (Laravel 8)
+        if (method_exists($message, 'getChildren')) {
+            $attachments = collect($message->getChildren())
+                ->filter(fn ($child) => method_exists($child, 'getFilename') && $child->getFilename() !== null)
+                ->values()
+                ->all();
+
+            return $this->formatAttachments($attachments);
+        }
+
+        return [];
     }
 
     /**

--- a/src/Watchers/MailWatcher.php
+++ b/src/Watchers/MailWatcher.php
@@ -46,7 +46,9 @@ class MailWatcher extends Watcher
             'subject' => $event->message->getSubject(),
             'html' => $body instanceof AbstractPart ? ($event->message->getHtmlBody() ?? $event->message->getTextBody()) : $body,
             'raw' => $event->message->toString(),
-            'attachments' => $this->formatAttachments($event->message->getAttachments()),
+            'attachments' => method_exists($event->message, 'getAttachments')
+                ? $this->formatAttachments($event->message->getAttachments())
+                : [],
         ])->tags($this->tags($event->message, $event->data)));
     }
 

--- a/src/Watchers/MailWatcher.php
+++ b/src/Watchers/MailWatcher.php
@@ -140,7 +140,7 @@ class MailWatcher extends Watcher
 
             $filename = method_exists($attachment, 'getFilename')
                 ? $attachment->getFilename()
-                : $attachment->getName();
+                : $attachment->getPreparedHeaders()->getHeaderParameter('Content-Disposition', 'filename');
 
             $contentType = method_exists($attachment, 'getContentType')
                 ? $attachment->getContentType()

--- a/tests/Http/MailAttachmentControllerTest.php
+++ b/tests/Http/MailAttachmentControllerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Laravel\Telescope\Tests\Http;
+
+use Illuminate\Support\Facades\Mail;
+use Laravel\Telescope\Http\Middleware\Authorize;
+use Laravel\Telescope\Tests\FeatureTestCase;
+use Laravel\Telescope\Watchers\MailWatcher;
+use Orchestra\Testbench\Attributes\WithConfig;
+
+#[WithConfig('mail.driver', 'array')]
+#[WithConfig('telescope.watchers', [
+    MailWatcher::class => true,
+])]
+class MailAttachmentControllerTest extends FeatureTestCase
+{
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutMiddleware(Authorize::class);
+    }
+
+    public function test_download_attachment()
+    {
+        Mail::raw('Telescope is amazing!', function ($message) {
+            $message->from('from@laravel.com')
+                ->to('to@laravel.com')
+                ->subject('Check this out!')
+                ->attachData('attachment content', 'document.pdf', [
+                    'mime' => 'application/pdf',
+                ]);
+        });
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $response = $this->get('/telescope/telescope-api/mail/'.$entry->uuid.'/attachments/0');
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'application/pdf');
+        $response->assertHeader('Content-Length', strlen('attachment content'));
+        $this->assertSame('attachment content', $response->content());
+    }
+
+    public function test_returns_404_for_invalid_attachment_index()
+    {
+        Mail::raw('Telescope is amazing!', function ($message) {
+            $message->from('from@laravel.com')
+                ->to('to@laravel.com')
+                ->subject('Check this out!')
+                ->attachData('attachment content', 'document.pdf', [
+                    'mime' => 'application/pdf',
+                ]);
+        });
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $response = $this->get('/telescope/telescope-api/mail/'.$entry->uuid.'/attachments/5');
+
+        $response->assertNotFound();
+    }
+
+    public function test_returns_404_for_entry_without_attachments()
+    {
+        Mail::raw('Telescope is amazing!', function ($message) {
+            $message->from('from@laravel.com')
+                ->to('to@laravel.com')
+                ->subject('Check this out!');
+        });
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $response = $this->get('/telescope/telescope-api/mail/'.$entry->uuid.'/attachments/0');
+
+        $response->assertNotFound();
+    }
+}

--- a/tests/Watchers/MailWatcherTest.php
+++ b/tests/Watchers/MailWatcherTest.php
@@ -47,5 +47,27 @@ class MailWatcherTest extends FeatureTestCase
         $this->assertContains('bcc@laravel.com', $tags);
         $this->assertContains('cc1@laravel.com', $tags);
         $this->assertContains('cc2@laravel.com', $tags);
+        $this->assertSame([], $entry->content['attachments']);
+    }
+
+    public function test_mail_watcher_registers_attachments()
+    {
+        Mail::raw('Telescope is amazing!', static function ($message) {
+            $message->from('from@laravel.com')
+                ->to('to@laravel.com')
+                ->subject('Check this out!')
+                ->attachData('attachment content', 'document.pdf', [
+                    'mime' => 'application/pdf',
+                ]);
+        });
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::MAIL, $entry->type);
+        $this->assertCount(1, $entry->content['attachments']);
+        $this->assertSame('document.pdf', $entry->content['attachments'][0]['filename']);
+        $this->assertSame('application/pdf', $entry->content['attachments'][0]['mime_type']);
+        $this->assertSame(strlen('attachment content'), $entry->content['attachments'][0]['size']);
+        $this->assertSame(base64_encode('attachment content'), $entry->content['attachments'][0]['content']);
     }
 }


### PR DESCRIPTION
Noticed that we could not see the attachments in emails, and there was an [issue](https://github.com/laravel/telescope/issues/440) opened about this.


Code used to send email:

```php
Route::get('/send-test-mail', function () {
    Mail::raw('Testing attachments in Telescope', function ($m) {
        $m->to('recipient@example.com')
            ->subject('Test Mail with Attachments')
            ->attachData('%PDF-1.4 sample pdf content', 'invoice.pdf', ['mime' => 'application/pdf'])
            ->attachData('Hello World!', 'readme.txt', ['mime' => 'text/plain']);
    });

    return 'Mail sent! <a href="/telescope/mail">View in Telescope</a>';
});

```


- Add attachments support to Telescope

<img width="3020" height="2018" alt="Captura de ecrã 2026-02-10, às 10 18 34" src="https://github.com/user-attachments/assets/65a9be56-9efa-434a-85e3-4b3ebce1cdc0" />

- Show subject on raw email list

## Before and After
<img width="2612" height="806" alt="Captura de ecrã 2026-02-10, às 10 15 38" src="https://github.com/user-attachments/assets/b4f838a9-18e7-4ffd-8f99-c2eed5176bdc" />

<img width="2550" height="954" alt="Captura de ecrã 2026-02-10, às 10 18 58" src="https://github.com/user-attachments/assets/b3b23695-8e3c-4ea5-88b3-91aaa9bda361" />

# How to test this PR easily

I have created a sample project, with everything explained in the README: https://github.com/monteiro/telescope-add-attachments