### PR TITLE
Support event-aware tags on queued listeners

### DIFF
--- a/src/ExtractTags.php
+++ b/src/ExtractTags.php
@@ -9,6 +9,7 @@ use Illuminate\Events\CallQueuedListener;
 use Illuminate\Mail\SendQueuedMailable;
 use Illuminate\Notifications\SendQueuedNotifications;
 use ReflectionClass;
+use ReflectionMethod;
 use stdClass;
 
 class ExtractTags
@@ -83,11 +84,16 @@ class ExtractTags
      */
     protected static function tagsForListener($job)
     {
-        return collect(
-            [static::extractListener($job), static::extractEvent($job)]
-        )->map(function ($job) {
-            return static::from($job);
-        })->collapse()->unique()->toArray();
+        $listener = static::extractListener($job);
+        $event = static::extractEvent($job);
+
+        return collect([
+            static::explicitTagsForListener($listener, $event),
+            static::modelsFor([$listener])->map(function ($model) {
+                return FormatModel::given($model);
+            })->all(),
+            static::from($event),
+        ])->collapse()->unique()->toArray();
     }
 
     /**
@@ -101,6 +107,28 @@ class ExtractTags
         return collect($targets)->map(function ($target) {
             return method_exists($target, 'tags') ? $target->tags() : [];
         })->collapse()->unique()->all();
+    }
+
+    /**
+     * Determine explicit tags for the given queued listener.
+     *
+     * @param  object  $listener
+     * @param  mixed  $event
+     * @return array
+     */
+    protected static function explicitTagsForListener($listener, $event)
+    {
+        if (! method_exists($listener, 'tags')) {
+            return [];
+        }
+
+        $method = new ReflectionMethod($listener, 'tags');
+
+        return match (true) {
+            $method->getNumberOfRequiredParameters() === 0 => $listener->tags(),
+            $method->getNumberOfParameters() === 1 && ! $event instanceof stdClass => $listener->tags($event),
+            default => [],
+        };
     }
 
     /**

--- a/tests/Telescope/ExtractTagTest.php
+++ b/tests/Telescope/ExtractTagTest.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Telescope\Tests\Telescope;
 
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Events\CallQueuedListener;
 use Illuminate\Mail\Mailable;
 use Laravel\Telescope\Database\Factories\EntryModelFactory;
 use Laravel\Telescope\ExtractTags;
@@ -40,6 +42,28 @@ class ExtractTagTest extends FeatureTestCase
 
         $this->assertSame($tag, $extracted_tag[0]);
     }
+
+    public function test_extract_tag_from_queued_listener_with_event_aware_tags_method()
+    {
+        $job = new CallQueuedListener(
+            EventAwareTaggedListener::class,
+            'handle',
+            [new EventAwareTaggableEvent]
+        );
+
+        $this->assertSame(['event-aware-tag'], ExtractTags::fromJob($job));
+    }
+
+    public function test_extract_tag_from_queued_listener_with_zero_argument_tags_method()
+    {
+        $job = new CallQueuedListener(
+            ZeroArgumentTaggedListener::class,
+            'handle',
+            [new EventAwareTaggableEvent]
+        );
+
+        $this->assertSame(['zero-argument-tag'], ExtractTags::fromJob($job));
+    }
 }
 
 class DummyMailableWithData extends Mailable
@@ -59,5 +83,36 @@ class DummyMailableWithData extends Mailable
             ->with([
                 'mail_data' => $this->mail_data,
             ]);
+    }
+}
+
+class EventAwareTaggableEvent
+{
+    public string $tag = 'event-aware-tag';
+}
+
+class EventAwareTaggedListener implements ShouldQueue
+{
+    public function handle(EventAwareTaggableEvent $event)
+    {
+        //
+    }
+
+    public function tags(EventAwareTaggableEvent $event)
+    {
+        return [$event->tag];
+    }
+}
+
+class ZeroArgumentTaggedListener implements ShouldQueue
+{
+    public function handle(EventAwareTaggableEvent $event)
+    {
+        //
+    }
+
+    public function tags()
+    {
+        return ['zero-argument-tag'];
     }
 }


### PR DESCRIPTION
## Summary
- support queued listener `tags($event)` methods when Telescope extracts tags from `CallQueuedListener` jobs
- preserve existing zero-argument `tags()` behavior for listeners and jobs
- add regression coverage for both event-aware and zero-argument listener tags

## Problem
Horizon documents queued listener tagging with an event-aware signature, for example `tags(OrderShipped $event): array`.

Telescope currently extracts tags from queued listeners by instantiating the listener and calling `tags()` with no arguments, which raises an argument count error for that documented Horizon pattern.

## Approach
This change keeps the fix scoped to `ExtractTags::tagsForListener()`:
- pass the extracted event when the listener `tags` method accepts one parameter
- continue calling `tags()` with no arguments when the listener method requires none
- continue extracting tags from the queued event payload as before

## Testing
- `vendor/bin/phpunit tests/Telescope/ExtractTagTest.php`
- `vendor/bin/phpunit tests/Watchers/JobWatcherTest.php`