### PR TITLE
Reduce risks of `localStorage` collision

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -15,7 +15,7 @@ import copyClipboard from './components/CopyClipboard.vue';
 
 import 'bootstrap';
 
-const LOCALSTORAGE_AUTOLOAD_KEY = 'telescope-autoLoadsNewEntries';
+const LOCALSTORAGE_AUTOLOAD_KEY = 'telescopeAutoLoadsNewEntries';
 
 let token = document.head.querySelector('meta[name="csrf-token"]');
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -15,7 +15,7 @@ import copyClipboard from './components/CopyClipboard.vue';
 
 import 'bootstrap';
 
-const LOCALSTORAGE_AUTOLOAD_KEY = 'telescope-autoLoadsNewEntries'
+const LOCALSTORAGE_AUTOLOAD_KEY = 'telescope-autoLoadsNewEntries';
 
 let token = document.head.querySelector('meta[name="csrf-token"]');
 
@@ -84,8 +84,8 @@ new Vue({
 
     methods: {
         autoLoadNewEntries() {
-            this.autoLoadsNewEntries = !this.autoLoadsNewEntries
-            localStorage[LOCALSTORAGE_AUTOLOAD_KEY] = Number(this.autoLoadsNewEntries)
+            this.autoLoadsNewEntries = !this.autoLoadsNewEntries;
+            localStorage[LOCALSTORAGE_AUTOLOAD_KEY] = Number(this.autoLoadsNewEntries);
         },
 
         toggleRecording() {

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -15,6 +15,8 @@ import copyClipboard from './components/CopyClipboard.vue';
 
 import 'bootstrap';
 
+const LOCALSTORAGE_AUTOLOAD_KEY = 'telescope-autoLoadsNewEntries'
+
 let token = document.head.querySelector('meta[name="csrf-token"]');
 
 if (token) {
@@ -66,7 +68,7 @@ new Vue({
                 confirmationCancel: null,
             },
 
-            autoLoadsNewEntries: localStorage.autoLoadsNewEntries === '1',
+            autoLoadsNewEntries: localStorage[LOCALSTORAGE_AUTOLOAD_KEY] === '1',
 
             recording: Telescope.recording,
         };
@@ -84,10 +86,10 @@ new Vue({
         autoLoadNewEntries() {
             if (!this.autoLoadsNewEntries) {
                 this.autoLoadsNewEntries = true;
-                localStorage.autoLoadsNewEntries = 1;
+                localStorage[LOCALSTORAGE_AUTOLOAD_KEY] = 1;
             } else {
                 this.autoLoadsNewEntries = false;
-                localStorage.autoLoadsNewEntries = 0;
+                localStorage[LOCALSTORAGE_AUTOLOAD_KEY] = 0;
             }
         },
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -84,13 +84,8 @@ new Vue({
 
     methods: {
         autoLoadNewEntries() {
-            if (!this.autoLoadsNewEntries) {
-                this.autoLoadsNewEntries = true;
-                localStorage[LOCALSTORAGE_AUTOLOAD_KEY] = 1;
-            } else {
-                this.autoLoadsNewEntries = false;
-                localStorage[LOCALSTORAGE_AUTOLOAD_KEY] = 0;
-            }
+            this.autoLoadsNewEntries = !this.autoLoadsNewEntries
+            localStorage[LOCALSTORAGE_AUTOLOAD_KEY] = Number(this.autoLoadsNewEntries)
         },
 
         toggleRecording() {


### PR DESCRIPTION
Currently, both [Telescope and Horizon shares the same `autoLoadsNewEntries` key](https://github.com/search?q=org%3Alaravel+localStorage.autoLoadsNewEntries&type=code) in `localStorage`.

## Issue

- you can’t have different setting in Telescope and Horizon (well, you can, but… manual work)
- risk of collision with apps also using this key
- some laptops are burning because of the CPU pressure of handling jobs + Horizon autoloading + Telescope autoloading. 🧯

## Changes

This PR adds a `telescope-` prefix to the `localStorage` key in order to reduce the risks of unwanted side-effects (5a71c8e).

I’ve not provided migration path from the old key to the new one because it may break apps using the legacy key for their own purpose, and I guess it’s fine for Telescope users to enable autoload again with a 1-time action.

I’ve also shorten the code a bit (in 362ff3c) which saves 0.07 KB gzipped.

If it’s okay for you, I can send the same PR to Horizon. Thanks for Telescope, love it!