### PR TITLE
[5.x] Fix workflow YAML syntax and Laravel 13 CSRF test failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - *.x
+      - '*.x'
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/tests/Http/AuthorizationTest.php
+++ b/tests/Http/AuthorizationTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Telescope\Tests\Http;
 
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
@@ -31,6 +32,7 @@ class AuthorizationTest extends FeatureTestCase
 
         $this->withoutMiddleware([VerifyCsrfToken::class]);
         $this->withoutMiddleware([ValidateCsrfToken::class]);
+        $this->withoutMiddleware([PreventRequestForgery::class]);
     }
 
     /** {@inheritdoc} */

--- a/tests/Http/RouteTest.php
+++ b/tests/Http/RouteTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Telescope\Tests\Http;
 
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
 use Illuminate\Testing\TestResponse;
 use Laravel\Telescope\Database\Factories\EntryModelFactory;
@@ -20,7 +21,7 @@ class RouteTest extends FeatureTestCase
     {
         parent::setUp();
 
-        $this->withoutMiddleware([Authorize::class, VerifyCsrfToken::class, ValidateCsrfToken::class]);
+        $this->withoutMiddleware([Authorize::class, VerifyCsrfToken::class, ValidateCsrfToken::class, PreventRequestForgery::class]);
 
         $this->registerAssertJsonExactFragmentMacro();
     }


### PR DESCRIPTION
## Summary

Two issues preventing tests from running and passing on the `5.x` branch.

### 1. Broken workflow file — all matrices affected (since 2026-02-20)

PR #1686 (Laravel 13.x Compatibility) accidentally unquoted `'*.x'` to `*.x` in `.github/workflows/tests.yml`. In YAML, `*` is a reserved character (alias node indicator), causing GitHub Actions to reject the workflow file. **No tests have been running** on push or schedule for over 5 weeks.

**Fix:** Re-quote `*.x` to `'*.x'`.

### 2. Laravel 13 CSRF middleware rename — 36 test failures

Laravel 13 renamed the `web` middleware group's CSRF class from `ValidateCsrfToken` to `PreventRequestForgery`. Telescope's HTTP tests disable CSRF via `withoutMiddleware()` but only listed the old class names (`VerifyCsrfToken`, `ValidateCsrfToken`). The new `PreventRequestForgery` middleware stayed active in the pipeline, so every POST request returned **419 CSRF token mismatch**.

The `runningUnitTests()` bypass in `PreventRequestForgery` doesn't help here because Telescope's `FeatureTestCase` sets the app environment to `'self-testing'` (not `'testing'`), so the bypass doesn't activate.

**Fix:** Add `PreventRequestForgery::class` to the `withoutMiddleware` calls in `AuthorizationTest.php` and `RouteTest.php`.

### CI result

All **20/20 matrix jobs pass** — PHP 8.0–8.5 × Laravel 8–13, static analysis, StyleCI.