### PR TITLE
Add missing limit(-1) to QueueController batch query

### DIFF
--- a/src/Http/Controllers/QueueController.php
+++ b/src/Http/Controllers/QueueController.php
@@ -33,7 +33,7 @@ class QueueController extends EntryController
         return response()->json([
             'entry' => $entry,
             'batch' => isset($entry->content['updated_batch_id'])
-                ? $storage->get(null, EntryQueryOptions::forBatchId($entry->content['updated_batch_id']))
+                ? $storage->get(null, EntryQueryOptions::forBatchId($entry->content['updated_batch_id'])->limit(-1))
                 : null,
         ]);
     }


### PR DESCRIPTION
The `QueueController::show()` method is missing `->limit(-1)` when fetching batch entries for the job detail page. Unlike the parent `EntryController::show()` which correctly uses `->limit(-1)`, the queue controller relies on the default limit of 50 from `EntryQueryOptions`.

This causes related entries to be silently truncated when a job produces more than 50 Telescope entries. For example, a job that sends 32 push notifications generates ~140 entries (logs + notifications + queries), but only the last 50 are returned — showing just 12 notifications on the detail page instead of 32.

Fixes #1683