### PR TITLE
Add explicit bool type hint to $keepExceptions parameter in prune method

### DIFF
--- a/src/Contracts/PrunableRepository.php
+++ b/src/Contracts/PrunableRepository.php
@@ -13,5 +13,5 @@ interface PrunableRepository
      * @param  bool  $keepExceptions
      * @return int
      */
-    public function prune(DateTimeInterface $before, $keepExceptions);
+    public function prune(DateTimeInterface $before, bool $keepExceptions);
 }


### PR DESCRIPTION
Adds explicit bool type to $keepExceptions parameter for better type safety.
No functional changes.
