### PR TITLE
Fix: Hardcoded config in Service Provider

### DIFF
--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -161,11 +161,11 @@ class TelescopeServiceProvider extends ServiceProvider
 
         $this->app->when(DatabaseEntriesRepository::class)
             ->needs('$connection')
-            ->give(fn() => config('telescope.storage.database.connection'));
+            ->give(fn () => config('telescope.storage.database.connection'));
 
         $this->app->when(DatabaseEntriesRepository::class)
             ->needs('$chunkSize')
-            ->give(fn() => config('telescope.storage.database.chunk'));
+            ->give(fn () => config('telescope.storage.database.chunk'));
     }
 
     /**

--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -161,11 +161,11 @@ class TelescopeServiceProvider extends ServiceProvider
 
         $this->app->when(DatabaseEntriesRepository::class)
             ->needs('$connection')
-            ->give(config('telescope.storage.database.connection'));
+            ->give(fn() => config('telescope.storage.database.connection'));
 
         $this->app->when(DatabaseEntriesRepository::class)
             ->needs('$chunkSize')
-            ->give(config('telescope.storage.database.chunk'));
+            ->give(fn() => config('telescope.storage.database.chunk'));
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue where the config is overridden at runtime.

In my case, it’s an additional developer package that reconfigures several tools, including Telescope.

Using a closure ensures that the config is retrieved when it’s needed, rather than at registration time.