### PR TITLE
[5.x] Retry exception storage on deadlock to survive concurrent job failures

### DIFF
--- a/src/Storage/DatabaseEntriesRepository.php
+++ b/src/Storage/DatabaseEntriesRepository.php
@@ -161,23 +161,25 @@ class DatabaseEntriesRepository implements Contract, ClearableRepository, Prunab
     protected function storeExceptions(Collection $exceptions)
     {
         $exceptions->chunk($this->chunkSize)->each(function ($chunked) {
-            $this->table('telescope_entries')->insert($chunked->map(function ($exception) {
-                $occurrences = $this->countExceptionOccurences($exception);
+            DB::connection($this->connection)->transaction(function () use ($chunked) {
+                $this->table('telescope_entries')->insert($chunked->map(function ($exception) {
+                    $occurrences = $this->countExceptionOccurences($exception);
 
-                $this->table('telescope_entries')
-                        ->where('type', EntryType::EXCEPTION)
-                        ->where('family_hash', $exception->familyHash())
-                        ->where('should_display_on_index', true)
-                        ->update(['should_display_on_index' => false]);
+                    $this->table('telescope_entries')
+                            ->where('type', EntryType::EXCEPTION)
+                            ->where('family_hash', $exception->familyHash())
+                            ->where('should_display_on_index', true)
+                            ->update(['should_display_on_index' => false]);
 
-                return array_merge($exception->toArray(), [
-                    'family_hash' => $exception->familyHash(),
-                    'content' => json_encode(
-                        array_merge($exception->content, ['occurrences' => $occurrences + 1]),
-                        JSON_INVALID_UTF8_SUBSTITUTE
-                    ),
-                ]);
-            })->toArray());
+                    return array_merge($exception->toArray(), [
+                        'family_hash' => $exception->familyHash(),
+                        'content' => json_encode(
+                            array_merge($exception->content, ['occurrences' => $occurrences + 1]),
+                            JSON_INVALID_UTF8_SUBSTITUTE
+                        ),
+                    ]);
+                })->toArray());
+            }, 3);
         });
 
         $this->storeTags($exceptions->pluck('tags', 'uuid'));

--- a/tests/Storage/DatabaseEntriesRepositoryTest.php
+++ b/tests/Storage/DatabaseEntriesRepositoryTest.php
@@ -2,7 +2,9 @@
 
 namespace Laravel\Telescope\Tests\Storage;
 
+use Illuminate\Database\Events\TransactionBeginning;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use Laravel\Telescope\Database\Factories\EntryModelFactory;
 use Laravel\Telescope\EntryType;
@@ -119,5 +121,41 @@ class DatabaseEntriesRepositoryTest extends FeatureTestCase
                 'content' => false,
             ]);
         });
+    }
+
+    public function test_store_exceptions_wraps_writes_in_a_transaction_to_avoid_deadlocks()
+    {
+        $transactions = 0;
+
+        Event::listen(TransactionBeginning::class, function () use (&$transactions) {
+            $transactions++;
+        });
+
+        $exception = new \Exception('message');
+
+        $entry = fn () => collect([
+            (new IncomingExceptionEntry($exception, [
+                'file' => $exception->getFile(),
+                'line' => $exception->getLine(),
+                'message' => $exception->getMessage(),
+            ]))->batchId((string) Str::uuid())->type(EntryType::EXCEPTION),
+        ]);
+
+        $repository = new DatabaseEntriesRepository('testbench');
+
+        $repository->store($entry());
+        $repository->store($entry());
+
+        $this->assertGreaterThan(0, $transactions);
+
+        $stored = DB::connection('testbench')->table('telescope_entries')
+            ->where('type', EntryType::EXCEPTION)
+            ->orderBy('sequence')
+            ->get();
+
+        $this->assertCount(2, $stored);
+        $this->assertEquals(0, $stored[0]->should_display_on_index);
+        $this->assertEquals(1, $stored[1]->should_display_on_index);
+        $this->assertSame(2, json_decode($stored[1]->content, true)['occurrences']);
     }
 }


### PR DESCRIPTION
Exceptions are stored by flipping `should_display_on_index` on the existing rows of the same family and then inserting the new row. When several Horizon workers fail jobs at the same time, these concurrent update/insert pairs contend on the same index range and MySQL kills one of them with a deadlock (1213), which then surfaces out of the failed-job handler instead of just being recorded. Wrapping each chunk of exception writes in a transaction lets the framework retry them when that happens.

Fixes #1750