### PR TITLE
Allow filter by tags with logic AND

### DIFF
--- a/resources/js/components/IndexScreen.vue
+++ b/resources/js/components/IndexScreen.vue
@@ -15,6 +15,7 @@ export default {
     data() {
         return {
             tag: '',
+            tags: '',
             familyHash: '',
             entries: [],
             ready: false,
@@ -46,6 +47,8 @@ export default {
         this.familyHash = this.$route.query.family_hash || '';
 
         this.tag = this.$route.query.tag || '';
+
+        this.tags = this.$route.query.tags || '';
 
         this.loadEntries((entries) => {
             this.entries = entries;
@@ -90,6 +93,10 @@ export default {
                 this.tag = '';
             }
 
+            if (!this.$route.query.tags) {
+                this.tags = '';
+            }
+
             this.ready = false;
 
             this.loadEntries((entries) => {
@@ -107,6 +114,7 @@ export default {
         loadEntries(after){
             axios.post(Telescope.basePath + '/telescope-api/' + this.resource +
                     '?tag=' + this.tag +
+                    '&tags=' + this.tags +
                     '&before=' + this.lastEntryIndex +
                     '&take=' + this.entriesPerRequest +
                     '&family_hash=' + this.familyHash
@@ -133,6 +141,7 @@ export default {
             this.newEntriesTimeout = setTimeout(() => {
                 axios.post(Telescope.basePath + '/telescope-api/' + this.resource +
                         '?tag=' + this.tag +
+                        '&tags=' + this.tags +
                         '&take=1' +
                         '&family_hash=' + this.familyHash
                 ).then(response => {

--- a/src/Storage/EntryModel.php
+++ b/src/Storage/EntryModel.php
@@ -67,6 +67,7 @@ class EntryModel extends Model
         $this->whereType($query, $type)
                 ->whereBatchId($query, $options)
                 ->whereTag($query, $options)
+                ->whereTags($query, $options)
                 ->whereFamilyHash($query, $options)
                 ->whereBeforeSequence($query, $options)
                 ->filter($query, $options);
@@ -140,6 +141,34 @@ class EntryModel extends Model
      * @param  \Laravel\Telescope\Storage\EntryQueryOptions  $options
      * @return $this
      */
+    protected function whereTags($query, EntryQueryOptions $options)
+    {
+        $query->when($options->tags, function ($query, $tag) {
+            $tags = collect(explode(',', $tag))->map(fn ($tag) => trim($tag));
+
+            if ($tags->isEmpty()) {
+                return $query;
+            }
+
+            return $query->whereIn('uuid', function ($query) use ($tags) {
+                $query->select('entry_uuid')
+                    ->from('telescope_entries_tags')
+                    ->whereIn('tag', $tags->all())
+                    ->groupBy('entry_uuid')
+                    ->havingRaw('COUNT(DISTINCT tag) = ?', [$tags->count()]);
+            });
+        });
+
+        return $this;
+    }
+
+    /**
+     * Scope the query for the given type.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Laravel\Telescope\Storage\EntryQueryOptions  $options
+     * @return $this
+     */
     protected function whereFamilyHash($query, EntryQueryOptions $options)
     {
         $query->when($options->familyHash, function ($query, $hash) {
@@ -174,7 +203,7 @@ class EntryModel extends Model
      */
     protected function filter($query, EntryQueryOptions $options)
     {
-        if ($options->familyHash || $options->tag || $options->batchId) {
+        if ($options->familyHash || $options->tag || $options->tags || $options->batchId) {
             return $this;
         }
 

--- a/src/Storage/EntryQueryOptions.php
+++ b/src/Storage/EntryQueryOptions.php
@@ -21,6 +21,13 @@ class EntryQueryOptions
     public $tag;
 
     /**
+     * The tags that must belong to retrieved entries.
+     *
+     * @var string
+     */
+    public $tags;
+
+    /**
      * The family hash that must belong to retrieved entries.
      *
      * @var string
@@ -61,6 +68,7 @@ class EntryQueryOptions
                 ->uuids($request->uuids)
                 ->beforeSequence($request->before)
                 ->tag($request->tag)
+                ->tags($request->tags)
                 ->familyHash($request->family_hash)
                 ->limit($request->take ?? 50);
     }
@@ -124,6 +132,19 @@ class EntryQueryOptions
     public function tag(?string $tag)
     {
         $this->tag = $tag;
+
+        return $this;
+    }
+
+    /**
+     * Set the tags that must all belong to retrieved entries.
+     *
+     * @param  string|null  $tags
+     * @return $this
+     */
+    public function tags(?string $tags)
+    {
+        $this->tags = $tags;
 
         return $this;
     }


### PR DESCRIPTION
Currently, Telescope supports filter result by tag with comma separated using logic OR
```
/telescope/requests?tag=Auth%3A1,status%3A422
```
This will show results with `Auth:1` OR `status:422`

This Pull Request allow us to filter result by tag using logic AND, using `tags` query.
```
/telescope/requests?tags=Auth%3A1,status%3A422
```
This will show results that have both `Auth:1` AND `status:422`

This feature has been [discussed](https://github.com/laravel/framework/discussions/36372) in the main repo.

Caveat:
- No UI to use this logic yet, user needs to manually type the query params
- I didn't push the app.js from `npm run build`, should I?