### PR TITLE
Skip publishing migrations if telescope migration already exists

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -38,7 +38,10 @@ class InstallCommand extends Command
         $this->callSilent('vendor:publish', ['--tag' => 'telescope-config']);
 
         $this->comment('Publishing Telescope Migrations...');
-        $this->callSilent('vendor:publish', ['--tag' => 'telescope-migrations']);
+
+        if (! glob(database_path('migrations/*_create_telescope_entries_table.php'))) {
+            $this->callSilent('vendor:publish', ['--tag' => 'telescope-migrations']);
+        }
 
         $this->registerTelescopeServiceProvider();
 


### PR DESCRIPTION
Running \`php artisan telescope:install\` more than once publishes a new migration file with a fresh timestamp each time, because \`publishesMigrations()\` (Laravel 11+) prefixes files with the current date. The second migration then fails with "table telescope_entries already exists."

The fix checks for any existing \`*_create_telescope_entries_table.php\` file in \`database/migrations/\` before publishing, and skips the publish step if one is already present — matching the same guard pattern used in the service provider registration below it.

Closes #1589.