### PR TITLE
[5.x] Normalize dashboard JavaScript line endings

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -845,6 +845,8 @@ class Telescope
             throw new RuntimeException('Unable to load the Telescope dashboard JavaScript.');
         }
 
+        $js = str_replace(["\r\n", "\r"], "\n", $js);
+
         $telescope = Js::from(static::scriptVariables());
 
         return new HtmlString(<<<HTML

--- a/tests/Telescope/TelescopeTest.php
+++ b/tests/Telescope/TelescopeTest.php
@@ -106,6 +106,15 @@ class TelescopeTest extends FeatureTestCase
 
         $this->assertFalse(Telescope::isRecording());
     }
+
+    public function test_dashboard_javascript_line_endings_are_normalized()
+    {
+        $javascript = Telescope::js()->toHtml();
+
+        $this->assertStringContainsString('<script type="module">', $javascript);
+        $this->assertStringContainsString('window.Telescope =', $javascript);
+        $this->assertStringNotContainsString("\r", $javascript);
+    }
 }
 
 class MySyncJob implements ShouldQueue


### PR DESCRIPTION
On a Windows checkout the dashboard's `dist/app.js` ends up with CRLF line endings, and those carriage returns break the inline `<script type="module">` block the dashboard boots from, so the page just renders blank. This normalizes the JavaScript to LF before it's embedded, which is a no-op when the file already uses LF. Added a test asserting the emitted script contains no carriage returns.

Fixes #1735
