### PR TITLE
Use cascadeOnDelete() to fix PHPStan error in migration

### DIFF
--- a/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -48,7 +48,7 @@ return new class extends Migration
             $table->foreign('entry_uuid')
                 ->references('uuid')
                 ->on('telescope_entries')
-                ->onDelete('cascade');
+                ->cascadeOnDelete();
         });
 
         $schema->create('telescope_monitoring', function (Blueprint $table) {


### PR DESCRIPTION
When installing telescope, I always get a warning on phsptan:

```composer test:types```

```
❯  ------ ------------------------------------------------------------------------------------------
    Line   database/migrations/2025_11_19_184639_create_telescope_entries_table.php
   ------ ------------------------------------------------------------------------------------------
    52     Call to an undefined method Illuminate\Database\Schema\ForeignKeyDefinition::onDelete().
           🪪  method.notFound
```

We can just change the method to avoid this error with ```->cascadeOnDelete()```

