### PR TITLE
Fix QueryWatcher uses incorrect PDO instance

### DIFF
--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -125,7 +125,9 @@ class QueryWatcher extends Watcher
     protected function quoteStringBinding($event, $binding)
     {
         try {
-            $pdo = $event->connection->getPdo();
+            $pdo = $event->readWriteType === 'read' ? 
+                $event->connection->getReadPdo()
+                : $event->connection->getPdo();
 
             if ($pdo instanceof \PDO) {
                 return $pdo->quote($binding);


### PR DESCRIPTION
This PR slightly updates the `quoteStringBinding` method of `QueryWatcher` to use the read PDO connection when handling read events.

Previously, the method always called `getPdo()`, which could trigger an unnecessary write connection creation in case you had separate configured read and write connections.