### PR TITLE
Escape CSP nonce attribute value

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -890,7 +890,7 @@ class Telescope
      */
     public static function cspNonce($nonce)
     {
-        static::$nonceAttribute = " nonce=\"{$nonce}\"";
+        static::$nonceAttribute = ' nonce="'.htmlspecialchars($nonce, ENT_QUOTES, 'UTF-8').'"';
 
         return new static;
     }

--- a/tests/Http/CspNonceTest.php
+++ b/tests/Http/CspNonceTest.php
@@ -48,4 +48,15 @@ class CspNonceTest extends FeatureTestCase
             ->assertSeeHtml("<style nonce=\"{$nonce}\">")
             ->assertSeeHtml("<script type=\"module\" nonce=\"{$nonce}\">");
     }
+
+    public function test_csp_nonce_value_is_escaped_when_rendered()
+    {
+        Telescope::cspNonce('"><script>alert(1)</script>');
+
+        $response = $this->get('/telescope');
+
+        $response->assertOk()
+            ->assertDontSeeHtml('<script>alert(1)</script>')
+            ->assertSeeHtml('&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;', false);
+    }
 }


### PR DESCRIPTION
The nonce passed to `Telescope::cspNonce()` is interpolated verbatim into a double-quoted HTML attribute in both `Telescope::css()` and `Telescope::js()`. A value containing `"` or `>` breaks out of the attribute context on the dashboard origin.

This escapes the value with `htmlspecialchars(..., ENT_QUOTES)` when the attribute is built, so any caller-supplied string renders inert while normal nonce values (`Str::random()`, base64) are unchanged.

Added a test covering a nonce containing markup.