### PR TITLE
Add authentication guard configuration for Telescope dashboard

### DIFF
--- a/config/telescope.php
+++ b/config/telescope.php
@@ -99,6 +99,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Telescope Authentication Guard
+    |--------------------------------------------------------------------------
+    |
+    | This option defines the authentication guard used to authorize access
+    | to the Telescope dashboard. You may change this value if your
+    | application uses a guard other than the default "web".
+    |
+    */
+
+    'guard' => 'web',
+
+    /*
+    |--------------------------------------------------------------------------
     | Allowed / Ignored Paths & Commands
     |--------------------------------------------------------------------------
     |

--- a/src/TelescopeApplicationServiceProvider.php
+++ b/src/TelescopeApplicationServiceProvider.php
@@ -29,8 +29,10 @@ class TelescopeApplicationServiceProvider extends ServiceProvider
         $guard = config('telescope.guard', null);
 
         Telescope::auth(function ($request) use ($guard) {
+            $user = $request->user($guard);
+
             return app()->environment('local') ||
-                   Gate::check('viewTelescope', [$request->user($guard)]);
+                Gate::forUser($user)->check('viewTelescope');
         });
     }
 

--- a/src/TelescopeApplicationServiceProvider.php
+++ b/src/TelescopeApplicationServiceProvider.php
@@ -26,9 +26,11 @@ class TelescopeApplicationServiceProvider extends ServiceProvider
     {
         $this->gate();
 
-        Telescope::auth(function ($request) {
+        $guard = config('telescope.guard', null);
+
+        Telescope::auth(function ($request) use ($guard) {
             return app()->environment('local') ||
-                   Gate::check('viewTelescope', [$request->user()]);
+                   Gate::check('viewTelescope', [$request->user($guard)]);
         });
     }
 

--- a/stubs/TelescopeServiceProvider.stub
+++ b/stubs/TelescopeServiceProvider.stub
@@ -2,7 +2,6 @@
 
 namespace App\Providers;
 
-use App\Models\User;
 use Illuminate\Support\Facades\Gate;
 use Laravel\Telescope\IncomingEntry;
 use Laravel\Telescope\Telescope;
@@ -56,7 +55,7 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
      */
     protected function gate(): void
     {
-        Gate::define('viewTelescope', function (User $user) {
+        Gate::define('viewTelescope', function ($user) {
             return in_array($user->email, [
                 //
             ]);


### PR DESCRIPTION
While working on **Telescope dashboard authorization**, I needed to use an `admin` guard instead of the default `web` guard.

During research, I found issue **#816**, but it was only a question, and there was no built-in way to configure the guard used by the `viewTelescope` Gate.

This PR addresses that gap by allowing developers to **specify the authentication guard** used when authorizing access to the Telescope dashboard.

### Configuration

A new `guard` option is added to the Telescope configuration:

```php
config/telescope.php

return [

    ...

    'guard' => 'web',

    ...

];
```

### Example (default `web` guard)

```php
/**
 * Register the Telescope gate.
 *
 * This gate determines who can access Telescope in non-local environments.
 */
protected function gate()
{
    Gate::define('viewTelescope', function ($user) {
        return in_array($user->email, [
            'user@guard.test',
        ]);
    });
}
```

### Example (using an `admin` guard)

```php
config/telescope.php

return [

    ...

    'guard' => 'admin',

    ...

];
```

```php
/**
 * Register the Telescope gate.
 *
 * This gate determines who can access Telescope in non-local environments.
 */
protected function gate()
{
    Gate::define('viewTelescope', function ($user) {
        return in_array($user->email, [
            'admin@guard.test',
        ]);
    });
}
```

This makes Telescope easier to integrate into applications that use **multiple guards** or **admin-specific authentication**.