### PR TITLE
Fix Telescope::css() return type docblock

### DIFF
--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -818,7 +818,7 @@ class Telescope
     /**
      * Get the CSS for the Telescope dashboard.
      *
-     * @return Illuminate\Contracts\Support\Htmlable
+     * @return \Illuminate\Contracts\Support\Htmlable
      */
     public static function css()
     {


### PR DESCRIPTION
## What

`Telescope::css()`'s `@return` docblock is missing the leading backslash (`Illuminate\Contracts\Support\Htmlable` instead of `\Illuminate\Contracts\Support\Htmlable`). Because `Telescope.php` is in namespace `Laravel\Telescope`, static analysis tools resolve the type relative to that namespace instead of the real interface. `Telescope::js()` has the identical docblock right below and already uses the correct fully qualified form; this PR just aligns `css()` with it.

## Benefit

Fixes a false-positive PHPStan/Larastan error (`class.notFound`) for any application that calls a method on `Telescope::css()`'s return value, e.g. `Telescope::css()->toHtml()`.

## Breaking changes

None. Docblock-only change, no runtime behavior is affected.
