### PR TITLE
[5.x] Order deletes when pruning and clearing to prevent deadlocks

### DIFF
--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -376,7 +376,8 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
     public function prune(DateTimeInterface $before, $keepExceptions)
     {
         $query = $this->table('telescope_entries')
-                ->where('created_at', '<', $before);
+                ->where('created_at', '<', $before)
+                ->orderBy('sequence');
 
         if ($keepExceptions) {
             $query->where('type', '!=', 'exception');
@@ -401,11 +402,11 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
     public function clear()
     {
         do {
-            $deleted = $this->table('telescope_entries')->take($this->chunkSize)->delete();
+            $deleted = $this->table('telescope_entries')->orderBy('sequence')->take($this->chunkSize)->delete();
         } while ($deleted !== 0);
 
         do {
-            $deleted = $this->table('telescope_monitoring')->take($this->chunkSize)->delete();
+            $deleted = $this->table('telescope_monitoring')->orderBy('tag')->take($this->chunkSize)->delete();
         } while ($deleted !== 0);
     }
 

--- a/tests/Storage/DatabaseEntriesRepositoryTest.php
+++ b/tests/Storage/DatabaseEntriesRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Telescope\Tests\Storage;
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Laravel\Telescope\Database\Factories\EntryModelFactory;
 use Laravel\Telescope\EntryType;
@@ -45,6 +46,53 @@ class DatabaseEntriesRepositoryTest extends FeatureTestCase
 
         $this->assertCount(1, $failedUpdates);
         $this->assertSame('missing-id', $failedUpdates->first()->uuid);
+    }
+
+    public function test_prune_orders_deletes_to_avoid_deadlocks()
+    {
+        EntryModelFactory::new()->create(['created_at' => now()->subDays(2)]);
+
+        $deletes = [];
+
+        DB::listen(function ($query) use (&$deletes) {
+            if (str_starts_with($query->sql, 'delete')) {
+                $deletes[] = $query->sql;
+            }
+        });
+
+        (new DatabaseEntriesRepository('testbench'))->prune(now()->subDay(), false);
+
+        $this->assertNotEmpty($deletes);
+
+        foreach ($deletes as $sql) {
+            $this->assertStringContainsString('order by', $sql);
+        }
+    }
+
+    public function test_clear_orders_deletes_to_avoid_deadlocks()
+    {
+        EntryModelFactory::new()->create();
+
+        DB::table('telescope_monitoring')->insert([
+            ['tag' => 'one'],
+            ['tag' => 'two'],
+        ]);
+
+        $deletes = [];
+
+        DB::listen(function ($query) use (&$deletes) {
+            if (str_starts_with($query->sql, 'delete')) {
+                $deletes[] = $query->sql;
+            }
+        });
+
+        (new DatabaseEntriesRepository('testbench'))->clear();
+
+        $this->assertNotEmpty($deletes);
+
+        foreach ($deletes as $sql) {
+            $this->assertStringContainsString('order by', $sql);
+        }
     }
 
     public function test_store_binary_content()


### PR DESCRIPTION
The prune and clear queries delete entries in chunked `take()->delete()` loops without any `order by`, so InnoDB is free to pick the delete order and can deadlock (1213) against concurrent request-time inserts. Adding an `order by` on the primary key makes each delete lock rows in a consistent order, matching what `get()` already does.

Fixes #1723