### PR TITLE
[5.x] Clear stale exception and failed tag when a job is marked processed

### DIFF
--- a/src/Watchers/JobWatcher.php
+++ b/src/Watchers/JobWatcher.php
@@ -101,8 +101,8 @@ class JobWatcher extends Watcher
         }
 
         Telescope::recordUpdate(EntryUpdate::make(
-            $uuid, EntryType::JOB, ['status' => 'processed']
-        ));
+            $uuid, EntryType::JOB, ['status' => 'processed', 'exception' => null]
+        )->removeTags(['failed']));
 
         $this->updateBatch($event->job->payload());
     }

--- a/tests/Watchers/JobWatcherTest.php
+++ b/tests/Watchers/JobWatcherTest.php
@@ -7,13 +7,17 @@ use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Auth\User;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Jobs\Job;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Str;
 use Laravel\Telescope\EntryType;
+use Laravel\Telescope\Telescope;
 use Laravel\Telescope\Tests\FeatureTestCase;
 use Laravel\Telescope\Watchers\JobWatcher;
+use Mockery as m;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\Attributes\WithMigration;
 use Orchestra\Testbench\Factories\UserFactory;
@@ -91,6 +95,49 @@ class JobWatcherTest extends FeatureTestCase
         $this->assertArrayNotHasKey('args', $entry->content['exception']['trace'][0]);
         $this->assertSame(MyFailedDatabaseJob::class, $entry->content['exception']['trace'][0]['class']);
         $this->assertSame('handle', $entry->content['exception']['trace'][0]['function']);
+    }
+
+    public function test_processed_job_clears_stale_failure_state_left_by_a_duplicate_reservation()
+    {
+        // A long-running job whose runtime exceeds the queue's retry_after can be
+        // reserved twice: a second worker fails it with MaxAttemptsExceededException
+        // (JobFailed) while the original worker eventually completes it (JobProcessed).
+        // Both events target the same telescope_uuid, so the processed update must not
+        // leave behind the failure's exception payload or "failed" tag.
+        Telescope::startRecording(false);
+
+        $watcher = new JobWatcher;
+
+        $entry = $watcher->recordJob('redis', 'default', [
+            'job' => 'Illuminate\Queue\CallQueuedHandler@call',
+            'displayName' => MyDatabaseJob::class,
+            'maxTries' => 1,
+            'timeout' => 30,
+            'data' => ['payload' => 'long-running'],
+        ]);
+
+        $job = m::mock(Job::class);
+        $job->shouldReceive('payload')->andReturn(['telescope_uuid' => $entry->uuid]);
+
+        $watcher->recordFailedJob(new JobFailed(
+            'redis', $job, new Exception(MyDatabaseJob::class.' has been attempted too many times.')
+        ));
+
+        $watcher->recordProcessedJob(new JobProcessed('redis', $job));
+
+        $stored = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::JOB, $stored->type);
+        $this->assertSame('processed', $stored->content['status']);
+        $this->assertNull($stored->content['exception']);
+
+        $hasFailedTag = $this->app['db']->connection('testbench')
+            ->table('telescope_entries_tags')
+            ->where('entry_uuid', $entry->uuid)
+            ->where('tag', 'failed')
+            ->exists();
+
+        $this->assertFalse($hasFailedTag, 'The "failed" tag must be removed once the job is processed.');
     }
 
     public function test_it_handles_pushed_jobs()


### PR DESCRIPTION
Fixes #1740.

## Problem

When the same queued job (same `telescope_uuid`) emits **both** a `JobFailed` and a `JobProcessed` event, `JobWatcher` persists an internally inconsistent job entry: `status: processed` while still carrying the `exception` payload **and** the `failed` tag written by the earlier failure.

`recordProcessedJob()` only updated the status and never cleared a previously-recorded exception:

```php
Telescope::recordUpdate(EntryUpdate::make(
    $uuid, EntryType::JOB, ['status' => 'processed']   // exception from a prior recordFailedJob() is retained
));
```

Because `DatabaseEntriesRepository::update()` merges changes with `array_merge($existingContent, $update->changes)`, the `exception` key set by `recordFailedJob()` survives, and the `failed` tag (added via `->addTags(['failed'])`) is never removed.

### How one `telescope_uuid` gets both events

A long-running job is reserved by two workers. With `tries = 1` and a queue `retry_after` shorter than the job's runtime, the in-flight job becomes visible again; a second worker reserves it, `attempts (2) > maxTries (1)`, and `Worker::process()` throws `MaxAttemptsExceededException` **before** `handle()` runs → `JobFailed`. The original worker later finishes successfully → `JobProcessed`. When the `JobProcessed` update is flushed last, the entry ends as **processed + exception + `failed` tag**, and the UI visibly flips failed → processed.

## Fix

Clear the stale failure state when marking a job processed:

```php
Telescope::recordUpdate(EntryUpdate::make(
    $uuid, EntryType::JOB, ['status' => 'processed', 'exception' => null]
)->removeTags(['failed']));
```

`exception` is set to `null` (the `array_merge` storage path cannot unset a key), which keeps the entry consistent and leaves `IncomingEntry::isFailedJob()` — which checks `status === 'failed'` — unaffected.

## Test

Added `test_processed_job_clears_stale_failure_state_left_by_a_duplicate_reservation` to `JobWatcherTest`. It records a pending job, fires `JobFailed` then `JobProcessed` for the same `telescope_uuid`, and asserts the stored entry is `processed`, has no lingering `exception`, and is no longer tagged `failed`. The test fails on the previous behaviour and passes with this change.
