### PR TITLE
[5.x] Add XML payload and response support to ClientRequestWatcher

### DIFF
--- a/src/Watchers/ClientRequestWatcher.php
+++ b/src/Watchers/ClientRequestWatcher.php
@@ -129,6 +129,12 @@ class ClientRequestWatcher extends Watcher
                     : 'Purged By Telescope';
             }
 
+            if ($xml = $this->parseXml($content)) {
+                return $this->contentWithinLimits($content)
+                    ? $this->hideParameters($xml, Telescope::$hiddenResponseParameters)
+                    : 'Purged By Telescope';
+            }
+
             if (Str::startsWith(strtolower($response->header('Content-Type') ?? ''), 'text/plain')) {
                 return $this->contentWithinLimits($content) ? $content : 'Purged By Telescope';
             }
@@ -208,6 +214,10 @@ class ClientRequestWatcher extends Watcher
     protected function input(Request $request)
     {
         if (! $request->isMultipart()) {
+            if ($xml = $this->parseXml($request->body())) {
+                return $xml;
+            }
+
             return $request->data();
         }
 
@@ -238,6 +248,36 @@ class ClientRequestWatcher extends Watcher
 
             return [$data['name'] => $value];
         })->toArray();
+    }
+
+    /**
+     * Parse XML content into an array.
+     *
+     * @param  string|null  $content
+     * @return array|null
+     */
+    protected function parseXml($content)
+    {
+        if (! is_string($content) || trim($content) === '') {
+            return null;
+        }
+
+        $previous = libxml_use_internal_errors(true);
+
+        try {
+            $xml = simplexml_load_string($content, 'SimpleXMLElement', LIBXML_NOCDATA);
+
+            if ($xml === false) {
+                return null;
+            }
+
+            $array = json_decode(json_encode($xml), true);
+
+            return is_array($array) ? $array : null;
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previous);
+        }
     }
 
     /**

--- a/tests/Watchers/ClientRequestWatcherTest.php
+++ b/tests/Watchers/ClientRequestWatcherTest.php
@@ -281,4 +281,61 @@ class ClientRequestWatcherTest extends FeatureTestCase
         $this->assertSame('first, second', $entry->content['headers']['x-foo']);
         $this->assertSame('single', $entry->content['headers']['x-bar']);
     }
+
+    public function test_client_request_watcher_registers_xml_response()
+    {
+        $xmlContent = '<?xml version="1.0" encoding="UTF-8"?><response><message>success</message><status>200</status></response>';
+
+        Http::fake([
+            '*' => Http::response($xmlContent, 200, ['Content-Type' => 'application/xml']),
+        ]);
+
+        Http::get('https://laravel.com/fake-xml-response');
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::CLIENT_REQUEST, $entry->type);
+        $this->assertSame('GET', $entry->content['method']);
+        $this->assertSame(200, $entry->content['response_status']);
+        $this->assertSame([
+            'message' => 'success',
+            'status' => '200',
+        ], $entry->content['response']);
+    }
+
+    public function test_client_request_watcher_registers_xml_request_payload()
+    {
+        $xmlPayload = '<?xml version="1.0"?><request><user>taylor</user><action>login</action></request>';
+
+        Http::fake(['*' => '']);
+
+        Http::withBody($xmlPayload, 'application/xml')
+            ->post('https://laravel.com/fake-xml-request');
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::CLIENT_REQUEST, $entry->type);
+        $this->assertSame('POST', $entry->content['method']);
+        $this->assertSame([
+            'user' => 'taylor',
+            'action' => 'login',
+        ], $entry->content['payload']);
+    }
+
+    public function test_client_request_watcher_purges_large_xml_response()
+    {
+        $xmlContent = '<response><data>'.str_repeat('x', 70000).'</data></response>';
+
+        Http::fake([
+            '*' => Http::response($xmlContent, 200, ['Content-Type' => 'application/xml']),
+        ]);
+
+        Http::get('https://laravel.com/fake-large-xml-response');
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::CLIENT_REQUEST, $entry->type);
+        $this->assertSame('GET', $entry->content['method']);
+        $this->assertSame('Purged By Telescope', $entry->content['response']);
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR adds support for parsing XML request payloads and responses in `ClientRequestWatcher`.

Currently, when sending or receiving XML via the HTTP Client, Telescope doesn't parse the XML body—recording payloads as empty arrays and responses as `HTML Response`.

With this change, valid XML content is parsed into arrays so it can be inspected, masked (`hideParameters`), and displayed cleanly in the UI similar to JSON payloads.