### PR TITLE
Update Symfony console and var-dumper versions to support v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         "ext-json": "*",
         "laravel/framework": "^8.37|^9.0|^10.0|^11.0|^12.0|^13.0",
         "laravel/sentinel": "^1.0",
-        "symfony/console": "^5.3|^6.0|^7.0",
-        "symfony/var-dumper": "^5.0|^6.0|^7.0"
+        "symfony/console": "^5.3|^6.0|^7.0|^8.0",
+        "symfony/var-dumper": "^5.0|^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "ext-gd": "*",


### PR DESCRIPTION
Updates Symfony versions to allow v8. without this , the installation fails on laravel 13 projects.

Fixes #1698 