### PR TITLE
[5.x] Add CSP nonce support

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -117,6 +117,13 @@ class Telescope
     public static $useDarkTheme = false;
 
     /**
+     * The CSP nonce to use for style and script tags.
+     *
+     * @var string
+     */
+    public static $nonceAttribute = '';
+
+    /**
      * Indicates if Telescope should record entries.
      *
      * @var bool
@@ -796,6 +803,19 @@ class Telescope
     }
 
     /**
+     * Set the CSP nonce to use for style and script tags.
+     *
+     * @param  string  $nonce
+     * @return static
+     */
+    public static function cspNonce($nonce)
+    {
+        static::$nonceAttribute = " nonce=\"{$nonce}\"";
+
+        return new static;
+    }
+
+    /**
      * Register the Telescope user avatar callback.
      *
      * @param  \Closure  $callback
@@ -828,9 +848,11 @@ class Telescope
             throw new RuntimeException('Unable to load the '.(static::$useDarkTheme ? 'dark' : 'light').' Telescope dashboard styles.');
         }
 
+        $nonceAttribute = static::$nonceAttribute;
+
         return new HtmlString(<<<HTML
-            <style>{$app}</style>
-            <style>{$styles}</style>
+            <style{$nonceAttribute}>{$app}</style>
+            <style{$nonceAttribute}>{$styles}</style>
         HTML);
     }
 
@@ -849,8 +871,10 @@ class Telescope
 
         $telescope = Js::from(static::scriptVariables());
 
+        $nonceAttribute = static::$nonceAttribute;
+
         return new HtmlString(<<<HTML
-            <script type="module">
+            <script type="module"{$nonceAttribute}>
                 window.Telescope = {$telescope};
                 {$js}
             </script>

--- a/tests/Http/CspNonceTest.php
+++ b/tests/Http/CspNonceTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Laravel\Telescope\Tests\Http;
+
+use Illuminate\Support\Str;
+use Laravel\Telescope\Http\Middleware\Authorize;
+use Laravel\Telescope\Telescope;
+use Laravel\Telescope\Tests\FeatureTestCase;
+
+class CspNonceTest extends FeatureTestCase
+{
+    /** {@inheritdoc} */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutMiddleware([Authorize::class]);
+    }
+
+    /** {@inheritdoc} */
+    #[\Override]
+    protected function tearDown(): void
+    {
+        Telescope::$nonceAttribute = '';
+
+        parent::tearDown();
+    }
+
+    public function test_csp_nonce_is_not_rendered_in_style_and_script_tags_if_not_set()
+    {
+        $response = $this->get('/telescope');
+
+        $response->assertOk()
+            ->assertSeeHtml('<style>')
+            ->assertSeeHtml('<script type="module">');
+    }
+
+    public function test_csp_nonce_is_rendered_in_style_and_script_tags_if_set()
+    {
+        $nonce = Str::random(40);
+
+        Telescope::cspNonce($nonce);
+
+        $response = $this->get('/telescope');
+
+        $response->assertOk()
+            ->assertSeeHtml("<style nonce=\"{$nonce}\">")
+            ->assertSeeHtml("<script type=\"module\" nonce=\"{$nonce}\">");
+    }
+}


### PR DESCRIPTION
This PR adds CSP nonce support to the Telescope dashboard, mirroring the equivalent feature that was recently added to Horizon in laravel/horizon#1792.

Telescope inlines its entire dashboard JavaScript and CSS into the layout via `Telescope::js()` / `Telescope::css()`. Applications enforcing a Content-Security-Policy without `'unsafe-inline'` currently have to exclude the `/telescope` path from their policy entirely. With this PR they can allow the dashboard's inline tags via a per-request nonce instead:

 ```php
 Telescope::cspNonce($nonce);
 ```
This is typically called from a middleware that also emits the matching CSP header - the exact same usage as `Horizon::cspNonce()`.

The implementation is a direct port of laravel/horizon#1792: a static `$nonceAttribute` property, the `cspNonce()` setter, and interpolation into the two `<style>` tags and the `<script type="module">` tag. The tests mirror Horizon's `CspNonceTest` (with one addition: a `tearDown()` reset of the static property so the nonce does not leak into subsequent test cases).