### PR TITLE
Fix ExtractTags crash for listeners with event-typed tags() method (fixes laravel/telescope#1693)

### DIFF
--- a/src/ExtractTags.php
+++ b/src/ExtractTags.php
@@ -9,6 +9,7 @@ use Illuminate\Events\CallQueuedListener;
 use Illuminate\Mail\SendQueuedMailable;
 use Illuminate\Notifications\SendQueuedNotifications;
 use ReflectionClass;
+use ReflectionMethod;
 use stdClass;
 
 class ExtractTags
@@ -99,7 +100,15 @@ class ExtractTags
     protected static function explicitTags(array $targets)
     {
         return collect($targets)->map(function ($target) {
-            return method_exists($target, 'tags') ? $target->tags() : [];
+            if (! method_exists($target, 'tags')) {
+                return [];
+            }
+
+            if ((new ReflectionMethod($target, 'tags'))->getNumberOfRequiredParameters() > 0) {
+                return [];
+            }
+
+            return $target->tags();
         })->collapse()->unique()->all();
     }
 

--- a/tests/Telescope/ExtractTagTest.php
+++ b/tests/Telescope/ExtractTagTest.php
@@ -40,6 +40,40 @@ class ExtractTagTest extends FeatureTestCase
 
         $this->assertSame($tag, $extracted_tag[0]);
     }
+
+    public function test_extract_tags_from_object_with_tags_method_requiring_arguments()
+    {
+        $listener = new DummyListenerWithEventTags;
+
+        $tags = ExtractTags::from($listener);
+
+        $this->assertSame([], $tags);
+    }
+
+    public function test_extract_tags_from_object_with_tags_method_without_arguments()
+    {
+        $job = new DummyJobWithTags;
+
+        $tags = ExtractTags::from($job);
+
+        $this->assertSame(['custom-tag'], $tags);
+    }
+}
+
+class DummyListenerWithEventTags
+{
+    public function tags(\stdClass $event): array
+    {
+        return ['shipment'];
+    }
+}
+
+class DummyJobWithTags
+{
+    public function tags(): array
+    {
+        return ['custom-tag'];
+    }
 }
 
 class DummyMailableWithData extends Mailable


### PR DESCRIPTION
## Summary

Fixes laravel/telescope#1693 — `ExtractTags::explicitTags()` crashes with "Too few arguments" when a queued event listener defines `tags(SomeEvent \$event)` as documented by Horizon.

## Steps to Reproduce

1. Install Laravel with Horizon and Telescope enabled
2. Create a queued event listener with the Horizon-documented `tags()` signature:
   ```php
   class SendShipmentNotification implements ShouldQueue
   {
       public function tags(OrderShipped \$event): array
       {
           return ['shipment'];
       }
   }
   ```
3. Dispatch the event so the listener is queued
4. Telescope crashes:
   ```
   Too few arguments to function App\Listeners\...\tags(), 0 passed in
   vendor/laravel/telescope/src/ExtractTags.php on line 102 and exactly 1 expected
   ```

## Before (Bug)

`ExtractTags::explicitTags()` calls `\$target->tags()` with no arguments. When a queued event listener uses Horizon's documented `tags(SomeEvent \$event)` method signature, the call fails because the method requires an event argument that Telescope doesn't provide.

## After (Fix)

Uses `ReflectionMethod::getNumberOfRequiredParameters()` to check if the `tags()` method requires arguments before calling it. If arguments are required, returns an empty array instead of crashing.

## Root Cause

Telescope and Horizon have different expectations for the `tags()` method signature. Horizon documents `tags(Event \$event)` for event listeners. Telescope calls `tags()` with no arguments. These are incompatible when both packages are installed.

## The Fix

```php
if ((new ReflectionMethod(\$target, 'tags'))->getNumberOfRequiredParameters() > 0) {
    return [];
}
return \$target->tags();
```

## Breaking Changes

None. Listeners with event-typed `tags()` methods will simply not have their tags extracted by Telescope (they previously crashed).

## Files Changed

- `src/ExtractTags.php` — Added parameter count check before calling `tags()` (+8/-1)
- `tests/Telescope/ExtractTagTest.php` — 2 new tests for parameterized and non-parameterized `tags()` methods (+34 lines)

## Test Results

- `test_extract_tags_from_object_with_tags_method_requiring_arguments` — passes (returns empty array)
- `test_extract_tags_from_object_with_tags_method_without_arguments` — passes (returns tags normally)
- All existing ExtractTag tests pass