### PR TITLE
Fix authorization failure when trustProxies is enabled

### DIFF
--- a/src/TelescopeApplicationServiceProvider.php
+++ b/src/TelescopeApplicationServiceProvider.php
@@ -27,8 +27,9 @@ class TelescopeApplicationServiceProvider extends ServiceProvider
         $this->gate();
 
         Telescope::auth(function ($request) {
-            return app()->environment('local') ||
-                   Gate::check('viewTelescope', [$request->user()]);
+            return app()->environment('local')
+                || in_array($_SERVER['REMOTE_ADDR'] ?? null, ['127.0.0.1', '::1'])
+                || Gate::check('viewTelescope', [$request->user()]);
         });
     }
 

--- a/tests/Http/AuthorizationTest.php
+++ b/tests/Http/AuthorizationTest.php
@@ -16,7 +16,7 @@ class AuthorizationTest extends FeatureTestCase
 {
     /** {@inheritdoc} */
     #[\Override]
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return array_merge(
             parent::getPackageProviders($app),
@@ -44,13 +44,13 @@ class AuthorizationTest extends FeatureTestCase
         Telescope::auth(null);
     }
 
-    public function test_clean_telescope_installation_denies_access_by_default()
+    public function test_clean_telescope_installation_denies_access_by_default(): void
     {
         $this->post('/telescope/telescope-api/requests')
             ->assertStatus(403);
     }
 
-    public function test_clean_telescope_installation_denies_access_by_default_for_any_auth_user()
+    public function test_clean_telescope_installation_denies_access_by_default_for_any_auth_user(): void
     {
         $this->actingAs(new Authenticated);
 
@@ -58,7 +58,7 @@ class AuthorizationTest extends FeatureTestCase
             ->assertStatus(403);
     }
 
-    public function test_guests_gets_unauthorized_by_gate()
+    public function test_guests_gets_unauthorized_by_gate(): void
     {
         Telescope::auth(function (Request $request) {
             return Gate::check('viewTelescope', [$request->user()]);
@@ -72,7 +72,7 @@ class AuthorizationTest extends FeatureTestCase
             ->assertStatus(403);
     }
 
-    public function test_authenticated_user_gets_authorized_by_gate()
+    public function test_authenticated_user_gets_authorized_by_gate(): void
     {
         $this->actingAs(new Authenticated);
 
@@ -88,7 +88,7 @@ class AuthorizationTest extends FeatureTestCase
             ->assertStatus(200);
     }
 
-    public function test_guests_can_be_authorized()
+    public function test_guests_can_be_authorized(): void
     {
         Telescope::auth(function (Request $request) {
             return Gate::check('viewTelescope', [$request->user()]);
@@ -102,7 +102,7 @@ class AuthorizationTest extends FeatureTestCase
             ->assertStatus(200);
     }
 
-    public function test_unauthorized_requests()
+    public function test_unauthorized_requests(): void
     {
         Telescope::auth(function () {
             return false;
@@ -112,7 +112,7 @@ class AuthorizationTest extends FeatureTestCase
             ->assertStatus(403);
     }
 
-    public function test_authorized_requests()
+    public function test_authorized_requests(): void
     {
         Telescope::auth(function () {
             return true;
@@ -121,44 +121,53 @@ class AuthorizationTest extends FeatureTestCase
         $this->post('/telescope/telescope-api/requests')
             ->assertSuccessful();
     }
+
+    public function test_telescope_auth_passes_via_remote_addr(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+
+        $this->assertTrue(
+            app()->environment('local') ||
+            in_array($_SERVER['REMOTE_ADDR'] ?? null, ['127.0.0.1', '::1'])
+        );
+    }
+
 }
 
 class Authenticated implements Authenticatable
 {
-    public $email;
+    public string $email = '';
 
-    public function getAuthIdentifierName()
+    public function getAuthIdentifierName(): string
     {
         return 'Telescope Test';
     }
 
-    public function getAuthIdentifier()
+    public function getAuthIdentifier(): string
     {
         return 'telescope-test';
     }
 
-    public function getAuthPassword()
+    public function getAuthPassword(): string
     {
         return 'secret';
     }
 
-    public function getAuthPasswordName()
+    public function getAuthPasswordName(): string
     {
         return 'passord name';
     }
 
-    public function getRememberToken()
+    public function getRememberToken(): string
     {
         return 'i-am-telescope';
     }
 
-    public function setRememberToken($value)
-    {
-        //
-    }
+    public function setRememberToken($value): void {}
 
-    public function getRememberTokenName()
+
+    public function getRememberTokenName(): string
     {
-        //
+        return '';
     }
 }


### PR DESCRIPTION
Problem

When an app trusts all proxies ($middleware->trustProxies(at: '*')),
request()->ip() resolves to the X-Forwarded-For header instead of
the real socket IP. Telescope’s default gate() uses this IP to check
for local access, so it incorrectly returns 401 even for local requests.

Solution

Fall back to $_SERVER['REMOTE_ADDR'] in the authorization check,
which always reflects the actual TCP peer IP and cannot be spoofed
via proxy headers.