### PR TITLE
Add "Copy as Markdown" button to all entry detail screens

### DIFF
--- a/resources/js/components/PreviewScreen.vue
+++ b/resources/js/components/PreviewScreen.vue
@@ -19,6 +19,7 @@ export default {
             entry: null,
             batch: null,
             ready: false,
+            copied: false,
 
             updateEntryTimeout: null,
             updateEntryTimer: 2500,
@@ -103,6 +104,22 @@ export default {
 
 
         /**
+         * Copy the entry as Markdown to the clipboard.
+         */
+        copyMarkdown() {
+            axios.get(Telescope.basePath + '/telescope-api/' + this.resource + '/' + this.id + '/markdown')
+                .then(response => {
+                    navigator.clipboard.writeText(response.data).then(() => {
+                        this.copied = true;
+                        setTimeout(() => { this.copied = false }, 2000);
+                    });
+                })
+                .catch(() => {
+                    this.alertError('Failed to copy markdown.');
+                });
+        },
+
+        /**
          * Update the existing entry if needed.
          */
         updateEntry(){
@@ -132,6 +149,16 @@ export default {
         <div class="card overflow-hidden">
             <div class="card-header d-flex align-items-center justify-content-between">
                 <h2 class="h6 m-0">{{ this.title }}</h2>
+
+                <button v-if="ready && entry" class="btn btn-primary" @click="copyMarkdown">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" style="width: 1.1rem; height: 1.1rem; vertical-align: text-bottom; margin-right: 0.3rem;">
+                        <path v-if="!copied" d="M8 3a1 1 0 011-1h2a1 1 0 110 2H9a1 1 0 01-1-1z"></path>
+                        <path v-if="!copied" d="M6 3a2 2 0 00-2 2v11a2 2 0 002 2h8a2 2 0 002-2V5a2 2 0 00-2-2 3 3 0 01-3 3H9a3 3 0 01-3-3z"></path>
+                        <path v-if="copied" d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"></path>
+                        <path v-if="copied" fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm9.707 5.707a1 1 0 00-1.414-1.414L9 12.586l-1.293-1.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
+                    </svg>
+                    {{ copied ? 'Copied!' : 'Copy as Markdown' }}
+                </button>
             </div>
 
             <div

--- a/resources/views/markdown/batch.blade.php
+++ b/resources/views/markdown/batch.blade.php
@@ -1,0 +1,22 @@
+# Batch Details
+
+- **Name:** {!! $name ?? $id ?? '' !!}
+- **Status:** {!! $failedJobs > 0 ? 'Failures' : ($pendingJobs > 0 ? 'Pending' : 'Finished') !!}
+- **Total Jobs:** {!! $totalJobs !!}
+- **Pending Jobs:** {!! $pendingJobs !!}
+- **Failed Jobs:** {!! $failedJobs !!}
+- **Progress:** {!! $progress !!}%
+- **Connection:** {!! $connection !!}
+- **Queue:** {!! $queue !!}
+@if(!empty($cancelledAt))
+- **Cancelled At:** {!! $cancelledAt !!}
+@endif
+@if(!empty($finishedAt))
+- **Finished At:** {!! $finishedAt !!}
+@endif
+- **Time:** {!! $createdAt->format('Y-m-d H:i:s') !!}
+@if(isset($hostname))
+- **Hostname:** {!! $hostname !!}
+@endif
+@include('telescope::markdown.partials.user')
+@include('telescope::markdown.partials.tags')

--- a/resources/views/markdown/cache.blade.php
+++ b/resources/views/markdown/cache.blade.php
@@ -1,0 +1,21 @@
+# Cache Details
+
+- **Action:** {!! ucfirst($type) !!}
+- **Key:** {!! $key !!}
+@if(isset($expiration))
+- **Expiration:** {!! $expiration !!}s
+@endif
+- **Time:** {!! $createdAt->format('Y-m-d H:i:s') !!}
+@if(isset($hostname))
+- **Hostname:** {!! $hostname !!}
+@endif
+@include('telescope::markdown.partials.user')
+@include('telescope::markdown.partials.tags')
+@if(isset($value))
+
+## Value
+
+```json
+{!! is_string($value) ? $value : json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) !!}
+```
+@endif

--- a/resources/views/markdown/client_request.blade.php
+++ b/resources/views/markdown/client_request.blade.php
@@ -1,0 +1,44 @@
+# Client Request Details
+
+- **Method:** {!! $method !!}
+- **URL:** {!! $uri !!}
+- **Status:** {!! $response_status !!}
+- **Duration:** {!! $duration ?? 'N/A' !!}ms
+- **Time:** {!! $createdAt->format('Y-m-d H:i:s') !!}
+@if(isset($hostname))
+- **Hostname:** {!! $hostname !!}
+@endif
+@include('telescope::markdown.partials.user')
+@include('telescope::markdown.partials.tags')
+@if(!empty($payload))
+
+## Payload
+
+```json
+{!! json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) !!}
+```
+@endif
+@if(!empty($response))
+
+## Response
+
+```json
+{!! is_string($response) ? $response : json_encode($response, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) !!}
+```
+@endif
+@if(!empty($headers))
+
+## Headers
+
+@foreach($headers as $key => $value)
+* **{!! $key !!}**: {!! is_array($value) ? implode(', ', $value) : $value !!}
+@endforeach
+@endif
+@if(!empty($response_headers))
+
+## Response Headers
+
+@foreach($response_headers as $key => $value)
+* **{!! $key !!}**: {!! is_array($value) ? implode(', ', $value) : $value !!}
+@endforeach
+@endif

--- a/resources/views/markdown/command.blade.php
+++ b/resources/views/markdown/command.blade.php
@@ -1,0 +1,28 @@
+# Command Details
+
+- **Command:** {!! $command !!}
+- **Exit Code:** {!! $exit_code !!}
+- **Time:** {!! $createdAt->format('Y-m-d H:i:s') !!}
+@if(isset($hostname))
+- **Hostname:** {!! $hostname !!}
+@endif
+@include('telescope::markdown.partials.user')
+@include('telescope::markdown.partials.tags')
+@if(!empty($arguments))
+
+## Arguments
+
+```json
+{!! json_encode($arguments, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) !!}
+```
+@endif
+@if(!empty($options))
+
+## Options
+
+```json
+{!! json_encode($options, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) !!}
+```
+@endif
+
+@include('telescope::markdown.partials.related')

--- a/resources/views/markdown/event.blade.php
+++ b/resources/views/markdown/event.blade.php
@@ -1,0 +1,28 @@
+# Event Details
+
+- **Event:** {!! $name !!}
+@if(!empty($broadcast))
+- **Broadcast:** Yes
+@endif
+- **Time:** {!! $createdAt->format('Y-m-d H:i:s') !!}
+@if(isset($hostname))
+- **Hostname:** {!! $hostname !!}
+@endif
+@include('telescope::markdown.partials.user')
+@include('telescope::markdown.partials.tags')
+@if(!empty($listeners))
+
+## Listeners
+
+@foreach($listeners as $listener)
+* {!! is_array($listener) ? $listener['name'] ?? $listener : $listener !!}
+@endforeach
+@endif
+@if(!empty($payload))
+
+## Payload
+
+```json
+{!! json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) !!}
+```
+@endif

--- a/resources/views/markdown/exception.blade.php
+++ b/resources/views/markdown/exception.blade.php
@@ -1,0 +1,32 @@
+# Exception Details
+
+- **Type:** {!! $class !!}
+- **Message:** {!! $message !!}
+- **Location:** {!! $file !!}:{!! $line !!}
+@if(!empty($resolved_at))
+- **Resolved At:** {!! $resolved_at !!}
+@endif
+- **Time:** {!! $createdAt->format('Y-m-d H:i:s') !!}
+@if(isset($hostname))
+- **Hostname:** {!! $hostname !!}
+@endif
+@include('telescope::markdown.partials.user')
+@include('telescope::markdown.partials.tags')
+@if(!empty($context))
+
+## Context
+
+```json
+{!! json_encode($context, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) !!}
+```
+@endif
+
+## Stack Trace
+
+```
+@foreach($trace as $i => $frame)
+{!! $i !!} - {!! $frame['file'] !!}:{!! $frame['line'] !!}
+@endforeach
+```
+
+@include('telescope::markdown.partials.related')

--- a/resources/views/markdown/gate.blade.php
+++ b/resources/views/markdown/gate.blade.php
@@ -1,0 +1,24 @@
+# Gate Details
+
+- **Ability:** {!! $ability !!}
+- **Result:** {!! ucfirst($result) !!}
+@if(!empty($message))
+- **Message:** {!! $message !!}
+@endif
+@if(isset($file))
+- **Location:** {!! $file !!}:{!! $line !!}
+@endif
+- **Time:** {!! $createdAt->format('Y-m-d H:i:s') !!}
+@if(isset($hostname))
+- **Hostname:** {!! $hostname !!}
+@endif
+@include('telescope::markdown.partials.user')
+@include('telescope::markdown.partials.tags')
+@if(!empty($arguments))
+
+## Arguments
+
+```json
+{!! json_encode($arguments, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) !!}
+```
+@endif

--- a/resources/views/markdown/job.blade.php
+++ b/resources/views/markdown/job.blade.php
@@ -1,0 +1,40 @@
+# Job Details
+
+- **Job:** {!! $name !!}
+- **Status:** {!! $status !!}
+- **Connection:** {!! $connection !!}
+- **Queue:** {!! $queue !!}
+- **Tries:** {!! $tries !!}
+@if(isset($timeout))
+- **Timeout:** {!! $timeout !!}s
+@endif
+- **Time:** {!! $createdAt->format('Y-m-d H:i:s') !!}
+@if(isset($hostname))
+- **Hostname:** {!! $hostname !!}
+@endif
+@include('telescope::markdown.partials.user')
+@include('telescope::markdown.partials.tags')
+@if(!empty($data))
+
+## Data
+
+```json
+{!! json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) !!}
+```
+@endif
+@if(!empty($exception))
+
+## Exception
+
+- **{!! $exception['class'] ?? 'Exception' !!}:** {!! $exception['message'] ?? '' !!}
+
+### Stack Trace
+
+```
+@foreach($exception['trace'] ?? [] as $i => $frame)
+{!! $i !!} - {!! $frame['file'] !!}:{!! $frame['line'] !!}
+@endforeach
+```
+@endif
+
+@include('telescope::markdown.partials.related')

--- a/resources/views/markdown/log.blade.php
+++ b/resources/views/markdown/log.blade.php
@@ -1,0 +1,18 @@
+# Log Details
+
+- **Level:** {!! strtoupper($level) !!}
+- **Message:** {!! $message !!}
+- **Time:** {!! $createdAt->format('Y-m-d H:i:s') !!}
+@if(isset($hostname))
+- **Hostname:** {!! $hostname !!}
+@endif
+@include('telescope::markdown.partials.user')
+@include('telescope::markdown.partials.tags')
+@if(!empty($context))
+
+## Context
+
+```json
+{!! json_encode($context, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) !!}
+```
+@endif

--- a/resources/views/markdown/mail.blade.php
+++ b/resources/views/markdown/mail.blade.php
@@ -1,0 +1,33 @@
+# Mail Details
+
+- **Mailable:** {!! $mailable ?? 'Mail' !!}
+@if(!empty($queued))
+- **Queued:** Yes
+@endif
+- **Subject:** {!! $subject ?? '' !!}
+@if(!empty($from))
+- **From:** @foreach($from as $address => $name){!! $name ? "$name <$address>" : $address !!}@if(!$loop->last), @endif @endforeach
+
+@endif
+@if(!empty($to))
+- **To:** @foreach($to as $address => $name){!! $name ? "$name <$address>" : $address !!}@if(!$loop->last), @endif @endforeach
+
+@endif
+@if(!empty($cc))
+- **CC:** @foreach($cc as $address => $name){!! $name ? "$name <$address>" : $address !!}@if(!$loop->last), @endif @endforeach
+
+@endif
+@if(!empty($bcc))
+- **BCC:** @foreach($bcc as $address => $name){!! $name ? "$name <$address>" : $address !!}@if(!$loop->last), @endif @endforeach
+
+@endif
+@if(!empty($replyTo))
+- **Reply To:** @foreach($replyTo as $address => $name){!! $name ? "$name <$address>" : $address !!}@if(!$loop->last), @endif @endforeach
+
+@endif
+- **Time:** {!! $createdAt->format('Y-m-d H:i:s') !!}
+@if(isset($hostname))
+- **Hostname:** {!! $hostname !!}
+@endif
+@include('telescope::markdown.partials.user')
+@include('telescope::markdown.partials.tags')

--- a/resources/views/markdown/model.blade.php
+++ b/resources/views/markdown/model.blade.php
@@ -1,0 +1,21 @@
+# Model Details
+
+- **Action:** {!! $action !!}
+- **Model:** {!! $model !!}
+@if(isset($count))
+- **Count:** {!! $count !!}
+@endif
+- **Time:** {!! $createdAt->format('Y-m-d H:i:s') !!}
+@if(isset($hostname))
+- **Hostname:** {!! $hostname !!}
+@endif
+@include('telescope::markdown.partials.user')
+@include('telescope::markdown.partials.tags')
+@if(!empty($changes))
+
+## Changes
+
+```json
+{!! json_encode($changes, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) !!}
+```
+@endif

--- a/resources/views/markdown/notification.blade.php
+++ b/resources/views/markdown/notification.blade.php
@@ -1,0 +1,14 @@
+# Notification Details
+
+- **Notification:** {!! $notification !!}
+@if(!empty($queued))
+- **Queued:** Yes
+@endif
+- **Channel:** {!! $channel !!}
+- **Notifiable:** {!! $notifiable !!}
+- **Time:** {!! $createdAt->format('Y-m-d H:i:s') !!}
+@if(isset($hostname))
+- **Hostname:** {!! $hostname !!}
+@endif
+@include('telescope::markdown.partials.user')
+@include('telescope::markdown.partials.tags')

--- a/resources/views/markdown/partials/related.blade.php
+++ b/resources/views/markdown/partials/related.blade.php
@@ -1,0 +1,47 @@
+@php
+$queries = $batch->where('type', 'query');
+$exceptions = $batch->where('type', 'exception');
+$logs = $batch->where('type', 'log');
+$events = $batch->where('type', 'event');
+$models = $batch->where('type', 'model');
+@endphp
+@if($queries->isNotEmpty())
+
+## Queries ({!! $queries->count() !!})
+
+@foreach($queries as $query)
+* `{!! $query->content['sql'] !!}` ({!! $query->content['time'] !!}ms)
+@endforeach
+@endif
+@if($exceptions->isNotEmpty())
+
+## Exceptions
+
+@foreach($exceptions as $exception)
+* **{!! $exception->content['class'] !!}**: {!! $exception->content['message'] !!} at {!! $exception->content['file'] !!}:{!! $exception->content['line'] !!}
+@endforeach
+@endif
+@if($logs->isNotEmpty())
+
+## Logs
+
+@foreach($logs as $log)
+* [{!! strtoupper($log->content['level']) !!}] {!! $log->content['message'] !!}
+@endforeach
+@endif
+@if($models->isNotEmpty())
+
+## Models
+
+@foreach($models as $model)
+* {!! $model->content['action'] !!} {!! $model->content['model'] !!}
+@endforeach
+@endif
+@if($events->isNotEmpty())
+
+## Events
+
+@foreach($events as $event)
+* {!! $event->content['name'] !!}
+@endforeach
+@endif

--- a/resources/views/markdown/partials/tags.blade.php
+++ b/resources/views/markdown/partials/tags.blade.php
@@ -1,0 +1,3 @@
+@if(!empty($tags))
+- **Tags:** {!! implode(', ', $tags) !!}
+@endif

--- a/resources/views/markdown/partials/user.blade.php
+++ b/resources/views/markdown/partials/user.blade.php
@@ -1,0 +1,11 @@
+@if(isset($user) && is_array($user))
+@if(isset($user['id']))
+- **User ID:** {!! $user['id'] !!}
+@endif
+@if(isset($user['name']))
+- **User Name:** {!! $user['name'] !!}
+@endif
+@if(isset($user['email']))
+- **User Email:** {!! $user['email'] !!}
+@endif
+@endif

--- a/resources/views/markdown/query.blade.php
+++ b/resources/views/markdown/query.blade.php
@@ -1,0 +1,22 @@
+# Query Details
+
+@if(!empty($slow))
+- **Slow:** Yes
+@endif
+- **Connection:** {!! $connection !!}
+- **Duration:** {!! $time !!}ms
+@if(isset($file))
+- **Location:** {!! $file !!}:{!! $line !!}
+@endif
+- **Time:** {!! $createdAt->format('Y-m-d H:i:s') !!}
+@if(isset($hostname))
+- **Hostname:** {!! $hostname !!}
+@endif
+@include('telescope::markdown.partials.user')
+@include('telescope::markdown.partials.tags')
+
+## SQL
+
+```sql
+{!! $sql !!}
+```

--- a/resources/views/markdown/redis.blade.php
+++ b/resources/views/markdown/redis.blade.php
@@ -1,0 +1,16 @@
+# Redis Command
+
+- **Connection:** {!! $connection !!}
+- **Duration:** {!! $time !!}ms
+- **Time:** {!! $createdAt->format('Y-m-d H:i:s') !!}
+@if(isset($hostname))
+- **Hostname:** {!! $hostname !!}
+@endif
+@include('telescope::markdown.partials.user')
+@include('telescope::markdown.partials.tags')
+
+## Command
+
+```
+{!! $command !!}
+```

--- a/resources/views/markdown/request.blade.php
+++ b/resources/views/markdown/request.blade.php
@@ -1,0 +1,62 @@
+# Request Details
+
+- **Method:** {!! $method !!}
+- **URL:** {!! $uri !!}
+- **Status:** {!! $response_status !!}
+@if(isset($controller_action))
+- **Controller:** {!! $controller_action !!}
+@endif
+- **Duration:** {!! $duration ?? 'N/A' !!}ms
+- **Memory:** {!! $memory !!}MB
+- **IP:** {!! $ip_address !!}
+@if(!empty($middleware))
+- **Middleware:** {!! implode(', ', $middleware) !!}
+@endif
+- **Time:** {!! $createdAt->format('Y-m-d H:i:s') !!}
+@if(isset($hostname))
+- **Hostname:** {!! $hostname !!}
+@endif
+@include('telescope::markdown.partials.user')
+@include('telescope::markdown.partials.tags')
+@if(!empty($payload))
+
+## Payload
+
+```json
+{!! json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) !!}
+```
+@endif
+@if(!empty($response))
+
+## Response
+
+```json
+{!! is_string($response) ? $response : json_encode($response, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) !!}
+```
+@endif
+@if(!empty($headers))
+
+## Headers
+
+@foreach($headers as $key => $value)
+* **{!! $key !!}**: {!! is_array($value) ? implode(', ', $value) : $value !!}
+@endforeach
+@endif
+@if(!empty($response_headers))
+
+## Response Headers
+
+@foreach($response_headers as $key => $value)
+* **{!! $key !!}**: {!! is_array($value) ? implode(', ', $value) : $value !!}
+@endforeach
+@endif
+@if(!empty($session))
+
+## Session
+
+```json
+{!! json_encode($session, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) !!}
+```
+@endif
+
+@include('telescope::markdown.partials.related')

--- a/resources/views/markdown/schedule.blade.php
+++ b/resources/views/markdown/schedule.blade.php
@@ -1,0 +1,24 @@
+# Scheduled Task Details
+
+- **Command:** {!! $command !!}
+@if(!empty($description))
+- **Description:** {!! $description !!}
+@endif
+- **Expression:** {!! $expression !!}
+@if(!empty($timezone))
+- **Timezone:** {!! $timezone !!}
+@endif
+- **Time:** {!! $createdAt->format('Y-m-d H:i:s') !!}
+@if(isset($hostname))
+- **Hostname:** {!! $hostname !!}
+@endif
+@include('telescope::markdown.partials.user')
+@include('telescope::markdown.partials.tags')
+@if(!empty($output))
+
+## Output
+
+```
+{!! $output !!}
+```
+@endif

--- a/resources/views/markdown/view.blade.php
+++ b/resources/views/markdown/view.blade.php
@@ -1,0 +1,26 @@
+# View Details
+
+- **Name:** {!! $name !!}
+- **Path:** {!! $path !!}
+- **Time:** {!! $createdAt->format('Y-m-d H:i:s') !!}
+@if(isset($hostname))
+- **Hostname:** {!! $hostname !!}
+@endif
+@include('telescope::markdown.partials.user')
+@include('telescope::markdown.partials.tags')
+@if(!empty($composers))
+
+## Composers
+
+@foreach($composers as $composer)
+* {!! $composer['name'] !!} ({!! $composer['type'] ?? 'class' !!})
+@endforeach
+@endif
+@if(!empty($data))
+
+## Data
+
+```json
+{!! json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) !!}
+```
+@endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,11 +7,13 @@ Route::post('/telescope-api/mail', 'MailController@index');
 Route::get('/telescope-api/mail/{telescopeEntryId}', 'MailController@show');
 Route::get('/telescope-api/mail/{telescopeEntryId}/preview', 'MailHtmlController@show');
 Route::get('/telescope-api/mail/{telescopeEntryId}/download', 'MailEmlController@show');
+Route::get('/telescope-api/mail/{telescopeEntryId}/markdown', 'MailController@markdown');
 
 // Exception entries...
 Route::post('/telescope-api/exceptions', 'ExceptionController@index');
 Route::get('/telescope-api/exceptions/{telescopeEntryId}', 'ExceptionController@show');
 Route::put('/telescope-api/exceptions/{telescopeEntryId}', 'ExceptionController@update');
+Route::get('/telescope-api/exceptions/{telescopeEntryId}/markdown', 'ExceptionController@markdown');
 
 // Dump entries...
 Route::post('/telescope-api/dumps', 'DumpController@index');
@@ -19,62 +21,77 @@ Route::post('/telescope-api/dumps', 'DumpController@index');
 // Log entries...
 Route::post('/telescope-api/logs', 'LogController@index');
 Route::get('/telescope-api/logs/{telescopeEntryId}', 'LogController@show');
+Route::get('/telescope-api/logs/{telescopeEntryId}/markdown', 'LogController@markdown');
 
 // Notifications entries...
 Route::post('/telescope-api/notifications', 'NotificationsController@index');
 Route::get('/telescope-api/notifications/{telescopeEntryId}', 'NotificationsController@show');
+Route::get('/telescope-api/notifications/{telescopeEntryId}/markdown', 'NotificationsController@markdown');
 
 // Queue entries...
 Route::post('/telescope-api/jobs', 'QueueController@index');
 Route::get('/telescope-api/jobs/{telescopeEntryId}', 'QueueController@show');
+Route::get('/telescope-api/jobs/{telescopeEntryId}/markdown', 'QueueController@markdown');
 
 // Queue Batches entries...
 Route::post('/telescope-api/batches', 'QueueBatchesController@index');
 Route::get('/telescope-api/batches/{telescopeEntryId}', 'QueueBatchesController@show');
+Route::get('/telescope-api/batches/{telescopeEntryId}/markdown', 'QueueBatchesController@markdown');
 
 // Events entries...
 Route::post('/telescope-api/events', 'EventsController@index');
 Route::get('/telescope-api/events/{telescopeEntryId}', 'EventsController@show');
+Route::get('/telescope-api/events/{telescopeEntryId}/markdown', 'EventsController@markdown');
 
 // Gates entries...
 Route::post('/telescope-api/gates', 'GatesController@index');
 Route::get('/telescope-api/gates/{telescopeEntryId}', 'GatesController@show');
+Route::get('/telescope-api/gates/{telescopeEntryId}/markdown', 'GatesController@markdown');
 
 // Cache entries...
 Route::post('/telescope-api/cache', 'CacheController@index');
 Route::get('/telescope-api/cache/{telescopeEntryId}', 'CacheController@show');
+Route::get('/telescope-api/cache/{telescopeEntryId}/markdown', 'CacheController@markdown');
 
 // Queries entries...
 Route::post('/telescope-api/queries', 'QueriesController@index');
 Route::get('/telescope-api/queries/{telescopeEntryId}', 'QueriesController@show');
+Route::get('/telescope-api/queries/{telescopeEntryId}/markdown', 'QueriesController@markdown');
 
 // Eloquent entries...
 Route::post('/telescope-api/models', 'ModelsController@index');
 Route::get('/telescope-api/models/{telescopeEntryId}', 'ModelsController@show');
+Route::get('/telescope-api/models/{telescopeEntryId}/markdown', 'ModelsController@markdown');
 
 // Requests entries...
 Route::post('/telescope-api/requests', 'RequestsController@index');
 Route::get('/telescope-api/requests/{telescopeEntryId}', 'RequestsController@show');
+Route::get('/telescope-api/requests/{telescopeEntryId}/markdown', 'RequestsController@markdown');
 
 // View entries...
 Route::post('/telescope-api/views', 'ViewsController@index');
 Route::get('/telescope-api/views/{telescopeEntryId}', 'ViewsController@show');
+Route::get('/telescope-api/views/{telescopeEntryId}/markdown', 'ViewsController@markdown');
 
 // Artisan Commands entries...
 Route::post('/telescope-api/commands', 'CommandsController@index');
 Route::get('/telescope-api/commands/{telescopeEntryId}', 'CommandsController@show');
+Route::get('/telescope-api/commands/{telescopeEntryId}/markdown', 'CommandsController@markdown');
 
 // Scheduled Commands entries...
 Route::post('/telescope-api/schedule', 'ScheduleController@index');
 Route::get('/telescope-api/schedule/{telescopeEntryId}', 'ScheduleController@show');
+Route::get('/telescope-api/schedule/{telescopeEntryId}/markdown', 'ScheduleController@markdown');
 
 // Redis Commands entries...
 Route::post('/telescope-api/redis', 'RedisController@index');
 Route::get('/telescope-api/redis/{telescopeEntryId}', 'RedisController@show');
+Route::get('/telescope-api/redis/{telescopeEntryId}/markdown', 'RedisController@markdown');
 
 // Client Requests entries...
 Route::post('/telescope-api/client-requests', 'ClientRequestController@index');
 Route::get('/telescope-api/client-requests/{telescopeEntryId}', 'ClientRequestController@show');
+Route::get('/telescope-api/client-requests/{telescopeEntryId}/markdown', 'ClientRequestController@markdown');
 
 // Monitored Tags...
 Route::get('/telescope-api/monitored-tags', 'MonitoredTagController@index');

--- a/src/Http/Controllers/EntryController.php
+++ b/src/Http/Controllers/EntryController.php
@@ -4,6 +4,7 @@ namespace Laravel\Telescope\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\View;
 use Laravel\Telescope\Contracts\EntriesRepository;
 use Laravel\Telescope\Storage\EntryQueryOptions;
 
@@ -56,6 +57,36 @@ abstract class EntryController extends Controller
             'entry' => $entry,
             'batch' => $storage->get(null, EntryQueryOptions::forBatchId($entry->batchId)->limit(-1)),
         ]);
+    }
+
+    /**
+     * Get the entry as a Markdown document.
+     *
+     * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function markdown(EntriesRepository $storage, $id)
+    {
+        $entry = $storage->find($id);
+
+        $view = "telescope::markdown.{$entry->type}";
+
+        abort_unless(View::exists($view), 404);
+
+        $batch = $storage->get(null, EntryQueryOptions::forBatchId($entry->batchId)->limit(-1));
+
+        $serialized = $entry->jsonSerialize();
+
+        return response(
+            view($view, array_merge($entry->content, [
+                'createdAt' => $entry->createdAt,
+                'tags' => $serialized['tags'] ?? [],
+                'batch' => collect($batch)->where('id', '!=', $entry->id),
+            ]))->render(),
+            200,
+            ['Content-Type' => 'text/markdown']
+        );
     }
 
     /**

--- a/tests/Http/MarkdownTest.php
+++ b/tests/Http/MarkdownTest.php
@@ -24,7 +24,7 @@ class MarkdownTest extends FeatureTestCase
     protected function assertMarkdownContains(TestResponse $response, array $expectedStrings): void
     {
         $response->assertOk();
-        $response->assertHeader('Content-Type', 'text/markdown; charset=UTF-8');
+        $this->assertStringStartsWith('text/markdown', $response->headers->get('Content-Type'));
 
         foreach ($expectedStrings as $expected) {
             $this->assertStringContainsString($expected, $response->content());

--- a/tests/Http/MarkdownTest.php
+++ b/tests/Http/MarkdownTest.php
@@ -1,0 +1,451 @@
+<?php
+
+namespace Laravel\Telescope\Tests\Http;
+
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
+use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
+use Illuminate\Testing\TestResponse;
+use Laravel\Telescope\Database\Factories\EntryModelFactory;
+use Laravel\Telescope\EntryType;
+use Laravel\Telescope\Http\Middleware\Authorize;
+use Laravel\Telescope\Tests\FeatureTestCase;
+use Orchestra\Testbench\Http\Middleware\VerifyCsrfToken;
+
+class MarkdownTest extends FeatureTestCase
+{
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutMiddleware([Authorize::class, VerifyCsrfToken::class, ValidateCsrfToken::class, PreventRequestForgery::class]);
+    }
+
+    protected function assertMarkdownContains(TestResponse $response, array $expectedStrings): void
+    {
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'text/markdown; charset=UTF-8');
+
+        foreach ($expectedStrings as $expected) {
+            $this->assertStringContainsString($expected, $response->content());
+        }
+    }
+
+    public function test_exception_markdown()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::EXCEPTION,
+            'content' => [
+                'class' => 'RuntimeException',
+                'file' => 'app/Http/Controllers/UserController.php',
+                'line' => 42,
+                'message' => 'Something went wrong',
+                'context' => null,
+                'trace' => [
+                    ['file' => 'app/Http/Controllers/UserController.php', 'line' => 42],
+                    ['file' => 'vendor/laravel/framework/Router.php', 'line' => 100],
+                ],
+                'line_preview' => [],
+                'hostname' => 'web-01',
+            ],
+        ]);
+
+        $response = $this->get("/telescope/telescope-api/exceptions/{$entry->uuid}/markdown");
+
+        $this->assertMarkdownContains($response, [
+            '# Exception Details',
+            '**Type:** RuntimeException',
+            '**Message:** Something went wrong',
+            '**Location:** app/Http/Controllers/UserController.php:42',
+        ]);
+    }
+
+    public function test_request_markdown()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::REQUEST,
+            'content' => [
+                'method' => 'POST',
+                'uri' => '/api/orders',
+                'controller_action' => 'OrderController@store',
+                'middleware' => ['auth'],
+                'headers' => ['accept' => 'application/json'],
+                'payload' => ['product_id' => 5],
+                'session' => [],
+                'response_headers' => [],
+                'response_status' => 201,
+                'response' => ['id' => 1],
+                'duration' => 150,
+                'memory' => 24,
+                'ip_address' => '127.0.0.1',
+                'hostname' => 'web-01',
+            ],
+        ]);
+
+        $response = $this->get("/telescope/telescope-api/requests/{$entry->uuid}/markdown");
+
+        $this->assertMarkdownContains($response, [
+            '# Request Details',
+            '**Method:** POST',
+            '**URL:** /api/orders',
+            '**Status:** 201',
+        ]);
+    }
+
+    public function test_query_markdown()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::QUERY,
+            'content' => [
+                'connection' => 'mysql',
+                'sql' => 'select * from "users" where "id" = 1',
+                'time' => '12.34',
+                'slow' => false,
+                'file' => 'app/Models/User.php',
+                'line' => 25,
+                'hash' => 'abc123',
+                'hostname' => 'web-01',
+            ],
+        ]);
+
+        $response = $this->get("/telescope/telescope-api/queries/{$entry->uuid}/markdown");
+
+        $this->assertMarkdownContains($response, [
+            'select * from',
+            '**Connection:** mysql',
+            '**Duration:** 12.34ms',
+        ]);
+    }
+
+    public function test_job_markdown()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::JOB,
+            'content' => [
+                'name' => 'App\\Jobs\\ProcessOrder',
+                'status' => 'processed',
+                'connection' => 'redis',
+                'queue' => 'default',
+                'tries' => 3,
+                'timeout' => null,
+                'data' => ['orderId' => 123],
+                'hostname' => 'web-01',
+            ],
+        ]);
+
+        $response = $this->get("/telescope/telescope-api/jobs/{$entry->uuid}/markdown");
+
+        $this->assertMarkdownContains($response, [
+            '# Job Details',
+            '**Job:** App\\Jobs\\ProcessOrder',
+            '**Status:** processed',
+        ]);
+    }
+
+    public function test_log_markdown()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::LOG,
+            'content' => [
+                'level' => 'error',
+                'message' => 'Payment failed for order 123',
+                'context' => ['order_id' => 123],
+                'hostname' => 'web-01',
+            ],
+        ]);
+
+        $response = $this->get("/telescope/telescope-api/logs/{$entry->uuid}/markdown");
+
+        $this->assertMarkdownContains($response, [
+            'ERROR',
+            'Payment failed for order 123',
+        ]);
+    }
+
+    public function test_mail_markdown()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::MAIL,
+            'content' => [
+                'mailable' => 'App\\Mail\\OrderConfirmation',
+                'queued' => false,
+                'from' => ['noreply@example.com' => 'Example App'],
+                'to' => ['user@example.com' => 'John Doe'],
+                'cc' => null,
+                'bcc' => null,
+                'replyTo' => null,
+                'subject' => 'Your Order #123',
+                'html' => '<html></html>',
+                'hostname' => 'web-01',
+            ],
+        ]);
+
+        $response = $this->get("/telescope/telescope-api/mail/{$entry->uuid}/markdown");
+
+        $this->assertMarkdownContains($response, [
+            'OrderConfirmation',
+            'Your Order #123',
+            'user@example.com',
+        ]);
+    }
+
+    public function test_event_markdown()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::EVENT,
+            'content' => [
+                'name' => 'App\\Events\\OrderPlaced',
+                'broadcast' => false,
+                'payload' => ['order_id' => 123],
+                'listeners' => ['App\\Listeners\\SendConfirmation'],
+                'hostname' => 'web-01',
+            ],
+        ]);
+
+        $response = $this->get("/telescope/telescope-api/events/{$entry->uuid}/markdown");
+
+        $this->assertMarkdownContains($response, [
+            'OrderPlaced',
+            'SendConfirmation',
+        ]);
+    }
+
+    public function test_cache_markdown()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::CACHE,
+            'content' => [
+                'type' => 'hit',
+                'key' => 'users.1.profile',
+                'value' => 'cached-data',
+                'expiration' => null,
+                'hostname' => 'web-01',
+            ],
+        ]);
+
+        $response = $this->get("/telescope/telescope-api/cache/{$entry->uuid}/markdown");
+
+        $this->assertMarkdownContains($response, [
+            'Hit',
+            'users.1.profile',
+        ]);
+    }
+
+    public function test_redis_markdown()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::REDIS,
+            'content' => [
+                'connection' => 'default',
+                'command' => 'GET telescope:pause-recording',
+                'time' => '0.15',
+                'hostname' => 'web-01',
+            ],
+        ]);
+
+        $response = $this->get("/telescope/telescope-api/redis/{$entry->uuid}/markdown");
+
+        $this->assertMarkdownContains($response, [
+            'GET telescope:pause-recording',
+            '**Connection:** default',
+            '**Duration:** 0.15ms',
+        ]);
+    }
+
+    public function test_model_markdown()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::MODEL,
+            'content' => [
+                'action' => 'updated',
+                'model' => 'App\\Models\\User:1',
+                'changes' => ['name' => ['old', 'new']],
+                'hostname' => 'web-01',
+            ],
+        ]);
+
+        $response = $this->get("/telescope/telescope-api/models/{$entry->uuid}/markdown");
+
+        $this->assertMarkdownContains($response, [
+            '# Model Details',
+            '**Action:** updated',
+            '**Model:** App\\Models\\User:1',
+        ]);
+    }
+
+    public function test_notification_markdown()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::NOTIFICATION,
+            'content' => [
+                'notification' => 'App\\Notifications\\InvoicePaid',
+                'queued' => true,
+                'notifiable' => 'App\\Models\\User:1',
+                'channel' => 'mail',
+                'hostname' => 'web-01',
+            ],
+        ]);
+
+        $response = $this->get("/telescope/telescope-api/notifications/{$entry->uuid}/markdown");
+
+        $this->assertMarkdownContains($response, [
+            '# Notification Details',
+            '**Notification:** App\\Notifications\\InvoicePaid',
+            '**Channel:** mail',
+        ]);
+    }
+
+    public function test_gate_markdown()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::GATE,
+            'content' => [
+                'ability' => 'update',
+                'result' => 'denied',
+                'message' => 'This action is unauthorized.',
+                'file' => null,
+                'line' => null,
+                'arguments' => ['App\\Models\\Post'],
+                'hostname' => 'web-01',
+            ],
+        ]);
+
+        $response = $this->get("/telescope/telescope-api/gates/{$entry->uuid}/markdown");
+
+        $this->assertMarkdownContains($response, [
+            '# Gate Details',
+            '**Ability:** update',
+            '**Result:** Denied',
+        ]);
+    }
+
+    public function test_command_markdown()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::COMMAND,
+            'content' => [
+                'command' => 'migrate:fresh',
+                'exit_code' => 0,
+                'arguments' => ['command' => 'migrate:fresh'],
+                'options' => ['seed' => true],
+                'hostname' => 'web-01',
+            ],
+        ]);
+
+        $response = $this->get("/telescope/telescope-api/commands/{$entry->uuid}/markdown");
+
+        $this->assertMarkdownContains($response, [
+            '# Command Details',
+            '**Command:** migrate:fresh',
+            '**Exit Code:** 0',
+        ]);
+    }
+
+    public function test_schedule_markdown()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::SCHEDULED_TASK,
+            'content' => [
+                'command' => 'inspire',
+                'description' => 'Display an inspiring quote',
+                'expression' => '* * * * *',
+                'timezone' => 'UTC',
+                'user' => null,
+                'output' => null,
+                'hostname' => 'web-01',
+            ],
+        ]);
+
+        $response = $this->get("/telescope/telescope-api/schedule/{$entry->uuid}/markdown");
+
+        $this->assertMarkdownContains($response, [
+            'inspire',
+            '* * * * *',
+        ]);
+    }
+
+    public function test_batch_markdown()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::BATCH,
+            'content' => [
+                'name' => 'Import Users',
+                'connection' => 'redis',
+                'queue' => 'default',
+                'totalJobs' => 100,
+                'pendingJobs' => 5,
+                'failedJobs' => 2,
+                'progress' => 93,
+                'cancelledAt' => null,
+                'finishedAt' => null,
+                'hostname' => 'web-01',
+            ],
+        ]);
+
+        $response = $this->get("/telescope/telescope-api/batches/{$entry->uuid}/markdown");
+
+        $this->assertMarkdownContains($response, [
+            '# Batch Details',
+            '**Name:** Import Users',
+            '**Total Jobs:** 100',
+        ]);
+    }
+
+    public function test_view_markdown()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::VIEW,
+            'content' => [
+                'name' => 'orders.show',
+                'path' => '/resources/views/orders/show.blade.php',
+                'data' => ['order' => ['id' => 1]],
+                'composers' => [],
+                'hostname' => 'web-01',
+            ],
+        ]);
+
+        $response = $this->get("/telescope/telescope-api/views/{$entry->uuid}/markdown");
+
+        $this->assertMarkdownContains($response, [
+            'orders.show',
+            'show.blade.php',
+        ]);
+    }
+
+    public function test_client_request_markdown()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::CLIENT_REQUEST,
+            'content' => [
+                'method' => 'POST',
+                'uri' => 'https://api.stripe.com/v1/charges',
+                'response_status' => 200,
+                'duration' => 450,
+                'payload' => ['amount' => 9999],
+                'headers' => ['content-type' => 'application/json'],
+                'response' => ['id' => 'ch_123'],
+                'response_headers' => [],
+                'hostname' => 'web-01',
+            ],
+        ]);
+
+        $response = $this->get("/telescope/telescope-api/client-requests/{$entry->uuid}/markdown");
+
+        $this->assertMarkdownContains($response, [
+            '# Client Request Details',
+            '**Method:** POST',
+            '**URL:** https://api.stripe.com/v1/charges',
+        ]);
+    }
+
+    public function test_markdown_returns_404_for_entry_without_template()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::DUMP,
+            'content' => ['dump' => 'test'],
+        ]);
+
+        $this->get("/telescope/telescope-api/logs/{$entry->uuid}/markdown")
+            ->assertNotFound();
+    }
+}


### PR DESCRIPTION
Telescope captures a lot of detailed debugging information (request payloads, stack traces, queries, job data), but there's no easy way to share that context outside the UI. You end up screenshotting or manually copying fields one by one. This is especially important in the era of AI coding agents. 

Laravel's built-in error page already has a "Copy as Markdown" button that makes it trivial to paste an exception into a GitHub issue, Slack thread, or an AI coding agent. This PR brings the same idea to every Telescope entry type.

<img width="1499" height="501" alt="image" src="https://github.com/user-attachments/assets/7057b250-ea32-4df7-90fd-7a52e5e22e39" />

> **Note:** The button style is the same as the one already used by the `/telescope/monitored-tags` page.

## Example outputs for all entry types

- [Batch](https://gist.github.com/jhm-ciberman/665c19558f781fbf7d952b2577718402#file-batch-md)
- [Cache](https://gist.github.com/jhm-ciberman/665c19558f781fbf7d952b2577718402#file-cache-md)
- [Client Request](https://gist.github.com/jhm-ciberman/665c19558f781fbf7d952b2577718402#file-client_request-md)
- [Command](https://gist.github.com/jhm-ciberman/665c19558f781fbf7d952b2577718402#file-command-md)
- [Event](https://gist.github.com/jhm-ciberman/665c19558f781fbf7d952b2577718402#file-event-md)
- [Exception](https://gist.github.com/jhm-ciberman/665c19558f781fbf7d952b2577718402#file-exception-md)
- [Gate](https://gist.github.com/jhm-ciberman/665c19558f781fbf7d952b2577718402#file-gate-md)
- [Job](https://gist.github.com/jhm-ciberman/665c19558f781fbf7d952b2577718402#file-job-md)
- [Log](https://gist.github.com/jhm-ciberman/665c19558f781fbf7d952b2577718402#file-log-md)
- [Mail](https://gist.github.com/jhm-ciberman/665c19558f781fbf7d952b2577718402#file-mail-md)
- [Model](https://gist.github.com/jhm-ciberman/665c19558f781fbf7d952b2577718402#file-model-md)
- [Notification](https://gist.github.com/jhm-ciberman/665c19558f781fbf7d952b2577718402#file-notification-md)
- [Query](https://gist.github.com/jhm-ciberman/665c19558f781fbf7d952b2577718402#file-query-md)
- [Redis](https://gist.github.com/jhm-ciberman/665c19558f781fbf7d952b2577718402#file-redis-md)
- [Request](https://gist.github.com/jhm-ciberman/665c19558f781fbf7d952b2577718402#file-request-md)
- [Schedule](https://gist.github.com/jhm-ciberman/665c19558f781fbf7d952b2577718402#file-schedule-md)
- [View](https://gist.github.com/jhm-ciberman/665c19558f781fbf7d952b2577718402#file-view-md)

### How it works

A new `markdown()` method on the base `EntryController` renders the entry through a Blade template and returns `text/markdown`. Each entry type has its own template in `resources/views/markdown/`, so adding markdown support for a new entry type is just creating one Blade file.

Blade was chosen over building the markdown string in JavaScript because it's testable with PHPUnit (one test per entry type), and it keeps the formatting logic on the same side as the data.

The Vue frontend adds a single button to `PreviewScreen.vue`. Since every detail screen uses this base component, all 17 entry types get the button automatically with no changes to individual screens.

For entry types that act as "entry points" (requests, exceptions, jobs, commands), the markdown also includes related entries from the same batch: queries, logs, model changes, and events, giving you the full picture of what happened.

### Example output (exception)

```markdown
# Exception Details

- **Type:** App\Exceptions\PaymentFailedException
- **Message:** Payment declined: insufficient funds. Gateway responded with code E_CARD_DECLINED for card ending in 4242.
- **Location:** app/Services/PaymentService.php:87
- **Time:** 2026-03-26 10:59:00
- **Hostname:** web-01
- **User ID:** 1
- **User Name:** Taylor Otwell
- **User Email:** taylor@laravel.com

## Context

json
{
    "order_id": 1846,
    "amount": 149.99,
    "currency": "USD",
    "gateway": "stripe",
    "card_last4": "4242",
    "error_code": "E_CARD_DECLINED"
}

## Stack Trace

0 - app/Services/PaymentService.php:87
1 - app/Services/OrderService.php:143
2 - app/Http/Controllers/CheckoutController.php:52
3 - vendor/laravel/framework/src/Illuminate/Routing/Controller.php:54
4 - vendor/laravel/framework/src/Illuminate/Routing/Router.php:822
5 - vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:180
6 - vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php:175

## Queries (1)

* `select * from "orders" where "id" = 1846 limit 1` (0.89ms)
```