### PR TITLE
Fix BatchWatcher::recordBatch docblock copied from JobWatcher

### DIFF
--- a/src/Watchers/BatchWatcher.php
+++ b/src/Watchers/BatchWatcher.php
@@ -20,11 +20,9 @@ class BatchWatcher extends Watcher
     }
 
     /**
-     * Record a job being created.
+     * Record a batch being dispatched.
      *
-     * @param  string  $connection
-     * @param  string  $queue
-     * @param  array  $payload
+     * @param  \Illuminate\Bus\Events\BatchDispatched  $event
      * @return \Laravel\Telescope\IncomingEntry|null
      */
     public function recordBatch(BatchDispatched $event)


### PR DESCRIPTION
`BatchWatcher::recordBatch()` carries the docblock of `JobWatcher::recordJob()`.

```php
/**
 * Record a job being created.
 *
 * @param  string  $connection
 * @param  string  $queue
 * @param  array  $payload
 * @return \Laravel\Telescope\IncomingEntry|null
 */
public function recordBatch(BatchDispatched $event)
```

The method takes a single `BatchDispatched $event`. `recordJob($connection, $queue, array $payload)` in `JobWatcher.php:58` really does take those three, and its block is correct — this one was copied across and never adjusted, summary line included.

Replaced the three tags with the parameter the method actually takes, and made the summary say batch rather than job.

Docblock only, no behaviour change.
