### PR TITLE
Fix ExtractTags crash for event-aware listener tags()

### DIFF
--- a/src/ExtractTags.php
+++ b/src/ExtractTags.php
@@ -9,6 +9,7 @@ use Illuminate\Events\CallQueuedListener;
 use Illuminate\Mail\SendQueuedMailable;
 use Illuminate\Notifications\SendQueuedNotifications;
 use ReflectionClass;
+use ReflectionMethod;
 use stdClass;
 
 class ExtractTags
@@ -83,11 +84,41 @@ class ExtractTags
      */
     protected static function tagsForListener($job)
     {
-        return collect(
-            [static::extractListener($job), static::extractEvent($job)]
-        )->map(function ($job) {
-            return static::from($job);
-        })->collapse()->unique()->toArray();
+        $listener = static::extractListener($job);
+        $event = static::extractEvent($job);
+
+        return collect([
+            static::tagsForListenerInstance($listener, $event),
+            static::from($event),
+        ])->collapse()->unique()->toArray();
+    }
+
+    /**
+     * Determine the explicit or model-based tags for the given listener instance.
+     *
+     * Horizon documents queued listener tagging with an event-aware signature
+     * such as `tags(OrderShipped $event): array`, so we can't blindly call
+     * `tags()` without arguments as we do for other taggable targets.
+     *
+     * @param  mixed  $listener
+     * @param  mixed  $event
+     * @return array
+     */
+    protected static function tagsForListenerInstance($listener, $event)
+    {
+        if (method_exists($listener, 'tags')) {
+            if ((new ReflectionMethod($listener, 'tags'))->getNumberOfParameters() > 0) {
+                return $event instanceof stdClass ? [] : $listener->tags($event);
+            }
+
+            if ($tags = $listener->tags()) {
+                return $tags;
+            }
+        }
+
+        return static::modelsFor([$listener])->map(function ($model) {
+            return FormatModel::given($model);
+        })->all();
     }
 
     /**

--- a/tests/Telescope/ExtractTagTest.php
+++ b/tests/Telescope/ExtractTagTest.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Telescope\Tests\Telescope;
 
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Events\CallQueuedListener;
 use Illuminate\Mail\Mailable;
 use Laravel\Telescope\Database\Factories\EntryModelFactory;
 use Laravel\Telescope\ExtractTags;
@@ -39,6 +41,59 @@ class ExtractTagTest extends FeatureTestCase
         $extracted_tag = ExtractTags::from($mailable);
 
         $this->assertSame($tag, $extracted_tag[0]);
+    }
+
+    public function test_extract_tags_for_queued_listener_with_event_aware_tags_method()
+    {
+        $job = new CallQueuedListener(
+            ListenerWithEventAwareTags::class,
+            'handle',
+            [new DummyTaggableEvent]
+        );
+
+        $this->assertSame(['from-event'], ExtractTags::fromJob($job));
+    }
+
+    public function test_extract_tags_for_queued_listener_with_no_argument_tags_method()
+    {
+        $job = new CallQueuedListener(
+            ListenerWithNoArgumentTags::class,
+            'handle',
+            [new DummyTaggableEvent]
+        );
+
+        $this->assertSame(['static-tag'], ExtractTags::fromJob($job));
+    }
+}
+
+class DummyTaggableEvent
+{
+    public $tag = 'from-event';
+}
+
+class ListenerWithEventAwareTags implements ShouldQueue
+{
+    public function handle(DummyTaggableEvent $event)
+    {
+        //
+    }
+
+    public function tags(DummyTaggableEvent $event)
+    {
+        return [$event->tag];
+    }
+}
+
+class ListenerWithNoArgumentTags implements ShouldQueue
+{
+    public function handle(DummyTaggableEvent $event)
+    {
+        //
+    }
+
+    public function tags()
+    {
+        return ['static-tag'];
     }
 }
 


### PR DESCRIPTION
Fixes #1693.

Telescope crashes when it inspects a queued event listener whose `tags()` method follows the signature Horizon documents for manually tagging listeners, e.g. `tags(OrderShipped $event): array`. `ExtractTags::tagsForListener()` routes the listener through `explicitTags()`, which always calls `$target->tags()` with no arguments, so a listener written exactly as Horizon's docs show throws `ArgumentCountError: Too few arguments`.

I changed `tagsForListener()` to look at the listener's `tags()` method with reflection before calling it: if it takes no parameters we call it as before, if it takes one we pass the queued event through, and if there's a real event but the method needs it and we don't have one (i.e. the extracted event is still the placeholder `stdClass`) we skip the explicit call rather than risk a type error. When `tags()` doesn't return anything useful, it still falls back to the existing model-based tag extraction, same as before.

I kept `ExtractTags::from()` untouched since it's used for mailables, notifications, broadcast events, etc. where `tags()` never takes an event argument, and I didn't want to change that public method's contract just to handle this one listener case.

Added two tests to `tests/Telescope/ExtractTagTest.php`: one with a queued listener whose `tags()` takes the event and returns a tag derived from it, and one with the existing zero-argument `tags()` style, to make sure both keep working through `ExtractTags::fromJob()`.

I ran the full `ExtractTagTest` suite locally (PHP 8.4, PHPUnit 13) and both new tests pass alongside the existing three. I also ran `JobWatcherTest` for a broader regression check — there's one pre-existing failure there (`test_job_can_handle_deleted_serialized_model`) that I confirmed also fails on a clean checkout of 5.x before my change, so it's unrelated to this fix.
