### PR TITLE
Support formatting composite model keys

### DIFF
--- a/src/FormatModel.php
+++ b/src/FormatModel.php
@@ -16,11 +16,17 @@ class FormatModel
      */
     public static function given($model)
     {
+        $keyName = $model->getKeyName();
+
         if ($model instanceof Pivot && ! $model->incrementing) {
             $keys = [
                 $model->getAttribute($model->getForeignKey()),
                 $model->getAttribute($model->getRelatedKey()),
             ];
+        } elseif (is_array($keyName)) {
+            $keys = array_map(function ($key) use ($model) {
+                return $model->getAttribute($key);
+            }, $keyName);
         } else {
             $keys = $model->getKey();
         }

--- a/tests/Watchers/ModelWatcherTest.php
+++ b/tests/Watchers/ModelWatcherTest.php
@@ -3,6 +3,8 @@
 namespace Laravel\Telescope\Tests\Watchers;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Laravel\Telescope\EntryType;
 use Laravel\Telescope\Telescope;
@@ -86,6 +88,32 @@ class ModelWatcherTest extends FeatureTestCase
         $this->assertCount(1, $this->loadTelescopeEntries());
     }
 
+    public function test_model_watcher_registers_entry_for_models_with_composite_keys()
+    {
+        Telescope::withoutRecording(function () {
+            Schema::create('composite_key_models', function (Blueprint $table) {
+                $table->unsignedInteger('first_id');
+                $table->unsignedInteger('second_id');
+                $table->string('name');
+            });
+        });
+
+        CompositeKeyModel::query()
+            ->create([
+                'first_id' => 1,
+                'second_id' => 2,
+                'name' => 'Telescope',
+            ]);
+
+        $entry = $this->loadTelescopeEntries()
+            ->where('type', EntryType::MODEL)
+            ->first();
+
+        $this->assertSame(EntryType::MODEL, $entry->type);
+        $this->assertSame('created', $entry->content['action']);
+        $this->assertSame(CompositeKeyModel::class.':1_2', $entry->content['model']);
+    }
+
     protected function createUser()
     {
         UserEloquent::create([
@@ -99,6 +127,19 @@ class ModelWatcherTest extends FeatureTestCase
 class UserEloquent extends Model
 {
     protected $table = 'users';
+
+    protected $guarded = [];
+}
+
+class CompositeKeyModel extends Model
+{
+    protected $table = 'composite_key_models';
+
+    protected $primaryKey = ['first_id', 'second_id'];
+
+    public $incrementing = false;
+
+    public $timestamps = false;
 
     protected $guarded = [];
 }


### PR DESCRIPTION
Fixes #1654.

`FormatModel::given()` currently calls Eloquent's `getKey()` for non-pivot models. When a model defines an array primary key, that eventually passes an array into `getAttribute()` and Telescope crashes while recording the model event.

This keeps the existing pivot behavior and formats models with array key names by reading each key attribute directly, producing the same `Class:key_key` tag shape Telescope already uses for multi-part pivot identifiers.

Tests run:

- `php -l src/FormatModel.php`
- `php -l tests/Watchers/ModelWatcherTest.php`
- `php vendor/bin/phpunit tests/Watchers/ModelWatcherTest.php --filter composite`
- `php vendor/bin/phpstan analyse src/FormatModel.php --memory-limit=1G`

Local note: running the whole `tests/Watchers/ModelWatcherTest.php` file in my unlocked Windows dependency install still has the pre-existing query-entry ordering failures in the older assertions; the new composite-key regression passes.