### PR TITLE
Fix Sentinel blocking Telescope behind Docker/reverse proxy

### DIFF
--- a/src/TelescopeSentinelDriver.php
+++ b/src/TelescopeSentinelDriver.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Laravel\Telescope;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Laravel\Sentinel\Drivers\Driver;
+
+class TelescopeSentinelDriver extends Driver
+{
+    /**
+     * The tunnel service hostnames that should be blocked.
+     *
+     * @var array<int, string>
+     */
+    protected $tunnelHostnames = [
+        '.sharedwithexpose.com',
+        '.ngrok-free.app',
+        '.ngrok.io',
+    ];
+
+    /**
+     * Authorize access for the request.
+     */
+    public function authorize(Request $request): bool
+    {
+        if (! $this->app()->environment('local')) {
+            return true;
+        }
+
+        if ($this->isTunnelRequest($request)) {
+            return false;
+        }
+
+        $remoteAddr = $request->server->get('REMOTE_ADDR', '');
+
+        if ($remoteAddr !== '' && $this->isPrivateIp($remoteAddr)) {
+            return true;
+        }
+
+        return $this->authorizeAccessingViaReverseProxies($request);
+    }
+
+    /**
+     * Determine if the request is coming through a known tunnel service.
+     */
+    protected function isTunnelRequest(Request $request): bool
+    {
+        return Str::endsWith($request->host(), $this->tunnelHostnames);
+    }
+}

--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -5,6 +5,7 @@ namespace Laravel\Telescope;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Sentinel\Http\Middleware\SentinelMiddleware;
+use Laravel\Sentinel\Sentinel;
 use Laravel\Telescope\Actions\UninstallAction;
 use Laravel\Telescope\Contracts\ClearableRepository;
 use Laravel\Telescope\Contracts\EntriesRepository;
@@ -27,6 +28,8 @@ class TelescopeServiceProvider extends ServiceProvider
         if (! config('telescope.enabled')) {
             return;
         }
+
+        Sentinel::extend('telescope', fn ($app) => new TelescopeSentinelDriver(fn () => $app));
 
         Route::middlewareGroup('telescope', [
             SentinelMiddleware::class.':telescope',

--- a/tests/TelescopeSentinelDriverTest.php
+++ b/tests/TelescopeSentinelDriverTest.php
@@ -1,0 +1,379 @@
+<?php
+
+namespace Laravel\Telescope\Tests;
+
+use Illuminate\Http\Request;
+use Laravel\Sentinel\Sentinel;
+use Laravel\Telescope\TelescopeSentinelDriver;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+
+class TelescopeSentinelDriverTest extends FeatureTestCase
+{
+    /**
+     * Create a driver instance with the given environment.
+     */
+    protected function createDriver(string $environment = 'local'): TelescopeSentinelDriver
+    {
+        return new TelescopeSentinelDriver(function () use ($environment) {
+            $app = $this->app;
+            $app->detectEnvironment(fn () => $environment);
+
+            return $app;
+        });
+    }
+
+    /**
+     * Create a request with the given parameters.
+     */
+    protected function createRequest(
+        string $remoteAddr = '127.0.0.1',
+        string $host = 'localhost',
+        array $trustedProxies = [],
+        ?string $forwardedFor = null,
+    ): Request {
+        $server = [
+            'REMOTE_ADDR' => $remoteAddr,
+            'HTTP_HOST' => $host,
+            'SERVER_NAME' => $host,
+        ];
+
+        if ($forwardedFor !== null) {
+            $server['HTTP_X_FORWARDED_FOR'] = $forwardedFor;
+        }
+
+        $symfonyRequest = new SymfonyRequest(
+            query: [],
+            request: [],
+            attributes: [],
+            cookies: [],
+            files: [],
+            server: $server,
+        );
+
+        if (! empty($trustedProxies)) {
+            Request::setTrustedProxies($trustedProxies, Request::HEADER_X_FORWARDED_FOR);
+        }
+
+        return Request::createFromBase($symfonyRequest);
+    }
+
+    /** {@inheritdoc} */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        Request::setTrustedProxies([], Request::HEADER_X_FORWARDED_FOR);
+
+        parent::tearDown();
+    }
+
+    // ---------------------------------------------------------------
+    // Non-local environment — Sentinel should never block
+    // ---------------------------------------------------------------
+
+    public function test_non_local_environment_always_allows_access(): void
+    {
+        $driver = $this->createDriver('production');
+
+        $request = $this->createRequest('203.0.113.50', 'myapp.com');
+        $this->assertTrue($driver->authorize($request));
+    }
+
+    public function test_staging_environment_always_allows_access(): void
+    {
+        $driver = $this->createDriver('staging');
+
+        $request = $this->createRequest('203.0.113.50', 'staging.myapp.com');
+        $this->assertTrue($driver->authorize($request));
+    }
+
+    // ---------------------------------------------------------------
+    // Normal local development — should allow
+    // ---------------------------------------------------------------
+
+    public function test_local_access_from_localhost_is_allowed(): void
+    {
+        $driver = $this->createDriver();
+
+        $request = $this->createRequest('127.0.0.1', 'localhost');
+        $this->assertTrue($driver->authorize($request));
+    }
+
+    public function test_local_access_from_ipv6_loopback_is_allowed(): void
+    {
+        $driver = $this->createDriver();
+
+        $request = $this->createRequest('::1', 'localhost');
+        $this->assertTrue($driver->authorize($request));
+    }
+
+    // ---------------------------------------------------------------
+    // Docker / reverse proxy — should allow (the bug fix)
+    // ---------------------------------------------------------------
+
+    public function test_docker_proxy_with_private_remote_addr_is_allowed(): void
+    {
+        $driver = $this->createDriver();
+
+        // Docker gateway connects from 172.18.0.1 (private), but X-Forwarded-For
+        // resolves to a non-private IP due to NAT translation.
+        $request = $this->createRequest(
+            remoteAddr: '172.18.0.1',
+            host: 'localhost',
+            trustedProxies: ['172.18.0.1'],
+            forwardedFor: '172.67.152.165',
+        );
+
+        $this->assertTrue($driver->authorize($request));
+    }
+
+    public function test_docker_proxy_with_10_network_is_allowed(): void
+    {
+        $driver = $this->createDriver();
+
+        $request = $this->createRequest(
+            remoteAddr: '10.0.0.1',
+            host: 'localhost',
+            trustedProxies: ['10.0.0.1'],
+            forwardedFor: '203.0.113.50',
+        );
+
+        $this->assertTrue($driver->authorize($request));
+    }
+
+    public function test_docker_proxy_with_192_168_network_is_allowed(): void
+    {
+        $driver = $this->createDriver();
+
+        $request = $this->createRequest(
+            remoteAddr: '192.168.1.1',
+            host: 'myapp.test',
+            trustedProxies: ['192.168.1.1'],
+            forwardedFor: '203.0.113.50',
+        );
+
+        $this->assertTrue($driver->authorize($request));
+    }
+
+    public function test_docker_proxy_with_wildcard_trusted_proxies_is_allowed(): void
+    {
+        $driver = $this->createDriver();
+
+        // TRUSTED_PROXIES=* is common in Sail/Docker setups
+        $request = $this->createRequest(
+            remoteAddr: '172.18.0.1',
+            host: 'localhost',
+            trustedProxies: ['0.0.0.0/0'],
+            forwardedFor: '172.67.152.165',
+        );
+
+        $this->assertTrue($driver->authorize($request));
+    }
+
+    // ---------------------------------------------------------------
+    // Herd .test domains — should allow
+    // ---------------------------------------------------------------
+
+    public function test_herd_test_domain_is_allowed(): void
+    {
+        $driver = $this->createDriver();
+
+        $request = $this->createRequest('127.0.0.1', 'myapp.test');
+        $this->assertTrue($driver->authorize($request));
+    }
+
+    public function test_herd_test_domain_behind_proxy_is_allowed(): void
+    {
+        $driver = $this->createDriver();
+
+        $request = $this->createRequest(
+            remoteAddr: '172.18.0.1',
+            host: 'myapp.test',
+            trustedProxies: ['172.18.0.1'],
+            forwardedFor: '192.168.1.100',
+        );
+
+        $this->assertTrue($driver->authorize($request));
+    }
+
+    // ---------------------------------------------------------------
+    // Expose tunnel — should block
+    // ---------------------------------------------------------------
+
+    public function test_expose_tunnel_is_blocked(): void
+    {
+        $driver = $this->createDriver();
+
+        // Expose sets REMOTE_ADDR to 127.0.0.1 (private) but the request
+        // is actually from the internet via the tunnel hostname.
+        $request = $this->createRequest('127.0.0.1', 'myapp.sharedwithexpose.com');
+        $this->assertFalse($driver->authorize($request));
+    }
+
+    public function test_expose_tunnel_is_blocked_even_with_trusted_proxy(): void
+    {
+        $driver = $this->createDriver();
+
+        $request = $this->createRequest(
+            remoteAddr: '127.0.0.1',
+            host: 'myapp.sharedwithexpose.com',
+            trustedProxies: ['127.0.0.1'],
+            forwardedFor: '203.0.113.50',
+        );
+
+        $this->assertFalse($driver->authorize($request));
+    }
+
+    public function test_expose_tunnel_is_blocked_with_private_forwarded_ip(): void
+    {
+        $driver = $this->createDriver();
+
+        // Even if the forwarded IP happens to be private, the tunnel hostname
+        // should still cause blocking.
+        $request = $this->createRequest(
+            remoteAddr: '127.0.0.1',
+            host: 'myapp.sharedwithexpose.com',
+            trustedProxies: ['127.0.0.1'],
+            forwardedFor: '192.168.1.100',
+        );
+
+        $this->assertFalse($driver->authorize($request));
+    }
+
+    // ---------------------------------------------------------------
+    // ngrok tunnel — should block
+    // ---------------------------------------------------------------
+
+    public function test_ngrok_free_tunnel_is_blocked(): void
+    {
+        $driver = $this->createDriver();
+
+        $request = $this->createRequest('127.0.0.1', 'abc123.ngrok-free.app');
+        $this->assertFalse($driver->authorize($request));
+    }
+
+    public function test_ngrok_io_tunnel_is_blocked(): void
+    {
+        $driver = $this->createDriver();
+
+        $request = $this->createRequest('127.0.0.1', 'abc123.ngrok.io');
+        $this->assertFalse($driver->authorize($request));
+    }
+
+    public function test_ngrok_tunnel_is_blocked_even_with_trusted_proxy(): void
+    {
+        $driver = $this->createDriver();
+
+        $request = $this->createRequest(
+            remoteAddr: '127.0.0.1',
+            host: 'abc123.ngrok-free.app',
+            trustedProxies: ['127.0.0.1'],
+            forwardedFor: '203.0.113.50',
+        );
+
+        $this->assertFalse($driver->authorize($request));
+    }
+
+    // ---------------------------------------------------------------
+    // Public IP without proxy — should block
+    // ---------------------------------------------------------------
+
+    public function test_public_remote_addr_without_proxy_is_allowed_by_driver(): void
+    {
+        $driver = $this->createDriver();
+
+        // A public REMOTE_ADDR with no trusted proxy and no tunnel hostname.
+        // authorizeAccessingViaReverseProxies() allows this because the request
+        // is not claiming to be from a trusted proxy.
+        $request = $this->createRequest('203.0.113.50', 'myapp.com');
+        $this->assertTrue($driver->authorize($request));
+    }
+
+    public function test_public_ip_via_trusted_proxy_is_blocked(): void
+    {
+        $driver = $this->createDriver();
+
+        // A public IP coming through a trusted proxy with a non-private resolved IP
+        // should be blocked by the parent's authorizeAccessingViaReverseProxies().
+        $request = $this->createRequest(
+            remoteAddr: '203.0.113.1',
+            host: 'myapp.com',
+            trustedProxies: ['203.0.113.1'],
+            forwardedFor: '198.51.100.50',
+        );
+
+        $this->assertFalse($driver->authorize($request));
+    }
+
+    // ---------------------------------------------------------------
+    // Tunnel blocking in non-local env — should not block
+    // ---------------------------------------------------------------
+
+    public function test_tunnel_hostnames_are_not_blocked_in_production(): void
+    {
+        $driver = $this->createDriver('production');
+
+        $request = $this->createRequest('127.0.0.1', 'myapp.sharedwithexpose.com');
+        $this->assertTrue($driver->authorize($request));
+    }
+
+    public function test_ngrok_hostname_is_not_blocked_in_production(): void
+    {
+        $driver = $this->createDriver('production');
+
+        $request = $this->createRequest('127.0.0.1', 'abc123.ngrok-free.app');
+        $this->assertTrue($driver->authorize($request));
+    }
+
+    // ---------------------------------------------------------------
+    // Integration — verify driver resolution through Sentinel manager
+    // ---------------------------------------------------------------
+
+    public function test_sentinel_resolves_telescope_driver(): void
+    {
+        $driver = Sentinel::driver('telescope');
+
+        $this->assertInstanceOf(TelescopeSentinelDriver::class, $driver);
+    }
+
+    public function test_sentinel_fallback_does_not_replace_telescope_driver(): void
+    {
+        $driver = Sentinel::driverOrFallback('telescope');
+
+        $this->assertInstanceOf(TelescopeSentinelDriver::class, $driver);
+    }
+
+    // ---------------------------------------------------------------
+    // Integration — full middleware pipeline (HTTP test)
+    // ---------------------------------------------------------------
+
+    public function test_telescope_accessible_in_local_env_via_middleware(): void
+    {
+        $this->app->detectEnvironment(fn () => 'local');
+
+        $this->get('/telescope/telescope-api/mail/1', [
+            'REMOTE_ADDR' => '127.0.0.1',
+        ])->assertStatus(404); // 404 = passed Sentinel + auth, entry just doesn't exist
+    }
+
+    public function test_telescope_blocked_via_tunnel_hostname_through_middleware(): void
+    {
+        $this->app->detectEnvironment(fn () => 'local');
+
+        $this->get(
+            'http://myapp.sharedwithexpose.com/telescope/telescope-api/mail/1',
+            ['REMOTE_ADDR' => '127.0.0.1'],
+        )->assertStatus(401);
+    }
+
+    public function test_docker_proxy_allowed_through_full_middleware_stack(): void
+    {
+        $this->app->detectEnvironment(fn () => 'local');
+
+        Request::setTrustedProxies(['172.18.0.1'], Request::HEADER_X_FORWARDED_FOR);
+
+        $this->get('/telescope/telescope-api/mail/1', [
+            'REMOTE_ADDR' => '172.18.0.1',
+            'HTTP_X_FORWARDED_FOR' => '172.67.152.165',
+        ])->assertStatus(404); // 404 = passed Sentinel + auth, entry just doesn't exist
+    }
+}


### PR DESCRIPTION
Fixes #1691

## Problem

After Sentinel was added in v5.18.0, Telescope returns 401 when accessed locally through Docker/reverse proxy setups with trusted proxies configured. This affects Laravel Sail, Docker Desktop, and any local reverse proxy (nginx, Caddy, etc.).

**Root cause:** Sentinel's default Laravel driver has two issues:

1. `authorizeAccessingViaReverseProxies()` checks `$request->ip()` (resolved via `X-Forwarded-For` after trusted proxy headers), which can be a non-private IP after NAT translation — even though the actual connecting machine (`REMOTE_ADDR`) is on a private Docker network.

2. The tunnel hostname check (Expose, ngrok) is gated behind `! $request->isFromTrustedProxy()`, so configuring `TRUSTED_PROXIES=*` (standard in Sail/Docker) silently disables tunnel blocking entirely.

## Solution

Registers a custom `telescope` Sentinel driver via `Sentinel::extend()` that fixes both issues by changing the check order:

1. **Non-local env** → pass through (same as default driver)
2. **Always check tunnel hostnames** (`.sharedwithexpose.com`, `.ngrok-free.app`, `.ngrok.io`) → block, **regardless of proxy configuration**
3. **Check raw `REMOTE_ADDR`** (before trusted proxy resolution) → if private, allow (Docker/local proxy)
4. **Fallback** to parent's `authorizeAccessingViaReverseProxies()` for edge cases

### Why this addresses the Expose concern

[As noted in the previous PR](https://github.com/JoshSalway/telescope/pull/1#discussion_r2006662651), Expose sets `REMOTE_ADDR` to `127.0.0.1` even when accessed from a different device/network. Simply checking if `REMOTE_ADDR` is private would defeat Sentinel's security.

This driver solves it by checking the **hostname first**: tunnel hostnames are blocked before the private-IP check ever runs. So Expose (`REMOTE_ADDR=127.0.0.1`, `Host: *.sharedwithexpose.com`) is correctly blocked, while Docker (`REMOTE_ADDR=172.18.0.1`, `Host: localhost`) is correctly allowed.

## Test results

### Unit tests (25 tests, 25 assertions — all pass)

Covers: normal local dev, IPv6 loopback, Docker proxy (172.x, 10.x, 192.168.x, wildcard), Herd `.test` domains, Expose tunnel (with/without proxy, with private forwarded IP), ngrok tunnel (free/io, with proxy), public IP edge cases, tunnels in production, driver resolution through Sentinel manager, and full middleware pipeline integration.

### Live HTTP tests against a real Laravel 12 app (`APP_ENV=local`, `TRUSTED_PROXIES=*`)

| Scenario | Host | X-Forwarded-For | Expected | Actual |
|----------|------|-----------------|----------|--------|
| Normal localhost | `localhost` | — | 200 | ✅ 200 |
| Herd `.test` domain | `myapp.test` | — | 200 | ✅ 200 |
| Docker behind proxy | `localhost` | `172.67.152.165` | 200 | ✅ 200 |
| Expose tunnel | `*.sharedwithexpose.com` | — | 401 | ✅ 401 |
| Expose + trusted proxy | `*.sharedwithexpose.com` | `203.0.113.50` | 401 | ✅ 401 |
| Expose + private fwd IP | `*.sharedwithexpose.com` | `192.168.1.100` | 401 | ✅ 401 |
| ngrok-free tunnel | `*.ngrok-free.app` | — | 401 | ✅ 401 |
| ngrok + trusted proxy | `*.ngrok-free.app` | `203.0.113.50` | 401 | ✅ 401 |
| ngrok.io tunnel | `*.ngrok.io` | — | 401 | ✅ 401 |

## Files changed

- **`src/TelescopeSentinelDriver.php`** (new) — Custom Sentinel driver
- **`src/TelescopeServiceProvider.php`** (+3 lines) — Register the driver
- **`tests/TelescopeSentinelDriverTest.php`** (new) — 25 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)