### PR TITLE
Add telescope cli commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 composer.phar
 composer.lock
 Thumbs.db
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@
 composer.phar
 composer.lock
 Thumbs.db
-CLAUDE.md

--- a/resources/boost/skills/telescope-debugging/SKILL.md
+++ b/resources/boost/skills/telescope-debugging/SKILL.md
@@ -11,13 +11,15 @@ Telescope records every request, job, and command as a **batch**: the entry itse
 
 2. **Show the batch.** Run `php artisan telescope:show <uuid>`, or `php artisan telescope:show latest:request`. The output is the entry's own detail followed by Queries, Exceptions, Cache, and Logs sections, all from the same batch.
 
-3. **Diagnose from the flags.** In the Queries table, `DUP` marks queries that share one SQL pattern, which usually indicates an N+1, and the Source column names the file and line that ran them. `SLOW` marks queries over the configured threshold. The Cache header states hits, misses, and hit rate. An exception entry shows the message, code context, and stack trace.
+3. **Diagnose from the flags.** In the Queries table, `DUP` marks queries that share one SQL pattern, which usually indicates an N+1, and the Source column names the file and line that ran them, shortened to a basename -- use `--json` for the full path. `SLOW` marks queries over the configured threshold. The Cache header states hits, misses, and hit rate. An exception entry shows the message, code context, and stack trace.
 
 4. **Done** when the finding names a file and line or a specific query, not a symptom.
 
 ### JSON output
 
-Both commands accept `--json`. Prefer it over the tables when you need exact values, want to filter, or the table output would be long. `telescope:list --json` prints an array of entries. `telescope:show --json` prints `{"entry": {...}, "batch": [...]}`, with the batch in chronological order and already filtered by `--type`. Every entry has `id`, `sequence`, `batch_id`, `type`, `content`, `tags`, `family_hash`, and `created_at`. The `content` keys match what the Telescope UI shows for that type, for example `sql`, `time`, `slow`, `file`, `line` on a query, or `class`, `message`, `file`, `line`, `trace` on an exception.
+Both commands accept `--json`. Prefer it over the tables when you need exact values, want to filter, or the table output would be long. `telescope:list --json` prints an array of entries. `telescope:show --json` prints `{"entry": {...}, "batch": [...]}`, with the batch in chronological order and already filtered by `--type`. `telescope:list --json` prints `[]` rather than a message when nothing matches.
+
+Every entry has `id`, `batch_id`, `type`, `content`, `family_hash`, and `created_at`. The `content` keys match what the Telescope UI shows for that type, for example `sql`, `time`, `slow`, `file`, `line` on a query, or `class`, `message`, `file`, `line`, `trace` on an exception. Two fields are not populated by these commands: `tags` is always `[]` (filter with `--tag` instead of reading it back), and `sequence` is `null` when the entry was addressed by UUID.
 
 ```bash
 # Exception class, message, and location for the latest exception
@@ -38,9 +40,9 @@ php artisan telescope:list job --json | jq '.[] | select(.content.status == "fai
 
 ### Reference
 
-- `latest`, `latest:request`, `latest:exception`, and `latest:job` resolve to the most recent entry of that type, so no UUID lookup is needed.
+- `latest` and `latest:{type}` -- for any entry type, so `latest:query` and `latest:job` work too -- resolve to the most recent entry, so no UUID lookup is needed.
 - `--json` on either command skips truncation entirely, so `--full` is only needed for table output.
 - `telescope:show <id> --full` disables truncation of SQL, messages, and payloads.
 - `telescope:show <id> --type=query,exception` limits the batch context to those types when a request produced hundreds of entries.
-- `telescope:list --tag=Auth:42` filters to one authenticated user, since Telescope tags entries with `Auth:<user id>`. `--batch=<id>` lists everything from one request. `--before=<sequence>` pages backwards using the cursor printed in the footer.
+- `telescope:list --tag=Auth:42` filters to one authenticated user, since Telescope tags entries with `Auth:<user id>`. `--batch=<id>` lists everything from one request. `--before=<sequence>` pages backwards using the cursor printed in the footer. `--family=<hash>` groups recurrences of one exception; read the hash from `--json` output's `family_hash`.
 - Run either command with `--help` for the full option list and valid entry types.

--- a/resources/boost/skills/telescope-debugging/SKILL.md
+++ b/resources/boost/skills/telescope-debugging/SKILL.md
@@ -11,13 +11,36 @@ Telescope records every request, job, and command as a **batch**: the entry itse
 
 2. **Show the batch.** Run `php artisan telescope:show <uuid>`, or `php artisan telescope:show latest:request`. The output is the entry's own detail followed by Queries, Exceptions, Cache, and Logs sections, all from the same batch.
 
-3. **Diagnose from the flags.** In the Queries table, `DUP` marks queries that share one SQL pattern, which is an N+1, and the Source column names the file and line that ran them. `SLOW` marks queries over the configured threshold. The Cache header states hits, misses, and hit rate. An exception entry shows the message, code context, and stack trace.
+3. **Diagnose from the flags.** In the Queries table, `DUP` marks queries that share one SQL pattern, which usually indicates an N+1, and the Source column names the file and line that ran them. `SLOW` marks queries over the configured threshold. The Cache header states hits, misses, and hit rate. An exception entry shows the message, code context, and stack trace.
 
 4. **Done** when the finding names a file and line or a specific query, not a symptom.
+
+### JSON output
+
+Both commands accept `--json`. Prefer it over the tables when you need exact values, want to filter, or the table output would be long. `telescope:list --json` prints an array of entries. `telescope:show --json` prints `{"entry": {...}, "batch": [...]}`, with the batch in chronological order and already filtered by `--type`. Every entry has `id`, `sequence`, `batch_id`, `type`, `content`, `tags`, `family_hash`, and `created_at`. The `content` keys match what the Telescope UI shows for that type, for example `sql`, `time`, `slow`, `file`, `line` on a query, or `class`, `message`, `file`, `line`, `trace` on an exception.
+
+```bash
+# Exception class, message, and location for the latest exception
+php artisan telescope:show latest:exception --json | jq '.entry.content | {class, message, file, line}'
+
+# Slow queries in the latest request, with the file that ran them
+php artisan telescope:show latest:request --json --type=query | jq '.batch[] | select(.content.slow) | {sql: .content.sql, time: .content.time, file: .content.file, line: .content.line}'
+
+# Repeated SQL patterns in a request (N+1 candidates), most repeated first
+php artisan telescope:show latest:request --json --type=query | jq '[.batch[].content.sql] | group_by(.) | map({sql: .[0], count: length}) | sort_by(-.count) | .[] | select(.count > 1)'
+
+# Recent 500 responses
+php artisan telescope:list request --json --limit=50 | jq '.[] | select(.content.response_status >= 500) | {id, uri: .content.uri, status: .content.response_status}'
+
+# Failed jobs and their exception messages
+php artisan telescope:list job --json | jq '.[] | select(.content.status == "failed") | {id, name: .content.name, error: .content.exception.message}'
+```
 
 ### Reference
 
 - `latest`, `latest:request`, `latest:exception`, and `latest:job` resolve to the most recent entry of that type, so no UUID lookup is needed.
+- `--json` on either command skips truncation entirely, so `--full` is only needed for table output.
+- `telescope:show <id> --full` disables truncation of SQL, messages, and payloads.
 - `telescope:show <id> --type=query,exception` limits the batch context to those types when a request produced hundreds of entries.
 - `telescope:list --tag=Auth:42` filters to one authenticated user, since Telescope tags entries with `Auth:<user id>`. `--batch=<id>` lists everything from one request. `--before=<sequence>` pages backwards using the cursor printed in the footer.
 - Run either command with `--help` for the full option list and valid entry types.

--- a/resources/boost/skills/telescope-debugging/SKILL.md
+++ b/resources/boost/skills/telescope-debugging/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: telescope-debugging
+description: Inspect what a Laravel app actually did using the telescope:list and telescope:show artisan commands. Use when debugging a slow page, an exception or 500 response, a failing queued job, an N+1 or slow query, or unexpected cache misses in a project that has laravel/telescope installed, even when Telescope is not mentioned.
+---
+
+Telescope records every request, job, and command as a **batch**: the entry itself plus every query, cache operation, log, event, exception, and view it produced. The two commands below read that store from the terminal. Prefer them over the web UI.
+
+### Workflow
+
+1. **Find the entry.** Run `php artisan telescope:list request` (or `exception`, `job`, `query`, `cache`). Pick the row by URI, class, or duration and copy its UUID. Skip this step when the most recent entry is the one you want.
+
+2. **Show the batch.** Run `php artisan telescope:show <uuid>`, or `php artisan telescope:show latest:request`. The output is the entry's own detail followed by Queries, Exceptions, Cache, and Logs sections, all from the same batch.
+
+3. **Diagnose from the flags.** In the Queries table, `DUP` marks queries that share one SQL pattern, which is an N+1, and the Source column names the file and line that ran them. `SLOW` marks queries over the configured threshold. The Cache header states hits, misses, and hit rate. An exception entry shows the message, code context, and stack trace.
+
+4. **Done** when the finding names a file and line or a specific query, not a symptom.
+
+### Reference
+
+- `latest`, `latest:request`, `latest:exception`, and `latest:job` resolve to the most recent entry of that type, so no UUID lookup is needed.
+- `telescope:show <id> --type=query,exception` limits the batch context to those types when a request produced hundreds of entries.
+- `telescope:list --tag=Auth:42` filters to one authenticated user, since Telescope tags entries with `Auth:<user id>`. `--batch=<id>` lists everything from one request. `--before=<sequence>` pages backwards using the cursor printed in the footer.
+- Run either command with `--help` for the full option list and valid entry types.

--- a/src/Console/Concerns/FormatsOutput.php
+++ b/src/Console/Concerns/FormatsOutput.php
@@ -6,9 +6,40 @@ use Carbon\Carbon;
 use Illuminate\Support\Str;
 use Laravel\Telescope\EntryResult;
 use Laravel\Telescope\EntryType;
+use ReflectionClass;
 
 trait FormatsOutput
 {
+    /**
+     * Get all valid entry types.
+     *
+     * @return string[]
+     */
+    protected function entryTypes(): array
+    {
+        return array_values((new ReflectionClass(EntryType::class))->getConstants());
+    }
+
+    /**
+     * Verify the given entry types are valid, printing an error if not.
+     *
+     * @param  string  ...$types
+     * @return bool
+     */
+    protected function validEntryTypes(string ...$types): bool
+    {
+        $invalid = collect($types)->diff($this->entryTypes());
+
+        if ($invalid->isEmpty()) {
+            return true;
+        }
+
+        $this->error('Invalid entry type: '.$invalid->implode(', '));
+        $this->line('Valid types: '.implode(', ', $this->entryTypes()));
+
+        return false;
+    }
+
     /**
      * Get a shortened UUID for display.
      *
@@ -148,13 +179,10 @@ trait FormatsOutput
      * Format a value as a pretty-printed JSON block.
      *
      * @param  mixed  $data
-     * @param  int|null  $limit
      * @return string
      */
-    protected function jsonBlock($data, ?int $limit = null): string
+    protected function jsonBlock($data): string
     {
-        $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
-
-        return $limit ? Str::limit($json, $limit) : $json;
+        return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 }

--- a/src/Console/Concerns/FormatsOutput.php
+++ b/src/Console/Concerns/FormatsOutput.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Laravel\Telescope\Console\Concerns;
+
+use Carbon\Carbon;
+use Illuminate\Support\Str;
+use Laravel\Telescope\EntryResult;
+use Laravel\Telescope\EntryType;
+
+trait FormatsOutput
+{
+    /**
+     * Get a shortened UUID for display.
+     *
+     * @param  string  $uuid
+     * @return string
+     */
+    protected function shortUuid(string $uuid): string
+    {
+        return substr($uuid, 0, 8);
+    }
+
+    /**
+     * Format a timestamp as a human readable difference.
+     *
+     * @param  mixed  $date
+     * @return string
+     */
+    protected function humanTime($date): string
+    {
+        return Carbon::parse($date)->diffForHumans();
+    }
+
+    /**
+     * Generate a one-line summary for the given entry.
+     *
+     * @param  \Laravel\Telescope\EntryResult  $entry
+     * @return string
+     */
+    protected function summarizeEntry(EntryResult $entry): string
+    {
+        $content = $entry->content;
+
+        return match ($entry->type) {
+            EntryType::REQUEST => ($content['method'] ?? '').' '.($content['uri'] ?? '').' -> '.($content['response_status'] ?? '').' ('.($content['duration'] ?? '').'ms)',
+            EntryType::EXCEPTION => Str::limit(($content['class'] ?? '').': '.($content['message'] ?? ''), 80),
+            EntryType::QUERY => Str::limit($content['sql'] ?? '', 60).' ('.($content['time'] ?? '').'ms)',
+            EntryType::JOB => class_basename($content['name'] ?? '').' ['.($content['status'] ?? '').']',
+            EntryType::CACHE => ($content['type'] ?? '').' '.($content['key'] ?? ''),
+            EntryType::LOG => '['.($content['level'] ?? '').'] '.Str::limit($content['message'] ?? '', 60),
+            EntryType::MAIL => Str::limit($content['subject'] ?? $content['mailable'] ?? '', 80),
+            EntryType::EVENT => ($content['name'] ?? '').(isset($content['listeners']) ? ' ('.count($content['listeners']).' listeners)' : ''),
+            EntryType::MODEL => ($content['model'] ?? '').': '.($content['action'] ?? ''),
+            EntryType::GATE => ($content['ability'] ?? '').': '.($content['result'] ?? ''),
+            EntryType::VIEW => $content['name'] ?? '',
+            EntryType::NOTIFICATION => class_basename($content['notification'] ?? '').' via '.($content['channel'] ?? ''),
+            EntryType::REDIS => Str::limit($content['command'] ?? '', 60),
+            EntryType::CLIENT_REQUEST => ($content['method'] ?? '').' '.Str::limit($content['uri'] ?? '', 40).' -> '.($content['response_status'] ?? 'N/A'),
+            EntryType::COMMAND => $content['command'] ?? '',
+            EntryType::SCHEDULED_TASK => ($content['command'] ?? '').' ['.($content['expression'] ?? '').']',
+            default => Str::limit(json_encode($content), 80),
+        };
+    }
+
+    /**
+     * Colorize an HTTP method for console output.
+     *
+     * @param  string  $method
+     * @return string
+     */
+    protected function colorMethod(string $method): string
+    {
+        return match (strtoupper($method)) {
+            'GET' => "<fg=gray>{$method}</>",
+            'POST', 'PATCH', 'PUT' => "<fg=blue>{$method}</>",
+            'DELETE' => "<fg=red>{$method}</>",
+            default => $method,
+        };
+    }
+
+    /**
+     * Colorize an HTTP status code for console output.
+     *
+     * @param  int  $status
+     * @return string
+     */
+    protected function colorStatus(int $status): string
+    {
+        return match (true) {
+            $status < 300 => "<fg=green>{$status}</>",
+            $status < 400 => "<fg=blue>{$status}</>",
+            $status < 500 => "<fg=yellow>{$status}</>",
+            default => "<fg=red>{$status}</>",
+        };
+    }
+
+    /**
+     * Colorize a log level for console output.
+     *
+     * @param  string  $level
+     * @return string
+     */
+    protected function colorLevel(string $level): string
+    {
+        return match ($level) {
+            'emergency', 'alert', 'critical', 'error' => "<fg=red>{$level}</>",
+            'warning' => "<fg=yellow>{$level}</>",
+            'notice', 'info' => "<fg=blue>{$level}</>",
+            'debug' => "<fg=gray>{$level}</>",
+            default => $level,
+        };
+    }
+
+    /**
+     * Colorize a cache action for console output.
+     *
+     * @param  string  $type
+     * @return string
+     */
+    protected function colorCacheAction(string $type): string
+    {
+        return match ($type) {
+            'hit' => '<fg=green>HIT</>',
+            'missed' => '<fg=red>MISS</>',
+            'set' => '<fg=blue>SET</>',
+            'forget' => '<fg=yellow>FORGET</>',
+            default => $type,
+        };
+    }
+
+    /**
+     * Colorize a job status for console output.
+     *
+     * @param  string  $status
+     * @return string
+     */
+    protected function colorJobStatus(string $status): string
+    {
+        return match ($status) {
+            'processed' => "<fg=green>{$status}</>",
+            'failed' => "<fg=red>{$status}</>",
+            'pending' => "<fg=yellow>{$status}</>",
+            default => $status,
+        };
+    }
+
+    /**
+     * Format a value as a pretty-printed JSON block.
+     *
+     * @param  mixed  $data
+     * @param  int|null  $limit
+     * @return string
+     */
+    protected function jsonBlock($data, ?int $limit = null): string
+    {
+        $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return $limit ? Str::limit($json, $limit) : $json;
+    }
+}

--- a/src/Console/Concerns/FormatsOutput.php
+++ b/src/Console/Concerns/FormatsOutput.php
@@ -2,42 +2,42 @@
 
 namespace Laravel\Telescope\Console\Concerns;
 
-use Carbon\Carbon;
 use Illuminate\Support\Str;
 use Laravel\Telescope\EntryResult;
 use Laravel\Telescope\EntryType;
-use ReflectionClass;
 
 trait FormatsOutput
 {
-    /**
-     * Get all valid entry types.
-     *
-     * @return string[]
-     */
-    protected function entryTypes(): array
-    {
-        return array_values((new ReflectionClass(EntryType::class))->getConstants());
-    }
-
     /**
      * Verify the given entry types are valid, printing an error if not.
      *
      * @param  string  ...$types
      * @return bool
      */
-    protected function validEntryTypes(string ...$types): bool
+    protected function ensureValidEntryTypes(string ...$types): bool
     {
-        $invalid = collect($types)->diff($this->entryTypes());
+        $invalid = collect($types)->diff(EntryType::all());
 
         if ($invalid->isEmpty()) {
             return true;
         }
 
         $this->error('Invalid entry type: '.$invalid->implode(', '));
-        $this->line('Valid types: '.implode(', ', $this->entryTypes()));
+        $this->line('Valid types: '.implode(', ', EntryType::all()));
 
         return false;
+    }
+
+    /**
+     * Append a unit to the given value, or return an empty string if it has none.
+     *
+     * @param  mixed  $value
+     * @param  string  $unit
+     * @return string
+     */
+    protected function unit($value, string $unit): string
+    {
+        return $value === null || $value === '' ? '' : $value.$unit;
     }
 
     /**
@@ -54,12 +54,12 @@ trait FormatsOutput
     /**
      * Format a timestamp as a human readable difference.
      *
-     * @param  mixed  $date
+     * @param  \Carbon\CarbonInterface  $date
      * @return string
      */
     protected function humanTime($date): string
     {
-        return Carbon::parse($date)->diffForHumans();
+        return $date->diffForHumans();
     }
 
     /**
@@ -89,6 +89,7 @@ trait FormatsOutput
             EntryType::CLIENT_REQUEST => ($content['method'] ?? '').' '.Str::limit($content['uri'] ?? '', 40).' -> '.($content['response_status'] ?? 'N/A'),
             EntryType::COMMAND => $content['command'] ?? '',
             EntryType::SCHEDULED_TASK => ($content['command'] ?? '').' ['.($content['expression'] ?? '').']',
+            EntryType::DUMP => Str::limit(trim(strip_tags($content['dump'] ?? '')), 80),
             default => Str::limit(json_encode($content), 80),
         };
     }

--- a/src/Console/ListCommand.php
+++ b/src/Console/ListCommand.php
@@ -10,7 +10,6 @@ use Laravel\Telescope\Contracts\EntriesRepository;
 use Laravel\Telescope\EntryType;
 use Laravel\Telescope\Storage\EntryQueryOptions;
 use Laravel\Telescope\Telescope;
-use ReflectionClass;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'telescope:list')]
@@ -29,7 +28,8 @@ class ListCommand extends Command
         {--batch= : Filter by batch ID}
         {--family= : Filter by family hash}
         {--limit=20 : Max entries to show}
-        {--before= : Pagination cursor (sequence ID)}';
+        {--before= : Pagination cursor (sequence ID)}
+        {--json : Output entries as JSON}';
 
     /**
      * The console command description.
@@ -49,18 +49,19 @@ class ListCommand extends Command
         return Telescope::withoutRecording(function () use ($storage) {
             $type = $this->argument('type');
 
-            $types = (new ReflectionClass(EntryType::class))->getConstants();
-
-            if ($type && ! in_array($type, $types)) {
-                $this->error("Invalid entry type: {$type}");
-                $this->line('Valid types: '.implode(', ', $types));
-
+            if ($type && ! $this->validEntryTypes($type)) {
                 return 1;
             }
 
             $limit = (int) $this->option('limit');
 
             $entries = $storage->get($type, $this->queryOptions($limit));
+
+            if ($this->option('json')) {
+                $this->line(json_encode($entries->all(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+                return;
+            }
 
             if ($entries->isEmpty()) {
                 $this->warn('No entries found.');

--- a/src/Console/ListCommand.php
+++ b/src/Console/ListCommand.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Laravel\Telescope\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Laravel\Telescope\Console\Concerns\FormatsOutput;
+use Laravel\Telescope\Contracts\EntriesRepository;
+use Laravel\Telescope\EntryType;
+use Laravel\Telescope\Storage\EntryQueryOptions;
+use Laravel\Telescope\Telescope;
+use ReflectionClass;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'telescope:list')]
+class ListCommand extends Command
+{
+    use FormatsOutput;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'telescope:list
+        {type? : Entry type (request, query, exception, job, cache, mail, log, event, gate, model, notification, redis, view, command, schedule, client_request, batch, dump)}
+        {--tag= : Filter by tag}
+        {--batch= : Filter by batch ID}
+        {--family= : Filter by family hash}
+        {--limit=20 : Max entries to show}
+        {--before= : Pagination cursor (sequence ID)}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'List Telescope entries';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
+     * @return int|void
+     */
+    public function handle(EntriesRepository $storage)
+    {
+        return Telescope::withoutRecording(function () use ($storage) {
+            $type = $this->argument('type');
+
+            $types = (new ReflectionClass(EntryType::class))->getConstants();
+
+            if ($type && ! in_array($type, $types)) {
+                $this->error("Invalid entry type: {$type}");
+                $this->line('Valid types: '.implode(', ', $types));
+
+                return 1;
+            }
+
+            $limit = (int) $this->option('limit');
+
+            $entries = $storage->get($type, $this->queryOptions($limit));
+
+            if ($entries->isEmpty()) {
+                $this->warn('No entries found.');
+
+                return;
+            }
+
+            $this->renderTable($type, $entries);
+
+            $nextPage = $limit > 0 && $entries->count() >= $limit
+                ? "Use --before={$entries->last()->sequence} for next page"
+                : 'No more entries';
+
+            $this->info("Showing {$entries->count()} entries — {$nextPage}");
+        });
+    }
+
+    /**
+     * Build the entry query options from the command's options.
+     *
+     * @param  int  $limit
+     * @return \Laravel\Telescope\Storage\EntryQueryOptions
+     */
+    protected function queryOptions(int $limit): EntryQueryOptions
+    {
+        return (new EntryQueryOptions)
+            ->tag($this->option('tag'))
+            ->batchId($this->option('batch'))
+            ->familyHash($this->option('family'))
+            ->beforeSequence($this->option('before'))
+            ->limit($limit);
+    }
+
+    /**
+     * Render the entries table for the given entry type.
+     *
+     * @param  string|null  $type
+     * @param  \Illuminate\Support\Collection  $entries
+     * @return void
+     */
+    protected function renderTable(?string $type, Collection $entries): void
+    {
+        [$headers, $row] = $this->tableColumns($type);
+
+        $this->table($headers, $entries->map($row)->all());
+    }
+
+    /**
+     * Get the table headers and row formatter for the given entry type.
+     *
+     * @param  string|null  $type
+     * @return array{0: string[], 1: \Closure}
+     */
+    protected function tableColumns(?string $type): array
+    {
+        return match ($type) {
+            EntryType::REQUEST => [
+                ['UUID', 'Method', 'URI', 'Status', 'Duration', 'Created'],
+                fn ($entry) => [
+                    $this->shortUuid($entry->id),
+                    $this->colorMethod($entry->content['method'] ?? ''),
+                    Str::limit($entry->content['uri'] ?? '', 40),
+                    $this->colorStatus((int) ($entry->content['response_status'] ?? 0)),
+                    ($entry->content['duration'] ?? '').'ms',
+                    $this->humanTime($entry->createdAt),
+                ],
+            ],
+            EntryType::QUERY => [
+                ['UUID', 'SQL', 'Time', 'Slow', 'Connection', 'Created'],
+                fn ($entry) => [
+                    $this->shortUuid($entry->id),
+                    Str::limit($entry->content['sql'] ?? '', 60),
+                    ($entry->content['time'] ?? '').'ms',
+                    ! empty($entry->content['slow']) ? '<fg=red>Yes</>' : 'No',
+                    $entry->content['connection'] ?? '',
+                    $this->humanTime($entry->createdAt),
+                ],
+            ],
+            EntryType::EXCEPTION => [
+                ['UUID', 'Class', 'Message', 'Occurrences', 'Created'],
+                fn ($entry) => [
+                    $this->shortUuid($entry->id),
+                    class_basename($entry->content['class'] ?? ''),
+                    Str::limit($entry->content['message'] ?? '', 50),
+                    $entry->content['occurrences'] ?? 1,
+                    $this->humanTime($entry->createdAt),
+                ],
+            ],
+            EntryType::JOB => [
+                ['UUID', 'Name', 'Queue', 'Status', 'Created'],
+                fn ($entry) => [
+                    $this->shortUuid($entry->id),
+                    class_basename($entry->content['name'] ?? ''),
+                    $entry->content['queue'] ?? '',
+                    $this->colorJobStatus($entry->content['status'] ?? ''),
+                    $this->humanTime($entry->createdAt),
+                ],
+            ],
+            EntryType::CACHE => [
+                ['UUID', 'Action', 'Key', 'Created'],
+                fn ($entry) => [
+                    $this->shortUuid($entry->id),
+                    $this->colorCacheAction($entry->content['type'] ?? ''),
+                    Str::limit($entry->content['key'] ?? '', 50),
+                    $this->humanTime($entry->createdAt),
+                ],
+            ],
+            EntryType::LOG => [
+                ['UUID', 'Level', 'Message', 'Created'],
+                fn ($entry) => [
+                    $this->shortUuid($entry->id),
+                    $this->colorLevel($entry->content['level'] ?? ''),
+                    Str::limit($entry->content['message'] ?? '', 60),
+                    $this->humanTime($entry->createdAt),
+                ],
+            ],
+            EntryType::MAIL => [
+                ['UUID', 'Mailable', 'Subject', 'To', 'Created'],
+                fn ($entry) => [
+                    $this->shortUuid($entry->id),
+                    class_basename($entry->content['mailable'] ?? ''),
+                    Str::limit($entry->content['subject'] ?? '', 40),
+                    Str::limit(implode(', ', array_keys($entry->content['to'] ?? [])), 30),
+                    $this->humanTime($entry->createdAt),
+                ],
+            ],
+            EntryType::COMMAND => [
+                ['UUID', 'Command', 'Exit Code', 'Created'],
+                fn ($entry) => [
+                    $this->shortUuid($entry->id),
+                    Str::limit($entry->content['command'] ?? '', 50),
+                    $entry->content['exit_code'] ?? '',
+                    $this->humanTime($entry->createdAt),
+                ],
+            ],
+            EntryType::CLIENT_REQUEST => [
+                ['UUID', 'Method', 'URI', 'Status', 'Duration', 'Created'],
+                fn ($entry) => [
+                    $this->shortUuid($entry->id),
+                    $this->colorMethod($entry->content['method'] ?? ''),
+                    Str::limit($entry->content['uri'] ?? '', 40),
+                    isset($entry->content['response_status']) ? $this->colorStatus((int) $entry->content['response_status']) : 'N/A',
+                    ($entry->content['duration'] ?? '').'ms',
+                    $this->humanTime($entry->createdAt),
+                ],
+            ],
+            default => [
+                ['UUID', 'Type', 'Summary', 'Created'],
+                fn ($entry) => [
+                    $this->shortUuid($entry->id),
+                    $entry->type,
+                    $this->summarizeEntry($entry),
+                    $this->humanTime($entry->createdAt),
+                ],
+            ],
+        };
+    }
+}

--- a/src/Console/ListCommand.php
+++ b/src/Console/ListCommand.php
@@ -3,7 +3,6 @@
 namespace Laravel\Telescope\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Telescope\Console\Concerns\FormatsOutput;
 use Laravel\Telescope\Contracts\EntriesRepository;
@@ -23,7 +22,7 @@ class ListCommand extends Command
      * @var string
      */
     protected $signature = 'telescope:list
-        {type? : Entry type (request, query, exception, job, cache, mail, log, event, gate, model, notification, redis, view, command, schedule, client_request, batch, dump)}
+        {type? : Entry type (omit or pass an invalid type to list the valid ones)}
         {--tag= : Filter by tag}
         {--batch= : Filter by batch ID}
         {--family= : Filter by family hash}
@@ -49,16 +48,20 @@ class ListCommand extends Command
         return Telescope::withoutRecording(function () use ($storage) {
             $type = $this->argument('type');
 
-            if ($type && ! $this->validEntryTypes($type)) {
+            if ($type && ! $this->ensureValidEntryTypes($type)) {
                 return 1;
             }
 
-            $limit = (int) $this->option('limit');
+            if (! ctype_digit((string) $this->option('limit')) || ($limit = (int) $this->option('limit')) < 1) {
+                $this->error('The --limit option must be a positive integer.');
 
-            $entries = $storage->get($type, $this->queryOptions($limit));
+                return 1;
+            }
+
+            $entries = collect($storage->get($type, $this->queryOptions($limit)));
 
             if ($this->option('json')) {
-                $this->line(json_encode($entries->all(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+                $this->line($this->jsonBlock($entries->all()));
 
                 return;
             }
@@ -69,13 +72,15 @@ class ListCommand extends Command
                 return;
             }
 
-            $this->renderTable($type, $entries);
+            [$headers, $row] = $this->tableColumns($type);
 
-            $nextPage = $limit > 0 && $entries->count() >= $limit
+            $this->table($headers, $entries->map($row)->all());
+
+            $nextPage = $entries->count() >= $limit
                 ? "Use --before={$entries->last()->sequence} for next page"
                 : 'No more entries';
 
-            $this->info("Showing {$entries->count()} entries — {$nextPage}");
+            $this->info('Showing '.$entries->count().' '.Str::plural('entry', $entries->count())." - {$nextPage}");
         });
     }
 
@@ -96,20 +101,6 @@ class ListCommand extends Command
     }
 
     /**
-     * Render the entries table for the given entry type.
-     *
-     * @param  string|null  $type
-     * @param  \Illuminate\Support\Collection  $entries
-     * @return void
-     */
-    protected function renderTable(?string $type, Collection $entries): void
-    {
-        [$headers, $row] = $this->tableColumns($type);
-
-        $this->table($headers, $entries->map($row)->all());
-    }
-
-    /**
      * Get the table headers and row formatter for the given entry type.
      *
      * @param  string|null  $type
@@ -125,7 +116,7 @@ class ListCommand extends Command
                     $this->colorMethod($entry->content['method'] ?? ''),
                     Str::limit($entry->content['uri'] ?? '', 40),
                     $this->colorStatus((int) ($entry->content['response_status'] ?? 0)),
-                    ($entry->content['duration'] ?? '').'ms',
+                    $this->unit($entry->content['duration'] ?? null, 'ms'),
                     $this->humanTime($entry->createdAt),
                 ],
             ],
@@ -134,7 +125,7 @@ class ListCommand extends Command
                 fn ($entry) => [
                     $this->shortUuid($entry->id),
                     Str::limit($entry->content['sql'] ?? '', 60),
-                    ($entry->content['time'] ?? '').'ms',
+                    $this->unit($entry->content['time'] ?? null, 'ms'),
                     ! empty($entry->content['slow']) ? '<fg=red>Yes</>' : 'No',
                     $entry->content['connection'] ?? '',
                     $this->humanTime($entry->createdAt),
@@ -204,7 +195,7 @@ class ListCommand extends Command
                     $this->colorMethod($entry->content['method'] ?? ''),
                     Str::limit($entry->content['uri'] ?? '', 40),
                     isset($entry->content['response_status']) ? $this->colorStatus((int) $entry->content['response_status']) : 'N/A',
-                    ($entry->content['duration'] ?? '').'ms',
+                    $this->unit($entry->content['duration'] ?? null, 'ms'),
                     $this->humanTime($entry->createdAt),
                 ],
             ],

--- a/src/Console/ShowCommand.php
+++ b/src/Console/ShowCommand.php
@@ -1,0 +1,607 @@
+<?php
+
+namespace Laravel\Telescope\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Laravel\Telescope\Console\Concerns\FormatsOutput;
+use Laravel\Telescope\Contracts\EntriesRepository;
+use Laravel\Telescope\EntryResult;
+use Laravel\Telescope\EntryType;
+use Laravel\Telescope\Storage\EntryQueryOptions;
+use Laravel\Telescope\Telescope;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'telescope:show')]
+class ShowCommand extends Command
+{
+    use FormatsOutput;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'telescope:show
+        {id : Entry UUID, "latest", or "latest:{type}" (e.g. latest:exception)}
+        {--type= : Filter batch entries to specific type(s), comma-separated}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Show a Telescope entry with full batch context';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
+     * @return int|void
+     */
+    public function handle(EntriesRepository $storage)
+    {
+        return Telescope::withoutRecording(function () use ($storage) {
+            $entry = $this->findEntry($storage, $this->argument('id'));
+
+            if (! $entry) {
+                return 1;
+            }
+
+            $batchId = $entry->content['updated_batch_id'] ?? $entry->batchId;
+
+            $batchEntries = $batchId
+                ? collect($storage->get(null, EntryQueryOptions::forBatchId($batchId)->limit(-1)))
+                : collect();
+
+            $batchByType = $batchEntries->reject(fn ($other) => $other->id === $entry->id)->groupBy('type');
+
+            if ($types = $this->option('type')) {
+                $batchByType = $batchByType->only(array_map('trim', explode(',', $types)));
+            }
+
+            $this->renderEntry($entry);
+            $this->renderBatchContext($batchId, $batchByType);
+        });
+    }
+
+    /**
+     * Find the entry with the given ID, supporting the "latest" and "latest:{type}" shortcuts.
+     *
+     * @param  \Laravel\Telescope\Contracts\EntriesRepository  $storage
+     * @param  string  $id
+     * @return \Laravel\Telescope\EntryResult|null
+     */
+    protected function findEntry(EntriesRepository $storage, string $id): ?EntryResult
+    {
+        if ($id === 'latest' || str_starts_with($id, 'latest:')) {
+            $type = $id === 'latest' ? null : Str::after($id, 'latest:');
+
+            $entry = collect($storage->get($type, (new EntryQueryOptions)->limit(1)))->first();
+
+            if (! $entry) {
+                $this->error('No '.($type ? "{$type} " : '').'entries found.');
+            }
+
+            return $entry;
+        }
+
+        try {
+            return $storage->find($id);
+        } catch (ModelNotFoundException) {
+            $this->error("Entry not found: {$id}");
+
+            return null;
+        }
+    }
+
+    /**
+     * Render the full detail view for the given entry.
+     *
+     * @param  \Laravel\Telescope\EntryResult  $entry
+     * @return void
+     */
+    protected function renderEntry(EntryResult $entry): void
+    {
+        match ($entry->type) {
+            EntryType::REQUEST => $this->renderRequest($entry),
+            EntryType::EXCEPTION => $this->renderException($entry),
+            EntryType::JOB => $this->renderJob($entry),
+            default => $this->renderGenericEntry($entry),
+        };
+    }
+
+    /**
+     * Render a request entry.
+     *
+     * @param  \Laravel\Telescope\EntryResult  $entry
+     * @return void
+     */
+    protected function renderRequest(EntryResult $entry): void
+    {
+        $content = $entry->content;
+
+        $this->info('Request: '.($content['method'] ?? '').' '.($content['uri'] ?? '').' → '.($content['response_status'] ?? ''));
+
+        $this->details($entry, [
+            'Controller' => $content['controller_action'] ?? 'Closure',
+            'Duration' => ($content['duration'] ?? '').'ms',
+            'Memory' => ($content['memory'] ?? '').'MB',
+            'IP' => $content['ip_address'] ?? '',
+            'Middleware' => implode(', ', (array) ($content['middleware'] ?? [])),
+            'User' => $this->formatUser($content['user'] ?? []),
+        ]);
+
+        $this->block('Payload', $content['payload'] ?? null);
+        $this->block('Response', $content['response'] ?? null, 1000);
+    }
+
+    /**
+     * Render an exception entry with code context and stack trace.
+     *
+     * @param  \Laravel\Telescope\EntryResult  $entry
+     * @return void
+     */
+    protected function renderException(EntryResult $entry): void
+    {
+        $content = $entry->content;
+
+        $this->info('Exception: '.class_basename($content['class'] ?? ''));
+
+        $this->details($entry, [
+            'Class' => $content['class'] ?? '',
+            'File' => ($content['file'] ?? '').':'.($content['line'] ?? ''),
+            'Occurrences' => (string) ($content['occurrences'] ?? 1),
+            'Resolved' => $content['resolved_at'] ?? '<fg=yellow>No</>',
+        ]);
+
+        $this->error($content['message'] ?? '');
+
+        if (! empty($content['line_preview'])) {
+            $this->info('Code Context');
+
+            $this->table([], collect($content['line_preview'])->map(fn ($code, $lineNo) => [
+                $lineNo == ($content['line'] ?? 0) ? "<fg=red>{$lineNo} →</>" : $lineNo,
+                $code,
+            ])->values());
+        }
+
+        $this->renderTrace($content['trace'] ?? []);
+    }
+
+    /**
+     * Render a job entry with exception detail if failed.
+     *
+     * @param  \Laravel\Telescope\EntryResult  $entry
+     * @return void
+     */
+    protected function renderJob(EntryResult $entry): void
+    {
+        $content = $entry->content;
+
+        $this->info('Job: '.class_basename($content['name'] ?? '').' ['.($content['status'] ?? 'pending').']');
+
+        $this->details($entry, [
+            'Status' => $this->colorJobStatus($content['status'] ?? 'pending'),
+            'Queue' => $content['queue'] ?? '',
+            'Connection' => $content['connection'] ?? '',
+            'Tries' => (string) ($content['tries'] ?? ''),
+            'Timeout' => ($content['timeout'] ?? '').'s',
+        ]);
+
+        $this->block('Data', $content['data'] ?? null, 500);
+
+        if (! empty($content['exception'])) {
+            $this->error($content['exception']['message'] ?? '');
+            $this->renderTrace($content['exception']['trace'] ?? [], 10);
+        }
+    }
+
+    /**
+     * Render any entry type using a data-driven field map.
+     *
+     * @param  \Laravel\Telescope\EntryResult  $entry
+     * @return void
+     */
+    protected function renderGenericEntry(EntryResult $entry): void
+    {
+        $content = $entry->content;
+        $config = $this->entryFieldConfig($entry->type, $content) + ['subtitle' => '', 'fields' => [], 'list' => null, 'blocks' => []];
+
+        $this->info(rtrim("{$config['label']}: {$config['subtitle']}", ': '));
+
+        $this->details($entry, $config['fields']);
+
+        if (! empty($config['list'])) {
+            $this->listing($config['list']['label'], $config['list']['items']);
+        }
+
+        foreach ($config['blocks'] as $label => $key) {
+            $this->block($label, $key === null ? $content : ($content[$key] ?? null), $key === null ? 1000 : 500);
+        }
+    }
+
+    /**
+     * Get the field configuration for a given entry type.
+     *
+     * @param  string  $type
+     * @param  array  $content
+     * @return array
+     */
+    protected function entryFieldConfig(string $type, array $content): array
+    {
+        return match ($type) {
+            EntryType::QUERY => [
+                'label' => 'Query',
+                'fields' => [
+                    'Connection' => $content['connection'] ?? '',
+                    'Duration' => ($content['time'] ?? '').'ms'.(! empty($content['slow']) ? '  <fg=red>SLOW</>' : ''),
+                    'Source' => isset($content['file']) ? ($content['file']).':'.($content['line'] ?? '') : '',
+                    'SQL' => $content['sql'] ?? '',
+                ],
+                'blocks' => ['Bindings' => 'bindings'],
+            ],
+            EntryType::CACHE => [
+                'label' => 'Cache', 'subtitle' => $content['type'] ?? '',
+                'fields' => [
+                    'Key' => $content['key'] ?? '',
+                    'Expiration' => isset($content['expiration']) ? $content['expiration'].'s' : '',
+                ],
+                'blocks' => ['Value' => 'value'],
+            ],
+            EntryType::LOG => [
+                'label' => 'Log', 'subtitle' => $content['level'] ?? '',
+                'fields' => ['Message' => $content['message'] ?? ''],
+                'blocks' => ['Context' => 'context'],
+            ],
+            EntryType::MAIL => [
+                'label' => 'Mail', 'subtitle' => $content['subject'] ?? '',
+                'fields' => [
+                    'Mailable' => $content['mailable'] ?? '', 'Subject' => $content['subject'] ?? '',
+                    'Queued' => ! empty($content['queued']) ? 'Yes' : '',
+                    'To' => $this->formatAddresses($content['to'] ?? []),
+                    'From' => $this->formatAddresses($content['from'] ?? []),
+                ],
+            ],
+            EntryType::EVENT => [
+                'label' => 'Event', 'subtitle' => $content['name'] ?? '',
+                'fields' => ['Broadcast' => ! empty($content['broadcast']) ? 'Yes' : ''],
+                'list' => ! empty($content['listeners']) ? ['label' => 'Listeners', 'items' => collect($content['listeners'])->map(fn ($listener) => $listener['name'].(empty($listener['queued']) ? '' : ' (queued)'))->all()] : null,
+                'blocks' => ['Payload' => 'payload'],
+            ],
+            EntryType::COMMAND => [
+                'label' => 'Command', 'subtitle' => $content['command'] ?? '',
+                'fields' => ['Exit Code' => (string) ($content['exit_code'] ?? '')],
+                'blocks' => ['Arguments' => 'arguments', 'Options' => 'options'],
+            ],
+            EntryType::SCHEDULED_TASK => [
+                'label' => 'Scheduled Task', 'subtitle' => $content['command'] ?? '',
+                'fields' => [
+                    'Expression' => $content['expression'] ?? '', 'Timezone' => $content['timezone'] ?? '',
+                    'Description' => $content['description'] ?? '',
+                ],
+                'blocks' => ['Output' => 'output'],
+            ],
+            EntryType::CLIENT_REQUEST => [
+                'label' => 'Client Request', 'subtitle' => ($content['method'] ?? '').' '.($content['uri'] ?? ''),
+                'fields' => [
+                    'Status' => isset($content['response_status']) ? $this->colorStatus((int) $content['response_status']) : 'N/A',
+                    'Duration' => ($content['duration'] ?? '').'ms',
+                ],
+                'blocks' => ['Payload' => 'payload', 'Response' => 'response'],
+            ],
+            EntryType::GATE => [
+                'label' => 'Gate',
+                'subtitle' => ($content['ability'] ?? '').': '.($content['result'] ?? ''),
+                'fields' => ['Source' => isset($content['file']) ? $content['file'].':'.($content['line'] ?? '') : ''],
+                'blocks' => ['Arguments' => 'arguments'],
+            ],
+            EntryType::MODEL => [
+                'label' => 'Model', 'subtitle' => ($content['model'] ?? '').': '.($content['action'] ?? ''),
+                'fields' => ['Count' => isset($content['count']) ? (string) $content['count'] : ''],
+                'blocks' => ['Changes' => 'changes'],
+            ],
+            EntryType::NOTIFICATION => [
+                'label' => 'Notification', 'subtitle' => class_basename($content['notification'] ?? ''),
+                'fields' => [
+                    'Channel' => $content['channel'] ?? '', 'Notifiable' => $content['notifiable'] ?? '',
+                    'Queued' => ! empty($content['queued']) ? 'Yes' : '',
+                ],
+            ],
+            EntryType::VIEW => [
+                'label' => 'View', 'subtitle' => $content['name'] ?? '',
+                'fields' => ['Path' => $content['path'] ?? ''],
+                'list' => ! empty($content['composers']) ? [
+                    'label' => 'Composers',
+                    'items' => collect($content['composers'])->map(fn ($composer) => ($composer['name'] ?? '').(isset($composer['type']) ? " ({$composer['type']})" : ''))->all(),
+                ] : null,
+                'blocks' => ['Data' => 'data'],
+            ],
+            EntryType::REDIS => [
+                'label' => 'Redis',
+                'fields' => [
+                    'Connection' => $content['connection'] ?? '',
+                    'Duration' => ($content['time'] ?? '').'ms',
+                    'Command' => $content['command'] ?? '',
+                ],
+            ],
+            default => [
+                'label' => ucfirst($type),
+                'blocks' => ['Content' => null],
+            ],
+        };
+    }
+
+    /**
+     * Render the batch context for the given entry.
+     *
+     * @param  string|null  $batchId
+     * @param  \Illuminate\Support\Collection  $batchByType
+     * @return void
+     */
+    protected function renderBatchContext(?string $batchId, Collection $batchByType): void
+    {
+        if ($batchByType->isEmpty()) {
+            return;
+        }
+
+        $this->info('Related Entries — batch '.$this->shortUuid($batchId));
+
+        $this->renderBatchQueries($batchByType->get(EntryType::QUERY, collect()));
+        $this->renderBatchExceptions($batchByType->get(EntryType::EXCEPTION, collect()));
+        $this->renderBatchCache($batchByType->get(EntryType::CACHE, collect()));
+        $this->renderBatchLogs($batchByType->get(EntryType::LOG, collect()));
+
+        $compactTypes = [
+            EntryType::VIEW => 'Views', EntryType::MODEL => 'Models',
+            EntryType::EVENT => 'Events', EntryType::GATE => 'Gates',
+            EntryType::MAIL => 'Mail', EntryType::NOTIFICATION => 'Notifications',
+            EntryType::REDIS => 'Redis', EntryType::CLIENT_REQUEST => 'Client Requests',
+            EntryType::JOB => 'Jobs', EntryType::COMMAND => 'Commands',
+            EntryType::SCHEDULED_TASK => 'Schedule',
+        ];
+
+        foreach ($compactTypes as $type => $label) {
+            $entries = $batchByType->get($type, collect());
+
+            if ($entries->isNotEmpty()) {
+                $this->listing("{$label} ({$entries->count()})", $entries->take(5)->map(fn ($related) => $this->summarizeEntry($related))->all());
+                $this->more($entries->count(), 5, $label);
+            }
+        }
+    }
+
+    /**
+     * Render the batch query section with stats.
+     *
+     * @param  \Illuminate\Support\Collection  $queries
+     * @return void
+     */
+    protected function renderBatchQueries(Collection $queries): void
+    {
+        if ($queries->isEmpty()) {
+            return;
+        }
+
+        $totalTime = round($queries->sum(fn ($query) => (float) ($query->content['time'] ?? 0)), 2);
+        $slowCount = $queries->filter(fn ($query) => ! empty($query->content['slow']))->count();
+
+        $duplicates = $queries->groupBy(fn ($query) => $query->content['hash'] ?? $query->content['sql'] ?? '')
+            ->filter(fn ($group) => $group->count() > 1);
+
+        $this->info(
+            "Queries — {$queries->count()} total, {$totalTime}ms".
+            ($slowCount > 0 ? ", {$slowCount} slow" : '').
+            ($duplicates->isNotEmpty() ? ", {$duplicates->count()} duplicate groups" : '')
+        );
+
+        $this->table(
+            ['#', 'UUID', 'Time', 'SQL', 'Source', 'Flags'],
+            $queries->take(20)->values()->map(fn ($query, $index) => [
+                $index + 1,
+                $this->shortUuid($query->id),
+                round((float) ($query->content['time'] ?? 0), 2).'ms',
+                Str::limit($query->content['sql'] ?? '', 60),
+                isset($query->content['file']) ? basename($query->content['file']).':'.($query->content['line'] ?? '') : '',
+                trim(
+                    (! empty($query->content['slow']) ? '<fg=red>SLOW</> ' : '').
+                    ($duplicates->has($query->content['hash'] ?? $query->content['sql'] ?? '') ? '<fg=yellow>DUP</>' : '')
+                ),
+            ])
+        );
+
+        $this->more($queries->count(), 20, 'queries');
+    }
+
+    /**
+     * Render the batch exception section.
+     *
+     * @param  \Illuminate\Support\Collection  $exceptions
+     * @return void
+     */
+    protected function renderBatchExceptions(Collection $exceptions): void
+    {
+        if ($exceptions->isEmpty()) {
+            return;
+        }
+
+        $this->info("Exceptions — {$exceptions->count()}");
+
+        $this->table(
+            ['UUID', 'Exception', 'Location'],
+            $exceptions->map(fn ($exception) => [
+                $this->shortUuid($exception->id),
+                ($exception->content['class'] ?? '').': '.Str::limit($exception->content['message'] ?? '', 80),
+                ($exception->content['file'] ?? '').':'.($exception->content['line'] ?? ''),
+            ])
+        );
+    }
+
+    /**
+     * Render the batch cache section with hit rate.
+     *
+     * @param  \Illuminate\Support\Collection  $cacheEntries
+     * @return void
+     */
+    protected function renderBatchCache(Collection $cacheEntries): void
+    {
+        if ($cacheEntries->isEmpty()) {
+            return;
+        }
+
+        $hits = $cacheEntries->filter(fn ($cacheEntry) => ($cacheEntry->content['type'] ?? '') === 'hit')->count();
+        $misses = $cacheEntries->filter(fn ($cacheEntry) => ($cacheEntry->content['type'] ?? '') === 'missed')->count();
+        $hitRate = round($hits / $cacheEntries->count() * 100, 1);
+
+        $this->info("Cache — {$hits} hits, {$misses} misses — {$hitRate}% hit rate");
+
+        $this->table(
+            ['Action', 'Key'],
+            $cacheEntries->take(10)->map(fn ($cacheEntry) => [
+                $this->colorCacheAction($cacheEntry->content['type'] ?? ''),
+                Str::limit($cacheEntry->content['key'] ?? '', 60),
+            ])
+        );
+
+        $this->more($cacheEntries->count(), 10, 'cache entries');
+    }
+
+    /**
+     * Render the batch log section.
+     *
+     * @param  \Illuminate\Support\Collection  $logs
+     * @return void
+     */
+    protected function renderBatchLogs(Collection $logs): void
+    {
+        if ($logs->isEmpty()) {
+            return;
+        }
+
+        $this->info("Logs — {$logs->count()}");
+
+        $this->table(
+            ['Level', 'Message'],
+            $logs->take(10)->map(fn ($log) => [
+                $this->colorLevel($log->content['level'] ?? ''),
+                Str::limit($log->content['message'] ?? '', 80),
+            ])
+        );
+
+        $this->more($logs->count(), 10, 'logs');
+    }
+
+    /**
+     * Render the entry's common fields followed by the given fields as a key/value table.
+     *
+     * @param  \Laravel\Telescope\EntryResult  $entry
+     * @param  array<string, string|null>  $fields
+     * @return void
+     */
+    protected function details(EntryResult $entry, array $fields): void
+    {
+        $rows = collect([
+            'Time' => $this->humanTime($entry->createdAt)."  <fg=gray>({$entry->createdAt})</>",
+            'Hostname' => $entry->content['hostname'] ?? '',
+        ] + $fields)
+            ->filter(fn ($value) => $value !== '' && $value !== null)
+            ->map(fn ($value, $label) => [$label, (string) $value])
+            ->values();
+
+        $this->table([], $rows);
+    }
+
+    /**
+     * Render a titled single-column list.
+     *
+     * @param  string  $title
+     * @param  array  $items
+     * @return void
+     */
+    protected function listing(string $title, array $items): void
+    {
+        $this->info($title);
+
+        $this->table([], collect($items)->map(fn ($item) => [$item]));
+    }
+
+    /**
+     * Render a titled content block (JSON or plain text) if it has a value.
+     *
+     * @param  string  $label
+     * @param  mixed  $value
+     * @param  int  $limit
+     * @return void
+     */
+    protected function block(string $label, $value, int $limit = 500): void
+    {
+        if (empty($value)) {
+            return;
+        }
+
+        $this->info($label);
+
+        $this->line(is_string($value) ? Str::limit($value, $limit) : $this->jsonBlock($value, $limit));
+    }
+
+    /**
+     * Note how many items were omitted beyond the given limit.
+     *
+     * @param  int  $count
+     * @param  int  $limit
+     * @param  string  $label
+     * @return void
+     */
+    protected function more(int $count, int $limit, string $label): void
+    {
+        if ($count > $limit) {
+            $this->line('... and '.($count - $limit)." more {$label}");
+        }
+    }
+
+    /**
+     * Render a stack trace.
+     *
+     * @param  array  $trace
+     * @param  int  $limit
+     * @return void
+     */
+    protected function renderTrace(array $trace, int $limit = 15): void
+    {
+        if (empty($trace)) {
+            return;
+        }
+
+        $this->listing('Stack Trace', collect($trace)->take($limit)->map(fn ($frame) => ($frame['file'] ?? '?').':'.($frame['line'] ?? '?'))->all());
+
+        $this->more(count($trace), $limit, 'frames');
+    }
+
+    /**
+     * Format the authenticated user for display.
+     *
+     * @param  array  $user
+     * @return string
+     */
+    protected function formatUser(array $user): string
+    {
+        return implode(' ', array_filter([
+            $user['name'] ?? null,
+            isset($user['email']) ? "({$user['email']})" : null,
+            isset($user['id']) ? "#{$user['id']}" : null,
+        ]));
+    }
+
+    /**
+     * Format an array of email addresses for display.
+     *
+     * @param  array  $addresses
+     * @return string
+     */
+    protected function formatAddresses(array $addresses): string
+    {
+        return collect($addresses)->map(fn ($name, $email) => $name ? "{$name} <{$email}>" : $email)->implode(', ');
+    }
+}

--- a/src/Console/ShowCommand.php
+++ b/src/Console/ShowCommand.php
@@ -26,7 +26,9 @@ class ShowCommand extends Command
      */
     protected $signature = 'telescope:show
         {id : Entry UUID, "latest", or "latest:{type}" (e.g. latest:exception)}
-        {--type= : Filter batch entries to specific type(s), comma-separated}';
+        {--type= : Filter batch entries to specific type(s), comma-separated}
+        {--full : Do not truncate SQL, messages, or payloads}
+        {--json : Output the entry and its batch as JSON}';
 
     /**
      * The console command description.
@@ -52,15 +54,27 @@ class ShowCommand extends Command
 
             $batchId = $entry->content['updated_batch_id'] ?? $entry->batchId;
 
+            $types = Str::of($this->option('type'))->explode(',')->map('trim')->filter();
+
+            if (! $this->validEntryTypes(...$types)) {
+                return 1;
+            }
+
             $batchEntries = $batchId
-                ? collect($storage->get(null, EntryQueryOptions::forBatchId($batchId)->limit(-1)))
+                ? collect($storage->get(null, EntryQueryOptions::forBatchId($batchId)->limit(-1)))->reverse()->values()
                 : collect();
 
-            $batchByType = $batchEntries->reject(fn ($other) => $other->id === $entry->id)->groupBy('type');
+            $batchEntries = $batchEntries->reject(fn ($other) => $other->id === $entry->id)
+                ->when($types->isNotEmpty(), fn ($entries) => $entries->whereIn('type', $types))
+                ->values();
 
-            if ($types = $this->option('type')) {
-                $batchByType = $batchByType->only(array_map('trim', explode(',', $types)));
+            if ($this->option('json')) {
+                $this->line(json_encode(['entry' => $entry, 'batch' => $batchEntries->all()], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+                return;
             }
+
+            $batchByType = $batchEntries->groupBy('type');
 
             $this->renderEntry($entry);
             $this->renderBatchContext($batchId, $batchByType);
@@ -78,6 +92,10 @@ class ShowCommand extends Command
     {
         if ($id === 'latest' || str_starts_with($id, 'latest:')) {
             $type = $id === 'latest' ? null : Str::after($id, 'latest:');
+
+            if ($type && ! $this->validEntryTypes($type)) {
+                return null;
+            }
 
             $entry = collect($storage->get($type, (new EntryQueryOptions)->limit(1)))->first();
 
@@ -355,7 +373,7 @@ class ShowCommand extends Command
         $this->renderBatchLogs($batchByType->get(EntryType::LOG, collect()));
 
         $compactTypes = [
-            EntryType::VIEW => 'Views', EntryType::MODEL => 'Models',
+            EntryType::REQUEST => 'Request', EntryType::VIEW => 'Views', EntryType::MODEL => 'Models',
             EntryType::EVENT => 'Events', EntryType::GATE => 'Gates',
             EntryType::MAIL => 'Mail', EntryType::NOTIFICATION => 'Notifications',
             EntryType::REDIS => 'Redis', EntryType::CLIENT_REQUEST => 'Client Requests',
@@ -403,7 +421,7 @@ class ShowCommand extends Command
                 $index + 1,
                 $this->shortUuid($query->id),
                 round((float) ($query->content['time'] ?? 0), 2).'ms',
-                Str::limit($query->content['sql'] ?? '', 60),
+                $this->limit($query->content['sql'] ?? '', 60),
                 isset($query->content['file']) ? basename($query->content['file']).':'.($query->content['line'] ?? '') : '',
                 trim(
                     (! empty($query->content['slow']) ? '<fg=red>SLOW</> ' : '').
@@ -433,7 +451,7 @@ class ShowCommand extends Command
             ['UUID', 'Exception', 'Location'],
             $exceptions->map(fn ($exception) => [
                 $this->shortUuid($exception->id),
-                ($exception->content['class'] ?? '').': '.Str::limit($exception->content['message'] ?? '', 80),
+                ($exception->content['class'] ?? '').': '.$this->limit($exception->content['message'] ?? '', 80),
                 ($exception->content['file'] ?? '').':'.($exception->content['line'] ?? ''),
             ])
         );
@@ -453,7 +471,7 @@ class ShowCommand extends Command
 
         $hits = $cacheEntries->filter(fn ($cacheEntry) => ($cacheEntry->content['type'] ?? '') === 'hit')->count();
         $misses = $cacheEntries->filter(fn ($cacheEntry) => ($cacheEntry->content['type'] ?? '') === 'missed')->count();
-        $hitRate = round($hits / $cacheEntries->count() * 100, 1);
+        $hitRate = $hits + $misses > 0 ? round($hits / ($hits + $misses) * 100, 1) : 0;
 
         $this->info("Cache — {$hits} hits, {$misses} misses — {$hitRate}% hit rate");
 
@@ -461,7 +479,7 @@ class ShowCommand extends Command
             ['Action', 'Key'],
             $cacheEntries->take(10)->map(fn ($cacheEntry) => [
                 $this->colorCacheAction($cacheEntry->content['type'] ?? ''),
-                Str::limit($cacheEntry->content['key'] ?? '', 60),
+                $this->limit($cacheEntry->content['key'] ?? '', 60),
             ])
         );
 
@@ -486,7 +504,7 @@ class ShowCommand extends Command
             ['Level', 'Message'],
             $logs->take(10)->map(fn ($log) => [
                 $this->colorLevel($log->content['level'] ?? ''),
-                Str::limit($log->content['message'] ?? '', 80),
+                $this->limit($log->content['message'] ?? '', 80),
             ])
         );
 
@@ -543,7 +561,19 @@ class ShowCommand extends Command
 
         $this->info($label);
 
-        $this->line(is_string($value) ? Str::limit($value, $limit) : $this->jsonBlock($value, $limit));
+        $this->line($this->limit(is_string($value) ? $value : $this->jsonBlock($value), $limit));
+    }
+
+    /**
+     * Truncate the given value unless the --full option was given.
+     *
+     * @param  string  $value
+     * @param  int  $limit
+     * @return string
+     */
+    protected function limit(string $value, int $limit): string
+    {
+        return $this->option('full') ? $value : Str::limit($value, $limit);
     }
 
     /**

--- a/src/Console/ShowCommand.php
+++ b/src/Console/ShowCommand.php
@@ -54,9 +54,9 @@ class ShowCommand extends Command
 
             $batchId = $entry->content['updated_batch_id'] ?? $entry->batchId;
 
-            $types = Str::of($this->option('type'))->explode(',')->map('trim')->filter();
+            $types = Str::of($this->option('type'))->explode(',')->map(fn ($type) => trim($type))->filter();
 
-            if (! $this->validEntryTypes(...$types)) {
+            if (! $this->ensureValidEntryTypes(...$types)) {
                 return 1;
             }
 
@@ -69,15 +69,13 @@ class ShowCommand extends Command
                 ->values();
 
             if ($this->option('json')) {
-                $this->line(json_encode(['entry' => $entry, 'batch' => $batchEntries->all()], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+                $this->line($this->jsonBlock(['entry' => $entry, 'batch' => $batchEntries->all()]));
 
                 return;
             }
 
-            $batchByType = $batchEntries->groupBy('type');
-
             $this->renderEntry($entry);
-            $this->renderBatchContext($batchId, $batchByType);
+            $this->renderBatchContext($batchId, $batchEntries->groupBy('type'), $types);
         });
     }
 
@@ -93,7 +91,7 @@ class ShowCommand extends Command
         if ($id === 'latest' || str_starts_with($id, 'latest:')) {
             $type = $id === 'latest' ? null : Str::after($id, 'latest:');
 
-            if ($type && ! $this->validEntryTypes($type)) {
+            if ($type && ! $this->ensureValidEntryTypes($type)) {
                 return null;
             }
 
@@ -141,12 +139,12 @@ class ShowCommand extends Command
     {
         $content = $entry->content;
 
-        $this->info('Request: '.($content['method'] ?? '').' '.($content['uri'] ?? '').' → '.($content['response_status'] ?? ''));
+        $this->info('Request: '.($content['method'] ?? '').' '.($content['uri'] ?? '').' -> '.($content['response_status'] ?? ''));
 
         $this->details($entry, [
             'Controller' => $content['controller_action'] ?? 'Closure',
-            'Duration' => ($content['duration'] ?? '').'ms',
-            'Memory' => ($content['memory'] ?? '').'MB',
+            'Duration' => $this->unit($content['duration'] ?? null, 'ms'),
+            'Memory' => $this->unit($content['memory'] ?? null, 'MB'),
             'IP' => $content['ip_address'] ?? '',
             'Middleware' => implode(', ', (array) ($content['middleware'] ?? [])),
             'User' => $this->formatUser($content['user'] ?? []),
@@ -181,7 +179,7 @@ class ShowCommand extends Command
             $this->info('Code Context');
 
             $this->table([], collect($content['line_preview'])->map(fn ($code, $lineNo) => [
-                $lineNo == ($content['line'] ?? 0) ? "<fg=red>{$lineNo} →</>" : $lineNo,
+                $lineNo == ($content['line'] ?? 0) ? "<fg=red>{$lineNo} ></>" : $lineNo,
                 $code,
             ])->values());
         }
@@ -206,7 +204,7 @@ class ShowCommand extends Command
             'Queue' => $content['queue'] ?? '',
             'Connection' => $content['connection'] ?? '',
             'Tries' => (string) ($content['tries'] ?? ''),
-            'Timeout' => ($content['timeout'] ?? '').'s',
+            'Timeout' => $this->unit($content['timeout'] ?? null, 's'),
         ]);
 
         $this->block('Data', $content['data'] ?? null, 500);
@@ -226,9 +224,13 @@ class ShowCommand extends Command
     protected function renderGenericEntry(EntryResult $entry): void
     {
         $content = $entry->content;
-        $config = $this->entryFieldConfig($entry->type, $content) + ['subtitle' => '', 'fields' => [], 'list' => null, 'blocks' => []];
+        $config = $this->entryFieldConfig($entry->type, $content) + [
+            'label' => ucfirst($entry->type), 'subtitle' => '', 'fields' => [], 'list' => null, 'blocks' => [],
+        ];
 
-        $this->info(rtrim("{$config['label']}: {$config['subtitle']}", ': '));
+        $this->info($config['subtitle'] === ''
+            ? $config['label']
+            : "{$config['label']}: {$config['subtitle']}");
 
         $this->details($entry, $config['fields']);
 
@@ -255,7 +257,7 @@ class ShowCommand extends Command
                 'label' => 'Query',
                 'fields' => [
                     'Connection' => $content['connection'] ?? '',
-                    'Duration' => ($content['time'] ?? '').'ms'.(! empty($content['slow']) ? '  <fg=red>SLOW</>' : ''),
+                    'Duration' => $this->unit($content['time'] ?? null, 'ms').(! empty($content['slow']) ? '  <fg=red>SLOW</>' : ''),
                     'Source' => isset($content['file']) ? ($content['file']).':'.($content['line'] ?? '') : '',
                     'SQL' => $content['sql'] ?? '',
                 ],
@@ -265,7 +267,7 @@ class ShowCommand extends Command
                 'label' => 'Cache', 'subtitle' => $content['type'] ?? '',
                 'fields' => [
                     'Key' => $content['key'] ?? '',
-                    'Expiration' => isset($content['expiration']) ? $content['expiration'].'s' : '',
+                    'Expiration' => $this->unit($content['expiration'] ?? null, 's'),
                 ],
                 'blocks' => ['Value' => 'value'],
             ],
@@ -306,7 +308,7 @@ class ShowCommand extends Command
                 'label' => 'Client Request', 'subtitle' => ($content['method'] ?? '').' '.($content['uri'] ?? ''),
                 'fields' => [
                     'Status' => isset($content['response_status']) ? $this->colorStatus((int) $content['response_status']) : 'N/A',
-                    'Duration' => ($content['duration'] ?? '').'ms',
+                    'Duration' => $this->unit($content['duration'] ?? null, 'ms'),
                 ],
                 'blocks' => ['Payload' => 'payload', 'Response' => 'response'],
             ],
@@ -341,7 +343,7 @@ class ShowCommand extends Command
                 'label' => 'Redis',
                 'fields' => [
                     'Connection' => $content['connection'] ?? '',
-                    'Duration' => ($content['time'] ?? '').'ms',
+                    'Duration' => $this->unit($content['time'] ?? null, 'ms'),
                     'Command' => $content['command'] ?? '',
                 ],
             ],
@@ -357,37 +359,33 @@ class ShowCommand extends Command
      *
      * @param  string|null  $batchId
      * @param  \Illuminate\Support\Collection  $batchByType
+     * @param  \Illuminate\Support\Collection  $requestedTypes
      * @return void
      */
-    protected function renderBatchContext(?string $batchId, Collection $batchByType): void
+    protected function renderBatchContext(?string $batchId, Collection $batchByType, Collection $requestedTypes): void
     {
         if ($batchByType->isEmpty()) {
+            if ($requestedTypes->isNotEmpty()) {
+                $this->line('No batch entries of type '.$requestedTypes->implode(', ').'.');
+            }
+
             return;
         }
 
-        $this->info('Related Entries — batch '.$this->shortUuid($batchId));
+        $this->info('Related Entries - batch '.$this->shortUuid($batchId));
+
+        $detailed = [EntryType::QUERY, EntryType::EXCEPTION, EntryType::CACHE, EntryType::LOG];
 
         $this->renderBatchQueries($batchByType->get(EntryType::QUERY, collect()));
         $this->renderBatchExceptions($batchByType->get(EntryType::EXCEPTION, collect()));
         $this->renderBatchCache($batchByType->get(EntryType::CACHE, collect()));
         $this->renderBatchLogs($batchByType->get(EntryType::LOG, collect()));
 
-        $compactTypes = [
-            EntryType::REQUEST => 'Request', EntryType::VIEW => 'Views', EntryType::MODEL => 'Models',
-            EntryType::EVENT => 'Events', EntryType::GATE => 'Gates',
-            EntryType::MAIL => 'Mail', EntryType::NOTIFICATION => 'Notifications',
-            EntryType::REDIS => 'Redis', EntryType::CLIENT_REQUEST => 'Client Requests',
-            EntryType::JOB => 'Jobs', EntryType::COMMAND => 'Commands',
-            EntryType::SCHEDULED_TASK => 'Schedule',
-        ];
+        foreach ($batchByType->except($detailed) as $type => $entries) {
+            $label = Str::plural(Str::headline($type));
 
-        foreach ($compactTypes as $type => $label) {
-            $entries = $batchByType->get($type, collect());
-
-            if ($entries->isNotEmpty()) {
-                $this->listing("{$label} ({$entries->count()})", $entries->take(5)->map(fn ($related) => $this->summarizeEntry($related))->all());
-                $this->more($entries->count(), 5, $label);
-            }
+            $this->listing("{$label} ({$entries->count()})", $entries->take(5)->map(fn ($related) => $this->summarizeEntry($related))->all());
+            $this->more($entries->count(), 5, $label);
         }
     }
 
@@ -410,9 +408,9 @@ class ShowCommand extends Command
             ->filter(fn ($group) => $group->count() > 1);
 
         $this->info(
-            "Queries — {$queries->count()} total, {$totalTime}ms".
+            "Queries - {$queries->count()} total, {$totalTime}ms".
             ($slowCount > 0 ? ", {$slowCount} slow" : '').
-            ($duplicates->isNotEmpty() ? ", {$duplicates->count()} duplicate groups" : '')
+            ($duplicates->isNotEmpty() ? ', '.$duplicates->count().' duplicate '.Str::plural('group', $duplicates->count()) : '')
         );
 
         $this->table(
@@ -445,16 +443,18 @@ class ShowCommand extends Command
             return;
         }
 
-        $this->info("Exceptions — {$exceptions->count()}");
+        $this->info("Exceptions - {$exceptions->count()}");
 
         $this->table(
             ['UUID', 'Exception', 'Location'],
-            $exceptions->map(fn ($exception) => [
+            $exceptions->take(10)->map(fn ($exception) => [
                 $this->shortUuid($exception->id),
                 ($exception->content['class'] ?? '').': '.$this->limit($exception->content['message'] ?? '', 80),
                 ($exception->content['file'] ?? '').':'.($exception->content['line'] ?? ''),
             ])
         );
+
+        $this->more($exceptions->count(), 10, 'exceptions');
     }
 
     /**
@@ -471,9 +471,10 @@ class ShowCommand extends Command
 
         $hits = $cacheEntries->filter(fn ($cacheEntry) => ($cacheEntry->content['type'] ?? '') === 'hit')->count();
         $misses = $cacheEntries->filter(fn ($cacheEntry) => ($cacheEntry->content['type'] ?? '') === 'missed')->count();
-        $hitRate = $hits + $misses > 0 ? round($hits / ($hits + $misses) * 100, 1) : 0;
+        $lookups = $hits + $misses;
 
-        $this->info("Cache — {$hits} hits, {$misses} misses — {$hitRate}% hit rate");
+        $this->info("Cache - {$hits} hits, {$misses} misses".
+            ($lookups > 0 ? ' - '.round($hits / $lookups * 100, 1).'% hit rate' : ''));
 
         $this->table(
             ['Action', 'Key'],
@@ -498,7 +499,7 @@ class ShowCommand extends Command
             return;
         }
 
-        $this->info("Logs — {$logs->count()}");
+        $this->info("Logs - {$logs->count()}");
 
         $this->table(
             ['Level', 'Message'],

--- a/src/EntryType.php
+++ b/src/EntryType.php
@@ -22,4 +22,33 @@ class EntryType
     public const GATE = 'gate';
     public const VIEW = 'view';
     public const CLIENT_REQUEST = 'client_request';
+
+    /**
+     * Get all of the entry types.
+     *
+     * @return string[]
+     */
+    public static function all()
+    {
+        return [
+            self::BATCH,
+            self::CACHE,
+            self::CLIENT_REQUEST,
+            self::COMMAND,
+            self::DUMP,
+            self::EVENT,
+            self::EXCEPTION,
+            self::GATE,
+            self::JOB,
+            self::LOG,
+            self::MAIL,
+            self::MODEL,
+            self::NOTIFICATION,
+            self::QUERY,
+            self::REDIS,
+            self::REQUEST,
+            self::SCHEDULED_TASK,
+            self::VIEW,
+        ];
+    }
 }

--- a/src/Telescope.php
+++ b/src/Telescope.php
@@ -188,6 +188,8 @@ class Telescope
                 'horizon',
                 'horizon:work',
                 'horizon:supervisor',
+                'telescope:list',
+                'telescope:show',
             ], config('telescope.ignoreCommands', []), config('telescope.ignore_commands', []))
         );
     }

--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -104,10 +104,12 @@ class TelescopeServiceProvider extends ServiceProvider
             $this->commands([
                 Console\ClearCommand::class,
                 Console\InstallCommand::class,
+                Console\ListCommand::class,
                 Console\PauseCommand::class,
                 Console\PruneCommand::class,
                 Console\PublishCommand::class,
                 Console\ResumeCommand::class,
+                Console\ShowCommand::class,
             ]);
         }
     }

--- a/tests/Console/CreatesTelescopeEntries.php
+++ b/tests/Console/CreatesTelescopeEntries.php
@@ -15,7 +15,7 @@ trait CreatesTelescopeEntries
      * @param  array  $attributes
      * @return \Laravel\Telescope\Storage\EntryModel
      */
-    protected function entry(string $type, array $content = [], array $attributes = [])
+    protected function createEntry(string $type, array $content = [], array $attributes = [])
     {
         return EntryModelFactory::new()->create($attributes + [
             'type' => $type,
@@ -30,9 +30,9 @@ trait CreatesTelescopeEntries
      * @param  array  $attributes
      * @return \Laravel\Telescope\Storage\EntryModel
      */
-    protected function request(array $content = [], array $attributes = [])
+    protected function createRequest(array $content = [], array $attributes = [])
     {
-        return $this->entry(EntryType::REQUEST, $content + [
+        return $this->createEntry(EntryType::REQUEST, $content + [
             'method' => 'GET', 'uri' => '/test', 'response_status' => 200,
             'duration' => 50, 'memory' => 8, 'ip_address' => '127.0.0.1',
             'middleware' => [], 'payload' => [], 'response' => [],
@@ -46,9 +46,9 @@ trait CreatesTelescopeEntries
      * @param  array  $attributes
      * @return \Laravel\Telescope\Storage\EntryModel
      */
-    protected function query(array $content = [], array $attributes = [])
+    protected function createQuery(array $content = [], array $attributes = [])
     {
-        return $this->entry(EntryType::QUERY, $content + [
+        return $this->createEntry(EntryType::QUERY, $content + [
             'sql' => 'select 1', 'time' => 1.0, 'connection' => 'testbench', 'slow' => false, 'hash' => 'h1',
         ], $attributes);
     }
@@ -60,9 +60,9 @@ trait CreatesTelescopeEntries
      * @param  array  $attributes
      * @return \Laravel\Telescope\Storage\EntryModel
      */
-    protected function exception(array $content = [], array $attributes = [])
+    protected function createException(array $content = [], array $attributes = [])
     {
-        return $this->entry(EntryType::EXCEPTION, $content + [
+        return $this->createEntry(EntryType::EXCEPTION, $content + [
             'class' => 'RuntimeException', 'message' => 'Test', 'file' => 'test.php',
             'line' => 1, 'trace' => [], 'occurrences' => 1,
         ], $attributes);

--- a/tests/Console/CreatesTelescopeEntries.php
+++ b/tests/Console/CreatesTelescopeEntries.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Laravel\Telescope\Tests\Console;
+
+use Laravel\Telescope\Database\Factories\EntryModelFactory;
+use Laravel\Telescope\EntryType;
+
+trait CreatesTelescopeEntries
+{
+    /**
+     * Create an entry of the given type.
+     *
+     * @param  string  $type
+     * @param  array  $content
+     * @param  array  $attributes
+     * @return \Laravel\Telescope\Storage\EntryModel
+     */
+    protected function entry(string $type, array $content = [], array $attributes = [])
+    {
+        return EntryModelFactory::new()->create($attributes + [
+            'type' => $type,
+            'content' => $content + ['hostname' => 'localhost'],
+        ]);
+    }
+
+    /**
+     * Create a request entry.
+     *
+     * @param  array  $content
+     * @param  array  $attributes
+     * @return \Laravel\Telescope\Storage\EntryModel
+     */
+    protected function request(array $content = [], array $attributes = [])
+    {
+        return $this->entry(EntryType::REQUEST, $content + [
+            'method' => 'GET', 'uri' => '/test', 'response_status' => 200,
+            'duration' => 50, 'memory' => 8, 'ip_address' => '127.0.0.1',
+            'middleware' => [], 'payload' => [], 'response' => [],
+        ], $attributes);
+    }
+
+    /**
+     * Create a query entry.
+     *
+     * @param  array  $content
+     * @param  array  $attributes
+     * @return \Laravel\Telescope\Storage\EntryModel
+     */
+    protected function query(array $content = [], array $attributes = [])
+    {
+        return $this->entry(EntryType::QUERY, $content + [
+            'sql' => 'select 1', 'time' => 1.0, 'connection' => 'testbench', 'slow' => false, 'hash' => 'h1',
+        ], $attributes);
+    }
+
+    /**
+     * Create an exception entry.
+     *
+     * @param  array  $content
+     * @param  array  $attributes
+     * @return \Laravel\Telescope\Storage\EntryModel
+     */
+    protected function exception(array $content = [], array $attributes = [])
+    {
+        return $this->entry(EntryType::EXCEPTION, $content + [
+            'class' => 'RuntimeException', 'message' => 'Test', 'file' => 'test.php',
+            'line' => 1, 'trace' => [], 'occurrences' => 1,
+        ], $attributes);
+    }
+}

--- a/tests/Console/ListCommandTest.php
+++ b/tests/Console/ListCommandTest.php
@@ -10,6 +10,15 @@ use Laravel\Telescope\Tests\FeatureTestCase;
 
 class ListCommandTest extends FeatureTestCase
 {
+    /**
+     * Indicates if console output should be mocked.
+     *
+     * Disabled so Artisan::output() captures the real command output.
+     *
+     * @var bool
+     */
+    public $mockConsoleOutput = false;
+
     public function test_list_filters_by_type()
     {
         EntryModelFactory::new()->create(['type' => EntryType::REQUEST, 'content' => [
@@ -29,8 +38,7 @@ class ListCommandTest extends FeatureTestCase
 
     public function test_list_validates_type_argument()
     {
-        $this->artisan('telescope:list', ['type' => 'foobar'])
-            ->assertFailed();
+        $this->assertSame(1, $this->artisan('telescope:list', ['type' => 'foobar']));
     }
 
     public function test_list_filters_by_batch()
@@ -70,8 +78,7 @@ class ListCommandTest extends FeatureTestCase
 
     public function test_list_shows_warning_when_empty()
     {
-        $this->artisan('telescope:list', ['type' => 'request'])
-            ->assertSuccessful();
+        $this->assertSame(0, $this->artisan('telescope:list', ['type' => 'request']));
     }
 
     public function test_list_shows_all_entry_types()

--- a/tests/Console/ListCommandTest.php
+++ b/tests/Console/ListCommandTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Laravel\Telescope\Tests\Console;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Laravel\Telescope\Database\Factories\EntryModelFactory;
+use Laravel\Telescope\EntryType;
+use Laravel\Telescope\Tests\FeatureTestCase;
+
+class ListCommandTest extends FeatureTestCase
+{
+    public function test_list_filters_by_type()
+    {
+        EntryModelFactory::new()->create(['type' => EntryType::REQUEST, 'content' => [
+            'method' => 'GET', 'uri' => '/test', 'response_status' => 200,
+            'duration' => 100, 'hostname' => 'localhost',
+        ]]);
+        EntryModelFactory::new()->create(['type' => EntryType::EXCEPTION, 'content' => [
+            'class' => 'RuntimeException', 'message' => 'fail', 'hostname' => 'localhost',
+        ]]);
+
+        Artisan::call('telescope:list', ['type' => 'request']);
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('/test', $output);
+        $this->assertStringContainsString('Showing 1 entries', $output);
+    }
+
+    public function test_list_validates_type_argument()
+    {
+        $this->artisan('telescope:list', ['type' => 'foobar'])
+            ->assertFailed();
+    }
+
+    public function test_list_filters_by_batch()
+    {
+        $batchId = (string) Str::uuid();
+
+        EntryModelFactory::new()->create([
+            'type' => EntryType::REQUEST,
+            'batch_id' => $batchId,
+            'content' => ['method' => 'GET', 'uri' => '/a', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost'],
+        ]);
+        EntryModelFactory::new()->create([
+            'type' => EntryType::REQUEST,
+            'content' => ['method' => 'POST', 'uri' => '/b', 'response_status' => 201, 'duration' => 80, 'hostname' => 'localhost'],
+        ]);
+
+        Artisan::call('telescope:list', ['type' => 'request', '--batch' => $batchId]);
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('/a', $output);
+        $this->assertStringNotContainsString('/b', $output);
+    }
+
+    public function test_list_respects_limit()
+    {
+        EntryModelFactory::new()->count(5)->create([
+            'type' => EntryType::REQUEST,
+            'content' => ['method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost'],
+        ]);
+
+        Artisan::call('telescope:list', ['type' => 'request', '--limit' => 2]);
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('Showing 2 entries', $output);
+        $this->assertStringContainsString('--before=', $output);
+    }
+
+    public function test_list_shows_warning_when_empty()
+    {
+        $this->artisan('telescope:list', ['type' => 'request'])
+            ->assertSuccessful();
+    }
+
+    public function test_list_shows_all_entry_types()
+    {
+        EntryModelFactory::new()->create(['type' => EntryType::REQUEST, 'content' => [
+            'method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost',
+        ]]);
+        EntryModelFactory::new()->create(['type' => EntryType::EXCEPTION, 'content' => [
+            'class' => 'RuntimeException', 'message' => 'fail', 'hostname' => 'localhost',
+        ]]);
+
+        Artisan::call('telescope:list');
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('Showing 2 entries', $output);
+        $this->assertStringContainsString('request', $output);
+        $this->assertStringContainsString('exception', $output);
+    }
+
+    public function test_list_cursor_has_more_false_when_all_returned()
+    {
+        EntryModelFactory::new()->count(3)->create([
+            'type' => EntryType::REQUEST,
+            'content' => ['method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost'],
+        ]);
+
+        Artisan::call('telescope:list', ['type' => 'request', '--limit' => 20]);
+
+        $this->assertStringContainsString('No more entries', Artisan::output());
+    }
+}

--- a/tests/Console/ListCommandTest.php
+++ b/tests/Console/ListCommandTest.php
@@ -109,4 +109,17 @@ class ListCommandTest extends FeatureTestCase
 
         $this->assertStringContainsString('No more entries', Artisan::output());
     }
+
+    public function test_list_outputs_json()
+    {
+        $entry = EntryModelFactory::new()->create(['type' => EntryType::REQUEST, 'content' => [
+            'method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost',
+        ]]);
+
+        Artisan::call('telescope:list', ['type' => 'request', '--json' => true]);
+        $json = json_decode(Artisan::output(), true);
+
+        $this->assertSame($entry->uuid, $json[0]['id']);
+        $this->assertSame('/test', $json[0]['content']['uri']);
+    }
 }

--- a/tests/Console/ListCommandTest.php
+++ b/tests/Console/ListCommandTest.php
@@ -23,8 +23,8 @@ class ListCommandTest extends FeatureTestCase
 
     public function test_list_filters_by_type()
     {
-        $this->request();
-        $this->exception(['message' => 'fail']);
+        $this->createRequest();
+        $this->createException(['message' => 'fail']);
 
         Artisan::call('telescope:list', ['type' => 'request']);
         $output = Artisan::output();
@@ -44,8 +44,8 @@ class ListCommandTest extends FeatureTestCase
     {
         $batchId = (string) Str::uuid();
 
-        $this->request(['uri' => '/a'], ['batch_id' => $batchId]);
-        $this->request(['uri' => '/b']);
+        $this->createRequest(['uri' => '/a'], ['batch_id' => $batchId]);
+        $this->createRequest(['uri' => '/b']);
 
         Artisan::call('telescope:list', ['--batch' => $batchId]);
         $output = Artisan::output();
@@ -56,8 +56,8 @@ class ListCommandTest extends FeatureTestCase
 
     public function test_list_filters_by_tag()
     {
-        $tagged = $this->request(['uri' => '/tagged']);
-        $this->request(['uri' => '/untagged']);
+        $tagged = $this->createRequest(['uri' => '/tagged']);
+        $this->createRequest(['uri' => '/untagged']);
 
         DB::table('telescope_entries_tags')->insert(['entry_uuid' => $tagged->uuid, 'tag' => 'Auth:42']);
 
@@ -70,8 +70,8 @@ class ListCommandTest extends FeatureTestCase
 
     public function test_list_pages_backwards_with_the_before_cursor()
     {
-        $this->request(['uri' => '/older'], ['sequence' => 1]);
-        $this->request(['uri' => '/newer'], ['sequence' => 2]);
+        $this->createRequest(['uri' => '/older'], ['sequence' => 1]);
+        $this->createRequest(['uri' => '/newer'], ['sequence' => 2]);
 
         Artisan::call('telescope:list', ['type' => 'request', '--before' => 2]);
         $output = Artisan::output();
@@ -85,7 +85,7 @@ class ListCommandTest extends FeatureTestCase
         $last = null;
 
         foreach (range(1, 3) as $sequence) {
-            $last = $this->request([], ['sequence' => $sequence]);
+            $last = $this->createRequest([], ['sequence' => $sequence]);
         }
 
         Artisan::call('telescope:list', ['type' => 'request', '--limit' => 2]);
@@ -99,7 +99,7 @@ class ListCommandTest extends FeatureTestCase
 
     public function test_list_rejects_a_non_positive_limit()
     {
-        $this->request();
+        $this->createRequest();
 
         foreach (['abc', '0', '-1'] as $limit) {
             $this->assertSame(1, $this->artisan('telescope:list', ['type' => 'request', '--limit' => $limit]));
@@ -115,8 +115,8 @@ class ListCommandTest extends FeatureTestCase
 
     public function test_list_summarizes_mixed_entry_types_when_no_type_is_given()
     {
-        $this->request();
-        $this->entry(EntryType::CACHE, ['type' => 'hit', 'key' => 'user:1']);
+        $this->createRequest();
+        $this->createEntry(EntryType::CACHE, ['type' => 'hit', 'key' => 'user:1']);
 
         Artisan::call('telescope:list');
         $output = Artisan::output();
@@ -128,7 +128,7 @@ class ListCommandTest extends FeatureTestCase
 
     public function test_list_outputs_json()
     {
-        $entry = $this->request();
+        $entry = $this->createRequest();
 
         Artisan::call('telescope:list', ['type' => 'request', '--json' => true]);
         $json = json_decode(Artisan::output(), true);

--- a/tests/Console/ListCommandTest.php
+++ b/tests/Console/ListCommandTest.php
@@ -3,13 +3,15 @@
 namespace Laravel\Telescope\Tests\Console;
 
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
-use Laravel\Telescope\Database\Factories\EntryModelFactory;
 use Laravel\Telescope\EntryType;
 use Laravel\Telescope\Tests\FeatureTestCase;
 
 class ListCommandTest extends FeatureTestCase
 {
+    use CreatesTelescopeEntries;
+
     /**
      * Indicates if console output should be mocked.
      *
@@ -21,105 +23,124 @@ class ListCommandTest extends FeatureTestCase
 
     public function test_list_filters_by_type()
     {
-        EntryModelFactory::new()->create(['type' => EntryType::REQUEST, 'content' => [
-            'method' => 'GET', 'uri' => '/test', 'response_status' => 200,
-            'duration' => 100, 'hostname' => 'localhost',
-        ]]);
-        EntryModelFactory::new()->create(['type' => EntryType::EXCEPTION, 'content' => [
-            'class' => 'RuntimeException', 'message' => 'fail', 'hostname' => 'localhost',
-        ]]);
+        $this->request();
+        $this->exception(['message' => 'fail']);
 
         Artisan::call('telescope:list', ['type' => 'request']);
         $output = Artisan::output();
 
         $this->assertStringContainsString('/test', $output);
-        $this->assertStringContainsString('Showing 1 entries', $output);
+        $this->assertStringNotContainsString('fail', $output);
+        $this->assertStringContainsString('Showing 1 entry', $output);
     }
 
     public function test_list_validates_type_argument()
     {
         $this->assertSame(1, $this->artisan('telescope:list', ['type' => 'foobar']));
+        $this->assertStringContainsString('Invalid entry type: foobar', Artisan::output());
     }
 
     public function test_list_filters_by_batch()
     {
         $batchId = (string) Str::uuid();
 
-        EntryModelFactory::new()->create([
-            'type' => EntryType::REQUEST,
-            'batch_id' => $batchId,
-            'content' => ['method' => 'GET', 'uri' => '/a', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost'],
-        ]);
-        EntryModelFactory::new()->create([
-            'type' => EntryType::REQUEST,
-            'content' => ['method' => 'POST', 'uri' => '/b', 'response_status' => 201, 'duration' => 80, 'hostname' => 'localhost'],
-        ]);
+        $this->request(['uri' => '/a'], ['batch_id' => $batchId]);
+        $this->request(['uri' => '/b']);
 
-        Artisan::call('telescope:list', ['type' => 'request', '--batch' => $batchId]);
+        Artisan::call('telescope:list', ['--batch' => $batchId]);
         $output = Artisan::output();
 
         $this->assertStringContainsString('/a', $output);
         $this->assertStringNotContainsString('/b', $output);
     }
 
-    public function test_list_respects_limit()
+    public function test_list_filters_by_tag()
     {
-        EntryModelFactory::new()->count(5)->create([
-            'type' => EntryType::REQUEST,
-            'content' => ['method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost'],
-        ]);
+        $tagged = $this->request(['uri' => '/tagged']);
+        $this->request(['uri' => '/untagged']);
+
+        DB::table('telescope_entries_tags')->insert(['entry_uuid' => $tagged->uuid, 'tag' => 'Auth:42']);
+
+        Artisan::call('telescope:list', ['type' => 'request', '--tag' => 'Auth:42']);
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('/tagged', $output);
+        $this->assertStringNotContainsString('/untagged', $output);
+    }
+
+    public function test_list_pages_backwards_with_the_before_cursor()
+    {
+        $this->request(['uri' => '/older'], ['sequence' => 1]);
+        $this->request(['uri' => '/newer'], ['sequence' => 2]);
+
+        Artisan::call('telescope:list', ['type' => 'request', '--before' => 2]);
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('/older', $output);
+        $this->assertStringNotContainsString('/newer', $output);
+    }
+
+    public function test_list_prints_a_cursor_when_the_page_is_full()
+    {
+        $last = null;
+
+        foreach (range(1, 3) as $sequence) {
+            $last = $this->request([], ['sequence' => $sequence]);
+        }
 
         Artisan::call('telescope:list', ['type' => 'request', '--limit' => 2]);
-        $output = Artisan::output();
 
-        $this->assertStringContainsString('Showing 2 entries', $output);
-        $this->assertStringContainsString('--before=', $output);
-    }
-
-    public function test_list_shows_warning_when_empty()
-    {
-        $this->assertSame(0, $this->artisan('telescope:list', ['type' => 'request']));
-    }
-
-    public function test_list_shows_all_entry_types()
-    {
-        EntryModelFactory::new()->create(['type' => EntryType::REQUEST, 'content' => [
-            'method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost',
-        ]]);
-        EntryModelFactory::new()->create(['type' => EntryType::EXCEPTION, 'content' => [
-            'class' => 'RuntimeException', 'message' => 'fail', 'hostname' => 'localhost',
-        ]]);
-
-        Artisan::call('telescope:list');
-        $output = Artisan::output();
-
-        $this->assertStringContainsString('Showing 2 entries', $output);
-        $this->assertStringContainsString('request', $output);
-        $this->assertStringContainsString('exception', $output);
-    }
-
-    public function test_list_cursor_has_more_false_when_all_returned()
-    {
-        EntryModelFactory::new()->count(3)->create([
-            'type' => EntryType::REQUEST,
-            'content' => ['method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost'],
-        ]);
+        $this->assertStringContainsString('Showing 2 entries - Use --before=2 for next page', Artisan::output());
 
         Artisan::call('telescope:list', ['type' => 'request', '--limit' => 20]);
 
         $this->assertStringContainsString('No more entries', Artisan::output());
     }
 
+    public function test_list_rejects_a_non_positive_limit()
+    {
+        $this->request();
+
+        foreach (['abc', '0', '-1'] as $limit) {
+            $this->assertSame(1, $this->artisan('telescope:list', ['type' => 'request', '--limit' => $limit]));
+            $this->assertStringContainsString('--limit option must be a positive integer', Artisan::output());
+        }
+    }
+
+    public function test_list_shows_warning_when_empty()
+    {
+        $this->assertSame(0, $this->artisan('telescope:list', ['type' => 'request']));
+        $this->assertStringContainsString('No entries found.', Artisan::output());
+    }
+
+    public function test_list_summarizes_mixed_entry_types_when_no_type_is_given()
+    {
+        $this->request();
+        $this->entry(EntryType::CACHE, ['type' => 'hit', 'key' => 'user:1']);
+
+        Artisan::call('telescope:list');
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('Showing 2 entries', $output);
+        $this->assertStringContainsString('GET /test -> 200', $output);
+        $this->assertStringContainsString('hit user:1', $output);
+    }
+
     public function test_list_outputs_json()
     {
-        $entry = EntryModelFactory::new()->create(['type' => EntryType::REQUEST, 'content' => [
-            'method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost',
-        ]]);
+        $entry = $this->request();
 
         Artisan::call('telescope:list', ['type' => 'request', '--json' => true]);
         $json = json_decode(Artisan::output(), true);
 
         $this->assertSame($entry->uuid, $json[0]['id']);
         $this->assertSame('/test', $json[0]['content']['uri']);
+    }
+
+    public function test_list_outputs_an_empty_json_array_when_empty()
+    {
+        Artisan::call('telescope:list', ['type' => 'request', '--json' => true]);
+
+        $this->assertSame([], json_decode(Artisan::output(), true));
     }
 }

--- a/tests/Console/ShowCommandTest.php
+++ b/tests/Console/ShowCommandTest.php
@@ -1,0 +1,299 @@
+<?php
+
+namespace Laravel\Telescope\Tests\Console;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Laravel\Telescope\Database\Factories\EntryModelFactory;
+use Laravel\Telescope\EntryType;
+use Laravel\Telescope\Tests\FeatureTestCase;
+
+class ShowCommandTest extends FeatureTestCase
+{
+    public function test_show_displays_request_entry()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::REQUEST,
+            'content' => [
+                'method' => 'GET', 'uri' => '/api/users', 'response_status' => 200,
+                'duration' => 145, 'memory' => 12, 'controller_action' => 'UserController@index',
+                'middleware' => ['web'], 'ip_address' => '127.0.0.1', 'hostname' => 'localhost',
+                'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [],
+            ],
+        ]);
+
+        $this->artisan('telescope:show', ['id' => $entry->uuid])
+            ->assertSuccessful();
+    }
+
+    public function test_show_displays_exception_entry()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::EXCEPTION,
+            'content' => [
+                'class' => 'InvalidArgumentException', 'message' => 'Something went wrong',
+                'file' => 'app/Http/Controllers/UserController.php', 'line' => 38,
+                'trace' => [], 'line_preview' => [], 'hostname' => 'localhost', 'occurrences' => 1,
+            ],
+        ]);
+
+        $this->artisan('telescope:show', ['id' => $entry->uuid])
+            ->assertSuccessful();
+    }
+
+    public function test_show_displays_batch_context()
+    {
+        $batchId = (string) Str::uuid();
+
+        $request = EntryModelFactory::new()->create([
+            'sequence' => 100,
+            'type' => EntryType::REQUEST,
+            'batch_id' => $batchId,
+            'content' => [
+                'method' => 'GET', 'uri' => '/api/users', 'response_status' => 200,
+                'duration' => 145, 'memory' => 12, 'hostname' => 'localhost',
+                'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [],
+                'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1',
+            ],
+        ]);
+
+        EntryModelFactory::new()->create([
+            'sequence' => 101,
+            'type' => EntryType::QUERY,
+            'batch_id' => $batchId,
+            'content' => [
+                'sql' => 'select * from "users"', 'time' => 2.5,
+                'connection' => 'testbench', 'slow' => false, 'hostname' => 'localhost',
+                'hash' => 'q1',
+            ],
+        ]);
+
+        EntryModelFactory::new()->create([
+            'sequence' => 102,
+            'type' => EntryType::EXCEPTION,
+            'batch_id' => $batchId,
+            'content' => [
+                'class' => 'RuntimeException', 'message' => 'Test',
+                'file' => 'test.php', 'line' => 1, 'trace' => [],
+                'hostname' => 'localhost', 'occurrences' => 1,
+            ],
+        ]);
+
+        $this->artisan('telescope:show', ['id' => $request->uuid])
+            ->assertSuccessful();
+    }
+
+    public function test_show_latest_shortcut()
+    {
+        EntryModelFactory::new()->create([
+            'sequence' => 1,
+            'type' => EntryType::REQUEST,
+            'created_at' => now()->subMinutes(5),
+            'content' => ['method' => 'GET', 'uri' => '/old', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost', 'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8],
+        ]);
+
+        EntryModelFactory::new()->create([
+            'sequence' => 2,
+            'type' => EntryType::EXCEPTION,
+            'created_at' => now(),
+            'content' => ['class' => 'RuntimeException', 'message' => 'Latest', 'file' => 'test.php', 'line' => 1, 'trace' => [], 'hostname' => 'localhost', 'occurrences' => 1],
+        ]);
+
+        $this->artisan('telescope:show', ['id' => 'latest'])
+            ->assertSuccessful();
+    }
+
+    public function test_show_latest_type_shortcut()
+    {
+        $request = EntryModelFactory::new()->create([
+            'sequence' => 1,
+            'type' => EntryType::REQUEST,
+            'content' => ['method' => 'GET', 'uri' => '/api/test', 'response_status' => 200, 'duration' => 100, 'hostname' => 'localhost', 'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8],
+        ]);
+
+        EntryModelFactory::new()->create([
+            'sequence' => 2,
+            'type' => EntryType::EXCEPTION,
+            'content' => ['class' => 'RuntimeException', 'message' => 'Error', 'file' => 'test.php', 'line' => 1, 'trace' => [], 'hostname' => 'localhost', 'occurrences' => 1],
+        ]);
+
+        Artisan::call('telescope:show', ['id' => 'latest:request']);
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('/api/test', $output);
+        $this->assertStringNotContainsString('RuntimeException', $output);
+    }
+
+    public function test_show_type_filter()
+    {
+        $batchId = (string) Str::uuid();
+
+        $request = EntryModelFactory::new()->create([
+            'sequence' => 100,
+            'type' => EntryType::REQUEST,
+            'batch_id' => $batchId,
+            'content' => ['method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost', 'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8],
+        ]);
+
+        EntryModelFactory::new()->create([
+            'sequence' => 101,
+            'type' => EntryType::QUERY,
+            'batch_id' => $batchId,
+            'content' => ['sql' => 'select 1', 'time' => 1.0, 'connection' => 'testbench', 'slow' => false, 'hostname' => 'localhost', 'hash' => 'h1'],
+        ]);
+
+        EntryModelFactory::new()->create([
+            'sequence' => 102,
+            'type' => EntryType::CACHE,
+            'batch_id' => $batchId,
+            'content' => ['type' => 'hit', 'key' => 'test', 'hostname' => 'localhost'],
+        ]);
+
+        Artisan::call('telescope:show', ['id' => $request->uuid, '--type' => 'query']);
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('select 1', $output);
+        $this->assertStringNotContainsString('hit rate', $output);
+    }
+
+    public function test_show_batch_context_lists_queries()
+    {
+        $batchId = (string) Str::uuid();
+
+        $request = EntryModelFactory::new()->create([
+            'sequence' => 100,
+            'type' => EntryType::REQUEST,
+            'batch_id' => $batchId,
+            'content' => ['method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost', 'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8],
+        ]);
+
+        EntryModelFactory::new()->create([
+            'sequence' => 101,
+            'type' => EntryType::QUERY,
+            'batch_id' => $batchId,
+            'content' => ['sql' => 'select 1', 'time' => 1.0, 'connection' => 'testbench', 'slow' => false, 'hostname' => 'localhost', 'hash' => 'h1'],
+        ]);
+
+        Artisan::call('telescope:show', ['id' => $request->uuid]);
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('Related Entries', $output);
+        $this->assertStringContainsString('Queries', $output);
+        $this->assertStringContainsString('select 1', $output);
+    }
+
+    public function test_show_batch_has_query_stats()
+    {
+        $batchId = (string) Str::uuid();
+
+        $request = EntryModelFactory::new()->create([
+            'sequence' => 100,
+            'type' => EntryType::REQUEST,
+            'batch_id' => $batchId,
+            'content' => ['method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost', 'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8],
+        ]);
+
+        EntryModelFactory::new()->create([
+            'sequence' => 101,
+            'type' => EntryType::QUERY,
+            'batch_id' => $batchId,
+            'content' => ['sql' => 'select * from users', 'time' => 150.0, 'connection' => 'testbench', 'slow' => true, 'hostname' => 'localhost', 'hash' => 'dup1'],
+        ]);
+
+        EntryModelFactory::new()->create([
+            'sequence' => 102,
+            'type' => EntryType::QUERY,
+            'batch_id' => $batchId,
+            'content' => ['sql' => 'select * from users', 'time' => 2.0, 'connection' => 'testbench', 'slow' => false, 'hostname' => 'localhost', 'hash' => 'dup1'],
+        ]);
+
+        Artisan::call('telescope:show', ['id' => $request->uuid]);
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('2 total, 152ms', $output);
+        $this->assertStringContainsString('1 slow', $output);
+        $this->assertStringContainsString('1 duplicate groups', $output);
+    }
+
+    public function test_show_batch_has_cache_stats()
+    {
+        $batchId = (string) Str::uuid();
+
+        $request = EntryModelFactory::new()->create([
+            'sequence' => 100,
+            'type' => EntryType::REQUEST,
+            'batch_id' => $batchId,
+            'content' => ['method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost', 'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8],
+        ]);
+
+        EntryModelFactory::new()->count(3)->create([
+            'type' => EntryType::CACHE,
+            'batch_id' => $batchId,
+            'content' => ['type' => 'hit', 'key' => 'user:1', 'hostname' => 'localhost'],
+        ]);
+
+        EntryModelFactory::new()->create([
+            'type' => EntryType::CACHE,
+            'batch_id' => $batchId,
+            'content' => ['type' => 'missed', 'key' => 'user:2', 'hostname' => 'localhost'],
+        ]);
+
+        Artisan::call('telescope:show', ['id' => $request->uuid]);
+
+        $this->assertStringContainsString('3 hits, 1 misses — 75% hit rate', Artisan::output());
+    }
+
+    public function test_show_entry_not_found()
+    {
+        $this->artisan('telescope:show', ['id' => 'nonexistent-uuid'])
+            ->assertFailed();
+    }
+
+    public function test_show_latest_with_no_entries()
+    {
+        $this->artisan('telescope:show', ['id' => 'latest'])
+            ->assertFailed();
+    }
+
+    public function test_show_latest_type_with_no_matching_entries()
+    {
+        EntryModelFactory::new()->create(['type' => EntryType::REQUEST, 'content' => [
+            'method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost',
+            'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8,
+        ]]);
+
+        $this->artisan('telescope:show', ['id' => 'latest:exception'])
+            ->assertFailed();
+    }
+
+    public function test_show_displays_event_listeners()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::EVENT,
+            'content' => [
+                'name' => 'App\\Events\\OrderShipped', 'broadcast' => false, 'hostname' => 'localhost',
+                'listeners' => [['name' => 'App\\Listeners\\SendShipmentNotification@handle', 'queued' => true]],
+                'payload' => [],
+            ],
+        ]);
+
+        Artisan::call('telescope:show', ['id' => $entry->uuid]);
+
+        $this->assertStringContainsString('SendShipmentNotification@handle (queued)', Artisan::output());
+    }
+
+    public function test_show_displays_mail_addresses()
+    {
+        $entry = EntryModelFactory::new()->create([
+            'type' => EntryType::MAIL,
+            'content' => [
+                'mailable' => 'App\\Mail\\Welcome', 'subject' => 'Welcome', 'queued' => false, 'hostname' => 'localhost',
+                'to' => ['alice@example.com' => 'Alice'], 'from' => ['noreply@example.com' => null],
+            ],
+        ]);
+
+        Artisan::call('telescope:show', ['id' => $entry->uuid]);
+
+        $this->assertStringContainsString('Alice <alice@example.com>', Artisan::output());
+    }
+}

--- a/tests/Console/ShowCommandTest.php
+++ b/tests/Console/ShowCommandTest.php
@@ -10,6 +10,15 @@ use Laravel\Telescope\Tests\FeatureTestCase;
 
 class ShowCommandTest extends FeatureTestCase
 {
+    /**
+     * Indicates if console output should be mocked.
+     *
+     * Disabled so Artisan::output() captures the real command output.
+     *
+     * @var bool
+     */
+    public $mockConsoleOutput = false;
+
     public function test_show_displays_request_entry()
     {
         $entry = EntryModelFactory::new()->create([
@@ -22,8 +31,7 @@ class ShowCommandTest extends FeatureTestCase
             ],
         ]);
 
-        $this->artisan('telescope:show', ['id' => $entry->uuid])
-            ->assertSuccessful();
+        $this->assertSame(0, $this->artisan('telescope:show', ['id' => $entry->uuid]));
     }
 
     public function test_show_displays_exception_entry()
@@ -37,8 +45,7 @@ class ShowCommandTest extends FeatureTestCase
             ],
         ]);
 
-        $this->artisan('telescope:show', ['id' => $entry->uuid])
-            ->assertSuccessful();
+        $this->assertSame(0, $this->artisan('telescope:show', ['id' => $entry->uuid]));
     }
 
     public function test_show_displays_batch_context()
@@ -79,8 +86,7 @@ class ShowCommandTest extends FeatureTestCase
             ],
         ]);
 
-        $this->artisan('telescope:show', ['id' => $request->uuid])
-            ->assertSuccessful();
+        $this->assertSame(0, $this->artisan('telescope:show', ['id' => $request->uuid]));
     }
 
     public function test_show_latest_shortcut()
@@ -99,8 +105,7 @@ class ShowCommandTest extends FeatureTestCase
             'content' => ['class' => 'RuntimeException', 'message' => 'Latest', 'file' => 'test.php', 'line' => 1, 'trace' => [], 'hostname' => 'localhost', 'occurrences' => 1],
         ]);
 
-        $this->artisan('telescope:show', ['id' => 'latest'])
-            ->assertSuccessful();
+        $this->assertSame(0, $this->artisan('telescope:show', ['id' => 'latest']));
     }
 
     public function test_show_latest_type_shortcut()
@@ -245,14 +250,12 @@ class ShowCommandTest extends FeatureTestCase
 
     public function test_show_entry_not_found()
     {
-        $this->artisan('telescope:show', ['id' => 'nonexistent-uuid'])
-            ->assertFailed();
+        $this->assertSame(1, $this->artisan('telescope:show', ['id' => 'nonexistent-uuid']));
     }
 
     public function test_show_latest_with_no_entries()
     {
-        $this->artisan('telescope:show', ['id' => 'latest'])
-            ->assertFailed();
+        $this->assertSame(1, $this->artisan('telescope:show', ['id' => 'latest']));
     }
 
     public function test_show_latest_type_with_no_matching_entries()
@@ -262,8 +265,7 @@ class ShowCommandTest extends FeatureTestCase
             'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8,
         ]]);
 
-        $this->artisan('telescope:show', ['id' => 'latest:exception'])
-            ->assertFailed();
+        $this->assertSame(1, $this->artisan('telescope:show', ['id' => 'latest:exception']));
     }
 
     public function test_show_displays_event_listeners()

--- a/tests/Console/ShowCommandTest.php
+++ b/tests/Console/ShowCommandTest.php
@@ -220,6 +220,81 @@ class ShowCommandTest extends FeatureTestCase
         $this->assertStringContainsString('1 duplicate groups', $output);
     }
 
+    public function test_show_batch_entries_are_chronological()
+    {
+        $batchId = (string) Str::uuid();
+
+        $request = EntryModelFactory::new()->create([
+            'sequence' => 100,
+            'type' => EntryType::REQUEST,
+            'batch_id' => $batchId,
+            'content' => ['method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost', 'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8],
+        ]);
+
+        foreach (['select first', 'select second'] as $index => $sql) {
+            EntryModelFactory::new()->create([
+                'sequence' => 101 + $index,
+                'type' => EntryType::QUERY,
+                'batch_id' => $batchId,
+                'content' => ['sql' => $sql, 'time' => 1.0, 'connection' => 'testbench', 'slow' => false, 'hostname' => 'localhost', 'hash' => "h{$index}"],
+            ]);
+        }
+
+        Artisan::call('telescope:show', ['id' => $request->uuid]);
+        $output = Artisan::output();
+
+        $this->assertLessThan(strpos($output, 'select second'), strpos($output, 'select first'));
+    }
+
+    public function test_show_exception_context_includes_request()
+    {
+        $batchId = (string) Str::uuid();
+
+        EntryModelFactory::new()->create([
+            'sequence' => 100,
+            'type' => EntryType::REQUEST,
+            'batch_id' => $batchId,
+            'content' => ['method' => 'POST', 'uri' => '/orders', 'response_status' => 500, 'duration' => 50, 'hostname' => 'localhost', 'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8],
+        ]);
+
+        $exception = EntryModelFactory::new()->create([
+            'sequence' => 101,
+            'type' => EntryType::EXCEPTION,
+            'batch_id' => $batchId,
+            'content' => ['class' => 'RuntimeException', 'message' => 'Boom', 'file' => 'test.php', 'line' => 1, 'trace' => [], 'hostname' => 'localhost', 'occurrences' => 1],
+        ]);
+
+        Artisan::call('telescope:show', ['id' => $exception->uuid]);
+
+        $this->assertStringContainsString('POST /orders -> 500', Artisan::output());
+    }
+
+    public function test_show_full_option_disables_truncation()
+    {
+        $batchId = (string) Str::uuid();
+        $sql = 'select * from users where '.str_repeat('id = 1 or ', 20).'id = 2';
+
+        $request = EntryModelFactory::new()->create([
+            'sequence' => 100,
+            'type' => EntryType::REQUEST,
+            'batch_id' => $batchId,
+            'content' => ['method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost', 'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8],
+        ]);
+
+        EntryModelFactory::new()->create([
+            'sequence' => 101,
+            'type' => EntryType::QUERY,
+            'batch_id' => $batchId,
+            'content' => ['sql' => $sql, 'time' => 1.0, 'connection' => 'testbench', 'slow' => false, 'hostname' => 'localhost', 'hash' => 'h1'],
+        ]);
+
+        Artisan::call('telescope:show', ['id' => $request->uuid]);
+        $this->assertStringNotContainsString('id = 2', Artisan::output());
+
+        Artisan::call('telescope:show', ['id' => $request->uuid, '--full' => true]);
+        $this->assertStringContainsString('id = 2', Artisan::output());
+    }
+
     public function test_show_batch_has_cache_stats()
     {
         $batchId = (string) Str::uuid();
@@ -243,6 +318,12 @@ class ShowCommandTest extends FeatureTestCase
             'content' => ['type' => 'missed', 'key' => 'user:2', 'hostname' => 'localhost'],
         ]);
 
+        EntryModelFactory::new()->create([
+            'type' => EntryType::CACHE,
+            'batch_id' => $batchId,
+            'content' => ['type' => 'set', 'key' => 'user:2', 'hostname' => 'localhost'],
+        ]);
+
         Artisan::call('telescope:show', ['id' => $request->uuid]);
 
         $this->assertStringContainsString('3 hits, 1 misses — 75% hit rate', Artisan::output());
@@ -256,6 +337,21 @@ class ShowCommandTest extends FeatureTestCase
     public function test_show_latest_with_no_entries()
     {
         $this->assertSame(1, $this->artisan('telescope:show', ['id' => 'latest']));
+    }
+
+    public function test_show_validates_latest_type()
+    {
+        $this->assertSame(1, $this->artisan('telescope:show', ['id' => 'latest:foobar']));
+    }
+
+    public function test_show_validates_type_option()
+    {
+        $entry = EntryModelFactory::new()->create(['type' => EntryType::REQUEST, 'content' => [
+            'method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost',
+            'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8,
+        ]]);
+
+        $this->assertSame(1, $this->artisan('telescope:show', ['id' => $entry->uuid, '--type' => 'foobar']));
     }
 
     public function test_show_latest_type_with_no_matching_entries()
@@ -297,5 +393,38 @@ class ShowCommandTest extends FeatureTestCase
         Artisan::call('telescope:show', ['id' => $entry->uuid]);
 
         $this->assertStringContainsString('Alice <alice@example.com>', Artisan::output());
+    }
+
+    public function test_show_outputs_json()
+    {
+        $batchId = (string) Str::uuid();
+
+        $request = EntryModelFactory::new()->create([
+            'sequence' => 100,
+            'type' => EntryType::REQUEST,
+            'batch_id' => $batchId,
+            'content' => ['method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost', 'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8],
+        ]);
+
+        EntryModelFactory::new()->create([
+            'sequence' => 101,
+            'type' => EntryType::QUERY,
+            'batch_id' => $batchId,
+            'content' => ['sql' => 'select 1', 'time' => 1.0, 'connection' => 'testbench', 'slow' => false, 'hostname' => 'localhost', 'hash' => 'h1'],
+        ]);
+
+        EntryModelFactory::new()->create([
+            'sequence' => 102,
+            'type' => EntryType::CACHE,
+            'batch_id' => $batchId,
+            'content' => ['type' => 'hit', 'key' => 'test', 'hostname' => 'localhost'],
+        ]);
+
+        Artisan::call('telescope:show', ['id' => $request->uuid, '--json' => true, '--type' => 'query']);
+        $json = json_decode(Artisan::output(), true);
+
+        $this->assertSame($request->uuid, $json['entry']['id']);
+        $this->assertCount(1, $json['batch']);
+        $this->assertSame('select 1', $json['batch'][0]['content']['sql']);
     }
 }

--- a/tests/Console/ShowCommandTest.php
+++ b/tests/Console/ShowCommandTest.php
@@ -4,12 +4,13 @@ namespace Laravel\Telescope\Tests\Console;
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Str;
-use Laravel\Telescope\Database\Factories\EntryModelFactory;
 use Laravel\Telescope\EntryType;
 use Laravel\Telescope\Tests\FeatureTestCase;
 
 class ShowCommandTest extends FeatureTestCase
 {
+    use CreatesTelescopeEntries;
+
     /**
      * Indicates if console output should be mocked.
      *
@@ -21,223 +22,112 @@ class ShowCommandTest extends FeatureTestCase
 
     public function test_show_displays_request_entry()
     {
-        $entry = EntryModelFactory::new()->create([
-            'type' => EntryType::REQUEST,
-            'content' => [
-                'method' => 'GET', 'uri' => '/api/users', 'response_status' => 200,
-                'duration' => 145, 'memory' => 12, 'controller_action' => 'UserController@index',
-                'middleware' => ['web'], 'ip_address' => '127.0.0.1', 'hostname' => 'localhost',
-                'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [],
-            ],
+        $entry = $this->request([
+            'uri' => '/api/users', 'duration' => 145, 'controller_action' => 'UserController@index',
+            'middleware' => ['web'],
         ]);
 
         $this->assertSame(0, $this->artisan('telescope:show', ['id' => $entry->uuid]));
+
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('Request: GET /api/users -> 200', $output);
+        $this->assertStringContainsString('UserController@index', $output);
+        $this->assertStringContainsString('145ms', $output);
+        $this->assertStringContainsString('127.0.0.1', $output);
     }
 
     public function test_show_displays_exception_entry()
     {
-        $entry = EntryModelFactory::new()->create([
-            'type' => EntryType::EXCEPTION,
-            'content' => [
-                'class' => 'InvalidArgumentException', 'message' => 'Something went wrong',
-                'file' => 'app/Http/Controllers/UserController.php', 'line' => 38,
-                'trace' => [], 'line_preview' => [], 'hostname' => 'localhost', 'occurrences' => 1,
-            ],
+        $entry = $this->exception([
+            'class' => 'InvalidArgumentException', 'message' => 'Something went wrong',
+            'file' => 'app/Http/Controllers/UserController.php', 'line' => 38,
         ]);
 
         $this->assertSame(0, $this->artisan('telescope:show', ['id' => $entry->uuid]));
+
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('Exception: InvalidArgumentException', $output);
+        $this->assertStringContainsString('Something went wrong', $output);
+        $this->assertStringContainsString('UserController.php:38', $output);
+    }
+
+    public function test_show_displays_a_failed_job_with_its_exception()
+    {
+        $job = $this->entry(EntryType::JOB, [
+            'name' => 'App\Jobs\SyncOrders', 'status' => 'failed', 'queue' => 'default',
+            'connection' => 'redis', 'tries' => 3, 'data' => ['order_id' => 7],
+            'exception' => [
+                'message' => 'Payment gateway timed out',
+                'trace' => [['file' => '/app/Jobs/SyncOrders.php', 'line' => 22]],
+            ],
+        ]);
+
+        $this->assertSame(0, $this->artisan('telescope:show', ['id' => $job->uuid]));
+
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('Job: SyncOrders [failed]', $output);
+        $this->assertStringContainsString('Payment gateway timed out', $output);
+        $this->assertStringContainsString('/app/Jobs/SyncOrders.php:22', $output);
     }
 
     public function test_show_displays_batch_context()
     {
         $batchId = (string) Str::uuid();
 
-        $request = EntryModelFactory::new()->create([
-            'sequence' => 100,
-            'type' => EntryType::REQUEST,
-            'batch_id' => $batchId,
-            'content' => [
-                'method' => 'GET', 'uri' => '/api/users', 'response_status' => 200,
-                'duration' => 145, 'memory' => 12, 'hostname' => 'localhost',
-                'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [],
-                'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1',
-            ],
-        ]);
-
-        EntryModelFactory::new()->create([
-            'sequence' => 101,
-            'type' => EntryType::QUERY,
-            'batch_id' => $batchId,
-            'content' => [
-                'sql' => 'select * from "users"', 'time' => 2.5,
-                'connection' => 'testbench', 'slow' => false, 'hostname' => 'localhost',
-                'hash' => 'q1',
-            ],
-        ]);
-
-        EntryModelFactory::new()->create([
-            'sequence' => 102,
-            'type' => EntryType::EXCEPTION,
-            'batch_id' => $batchId,
-            'content' => [
-                'class' => 'RuntimeException', 'message' => 'Test',
-                'file' => 'test.php', 'line' => 1, 'trace' => [],
-                'hostname' => 'localhost', 'occurrences' => 1,
-            ],
-        ]);
+        $request = $this->request(['uri' => '/api/users'], ['sequence' => 100, 'batch_id' => $batchId]);
+        $this->query(['sql' => 'select * from "users"'], ['sequence' => 101, 'batch_id' => $batchId]);
+        $this->exception([], ['sequence' => 102, 'batch_id' => $batchId]);
 
         $this->assertSame(0, $this->artisan('telescope:show', ['id' => $request->uuid]));
-    }
 
-    public function test_show_latest_shortcut()
-    {
-        EntryModelFactory::new()->create([
-            'sequence' => 1,
-            'type' => EntryType::REQUEST,
-            'created_at' => now()->subMinutes(5),
-            'content' => ['method' => 'GET', 'uri' => '/old', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost', 'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8],
-        ]);
-
-        EntryModelFactory::new()->create([
-            'sequence' => 2,
-            'type' => EntryType::EXCEPTION,
-            'created_at' => now(),
-            'content' => ['class' => 'RuntimeException', 'message' => 'Latest', 'file' => 'test.php', 'line' => 1, 'trace' => [], 'hostname' => 'localhost', 'occurrences' => 1],
-        ]);
-
-        $this->assertSame(0, $this->artisan('telescope:show', ['id' => 'latest']));
-    }
-
-    public function test_show_latest_type_shortcut()
-    {
-        $request = EntryModelFactory::new()->create([
-            'sequence' => 1,
-            'type' => EntryType::REQUEST,
-            'content' => ['method' => 'GET', 'uri' => '/api/test', 'response_status' => 200, 'duration' => 100, 'hostname' => 'localhost', 'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8],
-        ]);
-
-        EntryModelFactory::new()->create([
-            'sequence' => 2,
-            'type' => EntryType::EXCEPTION,
-            'content' => ['class' => 'RuntimeException', 'message' => 'Error', 'file' => 'test.php', 'line' => 1, 'trace' => [], 'hostname' => 'localhost', 'occurrences' => 1],
-        ]);
-
-        Artisan::call('telescope:show', ['id' => 'latest:request']);
         $output = Artisan::output();
 
-        $this->assertStringContainsString('/api/test', $output);
-        $this->assertStringNotContainsString('RuntimeException', $output);
+        $this->assertStringContainsString('Related Entries - batch '.substr($batchId, 0, 8), $output);
+        $this->assertStringContainsString('select * from "users"', $output);
+        $this->assertStringContainsString('Exceptions - 1', $output);
+        $this->assertStringContainsString('RuntimeException: Test', $output);
     }
 
-    public function test_show_type_filter()
+    public function test_show_batch_context_of_an_exception_includes_its_request()
     {
         $batchId = (string) Str::uuid();
 
-        $request = EntryModelFactory::new()->create([
-            'sequence' => 100,
-            'type' => EntryType::REQUEST,
-            'batch_id' => $batchId,
-            'content' => ['method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost', 'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8],
-        ]);
+        $this->request(['method' => 'POST', 'uri' => '/orders', 'response_status' => 500], ['sequence' => 100, 'batch_id' => $batchId]);
+        $exception = $this->exception(['message' => 'Boom'], ['sequence' => 101, 'batch_id' => $batchId]);
 
-        EntryModelFactory::new()->create([
-            'sequence' => 101,
-            'type' => EntryType::QUERY,
-            'batch_id' => $batchId,
-            'content' => ['sql' => 'select 1', 'time' => 1.0, 'connection' => 'testbench', 'slow' => false, 'hostname' => 'localhost', 'hash' => 'h1'],
-        ]);
+        Artisan::call('telescope:show', ['id' => $exception->uuid]);
 
-        EntryModelFactory::new()->create([
-            'sequence' => 102,
-            'type' => EntryType::CACHE,
-            'batch_id' => $batchId,
-            'content' => ['type' => 'hit', 'key' => 'test', 'hostname' => 'localhost'],
-        ]);
-
-        Artisan::call('telescope:show', ['id' => $request->uuid, '--type' => 'query']);
-        $output = Artisan::output();
-
-        $this->assertStringContainsString('select 1', $output);
-        $this->assertStringNotContainsString('hit rate', $output);
+        $this->assertStringContainsString('POST /orders -> 500', Artisan::output());
     }
 
-    public function test_show_batch_context_lists_queries()
+    public function test_show_renders_batch_entry_types_without_a_dedicated_section()
     {
         $batchId = (string) Str::uuid();
 
-        $request = EntryModelFactory::new()->create([
-            'sequence' => 100,
-            'type' => EntryType::REQUEST,
-            'batch_id' => $batchId,
-            'content' => ['method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost', 'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8],
-        ]);
-
-        EntryModelFactory::new()->create([
-            'sequence' => 101,
-            'type' => EntryType::QUERY,
-            'batch_id' => $batchId,
-            'content' => ['sql' => 'select 1', 'time' => 1.0, 'connection' => 'testbench', 'slow' => false, 'hostname' => 'localhost', 'hash' => 'h1'],
-        ]);
+        $request = $this->request([], ['sequence' => 100, 'batch_id' => $batchId]);
+        $this->entry(EntryType::DUMP, ['dump' => '<pre>needle</pre>'], ['sequence' => 101, 'batch_id' => $batchId]);
+        $this->entry(EntryType::VIEW, ['name' => 'welcome', 'path' => '/v.blade.php'], ['sequence' => 102, 'batch_id' => $batchId]);
 
         Artisan::call('telescope:show', ['id' => $request->uuid]);
         $output = Artisan::output();
 
-        $this->assertStringContainsString('Related Entries', $output);
-        $this->assertStringContainsString('Queries', $output);
-        $this->assertStringContainsString('select 1', $output);
-    }
-
-    public function test_show_batch_has_query_stats()
-    {
-        $batchId = (string) Str::uuid();
-
-        $request = EntryModelFactory::new()->create([
-            'sequence' => 100,
-            'type' => EntryType::REQUEST,
-            'batch_id' => $batchId,
-            'content' => ['method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost', 'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8],
-        ]);
-
-        EntryModelFactory::new()->create([
-            'sequence' => 101,
-            'type' => EntryType::QUERY,
-            'batch_id' => $batchId,
-            'content' => ['sql' => 'select * from users', 'time' => 150.0, 'connection' => 'testbench', 'slow' => true, 'hostname' => 'localhost', 'hash' => 'dup1'],
-        ]);
-
-        EntryModelFactory::new()->create([
-            'sequence' => 102,
-            'type' => EntryType::QUERY,
-            'batch_id' => $batchId,
-            'content' => ['sql' => 'select * from users', 'time' => 2.0, 'connection' => 'testbench', 'slow' => false, 'hostname' => 'localhost', 'hash' => 'dup1'],
-        ]);
-
-        Artisan::call('telescope:show', ['id' => $request->uuid]);
-        $output = Artisan::output();
-
-        $this->assertStringContainsString('2 total, 152ms', $output);
-        $this->assertStringContainsString('1 slow', $output);
-        $this->assertStringContainsString('1 duplicate groups', $output);
+        $this->assertStringContainsString('Dumps (1)', $output);
+        $this->assertStringContainsString('needle', $output);
+        $this->assertStringContainsString('Views (1)', $output);
+        $this->assertStringContainsString('welcome', $output);
     }
 
     public function test_show_batch_entries_are_chronological()
     {
         $batchId = (string) Str::uuid();
 
-        $request = EntryModelFactory::new()->create([
-            'sequence' => 100,
-            'type' => EntryType::REQUEST,
-            'batch_id' => $batchId,
-            'content' => ['method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost', 'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8],
-        ]);
+        $request = $this->request([], ['sequence' => 100, 'batch_id' => $batchId]);
 
         foreach (['select first', 'select second'] as $index => $sql) {
-            EntryModelFactory::new()->create([
-                'sequence' => 101 + $index,
-                'type' => EntryType::QUERY,
-                'batch_id' => $batchId,
-                'content' => ['sql' => $sql, 'time' => 1.0, 'connection' => 'testbench', 'slow' => false, 'hostname' => 'localhost', 'hash' => "h{$index}"],
-            ]);
+            $this->query(['sql' => $sql, 'hash' => "h{$index}"], ['sequence' => 101 + $index, 'batch_id' => $batchId]);
         }
 
         Artisan::call('telescope:show', ['id' => $request->uuid]);
@@ -246,47 +136,136 @@ class ShowCommandTest extends FeatureTestCase
         $this->assertLessThan(strpos($output, 'select second'), strpos($output, 'select first'));
     }
 
-    public function test_show_exception_context_includes_request()
+    public function test_show_batch_flags_slow_and_duplicate_queries()
     {
         $batchId = (string) Str::uuid();
 
-        EntryModelFactory::new()->create([
-            'sequence' => 100,
-            'type' => EntryType::REQUEST,
-            'batch_id' => $batchId,
-            'content' => ['method' => 'POST', 'uri' => '/orders', 'response_status' => 500, 'duration' => 50, 'hostname' => 'localhost', 'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8],
-        ]);
+        $request = $this->request([], ['sequence' => 100, 'batch_id' => $batchId]);
 
-        $exception = EntryModelFactory::new()->create([
-            'sequence' => 101,
-            'type' => EntryType::EXCEPTION,
-            'batch_id' => $batchId,
-            'content' => ['class' => 'RuntimeException', 'message' => 'Boom', 'file' => 'test.php', 'line' => 1, 'trace' => [], 'hostname' => 'localhost', 'occurrences' => 1],
-        ]);
+        foreach ([[101, 150.0, true], [102, 2.0, false]] as [$sequence, $time, $slow]) {
+            $this->query([
+                'sql' => 'select * from users', 'time' => $time, 'slow' => $slow, 'hash' => 'dup1',
+                'file' => '/app/Http/Controllers/UserController.php', 'line' => 3,
+            ], ['sequence' => $sequence, 'batch_id' => $batchId]);
+        }
 
-        Artisan::call('telescope:show', ['id' => $exception->uuid]);
+        Artisan::call('telescope:show', ['id' => $request->uuid]);
+        $output = Artisan::output();
 
-        $this->assertStringContainsString('POST /orders -> 500', Artisan::output());
+        $this->assertStringContainsString('2 total, 152ms', $output);
+        $this->assertStringContainsString('1 slow', $output);
+        $this->assertStringContainsString('1 duplicate group', $output);
+        $this->assertStringContainsString('SLOW', $output);
+        $this->assertStringContainsString('DUP', $output);
+        $this->assertStringContainsString('UserController.php:3', $output);
+    }
+
+    public function test_show_batch_reports_the_cache_hit_rate()
+    {
+        $batchId = (string) Str::uuid();
+
+        $request = $this->request([], ['sequence' => 100, 'batch_id' => $batchId]);
+
+        foreach (['hit', 'hit', 'hit', 'missed', 'set'] as $action) {
+            $this->entry(EntryType::CACHE, ['type' => $action, 'key' => 'user:1'], ['batch_id' => $batchId]);
+        }
+
+        Artisan::call('telescope:show', ['id' => $request->uuid]);
+
+        $this->assertStringContainsString('3 hits, 1 misses - 75% hit rate', Artisan::output());
+    }
+
+    public function test_show_batch_omits_the_hit_rate_when_no_cache_lookups_were_made()
+    {
+        $batchId = (string) Str::uuid();
+
+        $request = $this->request([], ['sequence' => 100, 'batch_id' => $batchId]);
+        $this->entry(EntryType::CACHE, ['type' => 'set', 'key' => 'user:1'], ['batch_id' => $batchId]);
+
+        Artisan::call('telescope:show', ['id' => $request->uuid]);
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('Cache - 0 hits, 0 misses', $output);
+        $this->assertStringNotContainsString('hit rate', $output);
+    }
+
+    public function test_show_latest_shortcut()
+    {
+        $this->request(['uri' => '/old'], ['sequence' => 1]);
+        $this->exception(['message' => 'Latest'], ['sequence' => 2]);
+
+        $this->assertSame(0, $this->artisan('telescope:show', ['id' => 'latest']));
+
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('Exception: RuntimeException', $output);
+        $this->assertStringContainsString('Latest', $output);
+        $this->assertStringNotContainsString('/old', $output);
+    }
+
+    public function test_show_latest_type_shortcut()
+    {
+        $this->request(['uri' => '/api/test'], ['sequence' => 1]);
+        $this->exception(['message' => 'Error'], ['sequence' => 2]);
+
+        Artisan::call('telescope:show', ['id' => 'latest:request']);
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('/api/test', $output);
+        $this->assertStringNotContainsString('RuntimeException', $output);
+    }
+
+    public function test_show_type_option_filters_the_batch()
+    {
+        $batchId = (string) Str::uuid();
+
+        $request = $this->request([], ['sequence' => 100, 'batch_id' => $batchId]);
+        $this->query([], ['sequence' => 101, 'batch_id' => $batchId]);
+        $this->entry(EntryType::CACHE, ['type' => 'hit', 'key' => 'test'], ['sequence' => 102, 'batch_id' => $batchId]);
+
+        Artisan::call('telescope:show', ['id' => $request->uuid, '--type' => 'query']);
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('select 1', $output);
+        $this->assertStringNotContainsString('hit rate', $output);
+    }
+
+    public function test_show_type_option_accepts_a_list_with_spaces()
+    {
+        $batchId = (string) Str::uuid();
+
+        $request = $this->request([], ['sequence' => 100, 'batch_id' => $batchId]);
+        $this->query([], ['sequence' => 101, 'batch_id' => $batchId]);
+        $this->entry(EntryType::CACHE, ['type' => 'hit', 'key' => 'spaced'], ['sequence' => 102, 'batch_id' => $batchId]);
+
+        $this->assertSame(0, $this->artisan('telescope:show', ['id' => $request->uuid, '--type' => 'query, cache']));
+
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('select 1', $output);
+        $this->assertStringContainsString('spaced', $output);
+    }
+
+    public function test_show_reports_when_the_batch_has_no_entries_of_the_requested_type()
+    {
+        $batchId = (string) Str::uuid();
+
+        $request = $this->request([], ['sequence' => 100, 'batch_id' => $batchId]);
+        $this->query([], ['sequence' => 101, 'batch_id' => $batchId]);
+
+        $this->assertSame(0, $this->artisan('telescope:show', ['id' => $request->uuid, '--type' => 'log']));
+
+        $this->assertStringContainsString('No batch entries of type log.', Artisan::output());
     }
 
     public function test_show_full_option_disables_truncation()
     {
         $batchId = (string) Str::uuid();
-        $sql = 'select * from users where '.str_repeat('id = 1 or ', 20).'id = 2';
 
-        $request = EntryModelFactory::new()->create([
-            'sequence' => 100,
-            'type' => EntryType::REQUEST,
-            'batch_id' => $batchId,
-            'content' => ['method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost', 'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8],
-        ]);
-
-        EntryModelFactory::new()->create([
-            'sequence' => 101,
-            'type' => EntryType::QUERY,
-            'batch_id' => $batchId,
-            'content' => ['sql' => $sql, 'time' => 1.0, 'connection' => 'testbench', 'slow' => false, 'hostname' => 'localhost', 'hash' => 'h1'],
-        ]);
+        $request = $this->request([], ['sequence' => 100, 'batch_id' => $batchId]);
+        $this->query([
+            'sql' => 'select * from users where '.str_repeat('id = 1 or ', 20).'id = 2',
+        ], ['sequence' => 101, 'batch_id' => $batchId]);
 
         Artisan::call('telescope:show', ['id' => $request->uuid]);
         $this->assertStringNotContainsString('id = 2', Artisan::output());
@@ -295,84 +274,23 @@ class ShowCommandTest extends FeatureTestCase
         $this->assertStringContainsString('id = 2', Artisan::output());
     }
 
-    public function test_show_batch_has_cache_stats()
+    public function test_show_omits_units_for_values_the_entry_does_not_have()
     {
-        $batchId = (string) Str::uuid();
-
-        $request = EntryModelFactory::new()->create([
-            'sequence' => 100,
-            'type' => EntryType::REQUEST,
-            'batch_id' => $batchId,
-            'content' => ['method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost', 'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8],
+        $job = $this->entry(EntryType::JOB, [
+            'name' => 'App\Jobs\SyncOrders', 'status' => 'processed', 'queue' => 'default',
+            'connection' => 'redis', 'tries' => null, 'timeout' => null, 'data' => [],
         ]);
 
-        EntryModelFactory::new()->count(3)->create([
-            'type' => EntryType::CACHE,
-            'batch_id' => $batchId,
-            'content' => ['type' => 'hit', 'key' => 'user:1', 'hostname' => 'localhost'],
-        ]);
+        Artisan::call('telescope:show', ['id' => $job->uuid]);
 
-        EntryModelFactory::new()->create([
-            'type' => EntryType::CACHE,
-            'batch_id' => $batchId,
-            'content' => ['type' => 'missed', 'key' => 'user:2', 'hostname' => 'localhost'],
-        ]);
-
-        EntryModelFactory::new()->create([
-            'type' => EntryType::CACHE,
-            'batch_id' => $batchId,
-            'content' => ['type' => 'set', 'key' => 'user:2', 'hostname' => 'localhost'],
-        ]);
-
-        Artisan::call('telescope:show', ['id' => $request->uuid]);
-
-        $this->assertStringContainsString('3 hits, 1 misses — 75% hit rate', Artisan::output());
-    }
-
-    public function test_show_entry_not_found()
-    {
-        $this->assertSame(1, $this->artisan('telescope:show', ['id' => 'nonexistent-uuid']));
-    }
-
-    public function test_show_latest_with_no_entries()
-    {
-        $this->assertSame(1, $this->artisan('telescope:show', ['id' => 'latest']));
-    }
-
-    public function test_show_validates_latest_type()
-    {
-        $this->assertSame(1, $this->artisan('telescope:show', ['id' => 'latest:foobar']));
-    }
-
-    public function test_show_validates_type_option()
-    {
-        $entry = EntryModelFactory::new()->create(['type' => EntryType::REQUEST, 'content' => [
-            'method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost',
-            'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8,
-        ]]);
-
-        $this->assertSame(1, $this->artisan('telescope:show', ['id' => $entry->uuid, '--type' => 'foobar']));
-    }
-
-    public function test_show_latest_type_with_no_matching_entries()
-    {
-        EntryModelFactory::new()->create(['type' => EntryType::REQUEST, 'content' => [
-            'method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost',
-            'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8,
-        ]]);
-
-        $this->assertSame(1, $this->artisan('telescope:show', ['id' => 'latest:exception']));
+        $this->assertStringNotContainsString('Timeout', Artisan::output());
     }
 
     public function test_show_displays_event_listeners()
     {
-        $entry = EntryModelFactory::new()->create([
-            'type' => EntryType::EVENT,
-            'content' => [
-                'name' => 'App\\Events\\OrderShipped', 'broadcast' => false, 'hostname' => 'localhost',
-                'listeners' => [['name' => 'App\\Listeners\\SendShipmentNotification@handle', 'queued' => true]],
-                'payload' => [],
-            ],
+        $entry = $this->entry(EntryType::EVENT, [
+            'name' => 'App\Events\OrderShipped', 'broadcast' => false, 'payload' => [],
+            'listeners' => [['name' => 'App\Listeners\SendShipmentNotification@handle', 'queued' => true]],
         ]);
 
         Artisan::call('telescope:show', ['id' => $entry->uuid]);
@@ -382,12 +300,9 @@ class ShowCommandTest extends FeatureTestCase
 
     public function test_show_displays_mail_addresses()
     {
-        $entry = EntryModelFactory::new()->create([
-            'type' => EntryType::MAIL,
-            'content' => [
-                'mailable' => 'App\\Mail\\Welcome', 'subject' => 'Welcome', 'queued' => false, 'hostname' => 'localhost',
-                'to' => ['alice@example.com' => 'Alice'], 'from' => ['noreply@example.com' => null],
-            ],
+        $entry = $this->entry(EntryType::MAIL, [
+            'mailable' => 'App\Mail\Welcome', 'subject' => 'Welcome', 'queued' => false,
+            'to' => ['alice@example.com' => 'Alice'], 'from' => ['noreply@example.com' => null],
         ]);
 
         Artisan::call('telescope:show', ['id' => $entry->uuid]);
@@ -399,26 +314,9 @@ class ShowCommandTest extends FeatureTestCase
     {
         $batchId = (string) Str::uuid();
 
-        $request = EntryModelFactory::new()->create([
-            'sequence' => 100,
-            'type' => EntryType::REQUEST,
-            'batch_id' => $batchId,
-            'content' => ['method' => 'GET', 'uri' => '/test', 'response_status' => 200, 'duration' => 50, 'hostname' => 'localhost', 'payload' => [], 'response' => [], 'headers' => [], 'response_headers' => [], 'session' => [], 'middleware' => [], 'ip_address' => '127.0.0.1', 'memory' => 8],
-        ]);
-
-        EntryModelFactory::new()->create([
-            'sequence' => 101,
-            'type' => EntryType::QUERY,
-            'batch_id' => $batchId,
-            'content' => ['sql' => 'select 1', 'time' => 1.0, 'connection' => 'testbench', 'slow' => false, 'hostname' => 'localhost', 'hash' => 'h1'],
-        ]);
-
-        EntryModelFactory::new()->create([
-            'sequence' => 102,
-            'type' => EntryType::CACHE,
-            'batch_id' => $batchId,
-            'content' => ['type' => 'hit', 'key' => 'test', 'hostname' => 'localhost'],
-        ]);
+        $request = $this->request([], ['sequence' => 100, 'batch_id' => $batchId]);
+        $this->query([], ['sequence' => 101, 'batch_id' => $batchId]);
+        $this->entry(EntryType::CACHE, ['type' => 'hit', 'key' => 'test'], ['sequence' => 102, 'batch_id' => $batchId]);
 
         Artisan::call('telescope:show', ['id' => $request->uuid, '--json' => true, '--type' => 'query']);
         $json = json_decode(Artisan::output(), true);
@@ -426,5 +324,39 @@ class ShowCommandTest extends FeatureTestCase
         $this->assertSame($request->uuid, $json['entry']['id']);
         $this->assertCount(1, $json['batch']);
         $this->assertSame('select 1', $json['batch'][0]['content']['sql']);
+    }
+
+    public function test_show_entry_not_found()
+    {
+        $this->assertSame(1, $this->artisan('telescope:show', ['id' => 'nonexistent-uuid']));
+        $this->assertStringContainsString('Entry not found: nonexistent-uuid', Artisan::output());
+    }
+
+    public function test_show_latest_with_no_entries()
+    {
+        $this->assertSame(1, $this->artisan('telescope:show', ['id' => 'latest']));
+        $this->assertStringContainsString('No entries found.', Artisan::output());
+    }
+
+    public function test_show_latest_type_with_no_matching_entries()
+    {
+        $this->request();
+
+        $this->assertSame(1, $this->artisan('telescope:show', ['id' => 'latest:exception']));
+        $this->assertStringContainsString('No exception entries found.', Artisan::output());
+    }
+
+    public function test_show_validates_latest_type()
+    {
+        $this->assertSame(1, $this->artisan('telescope:show', ['id' => 'latest:foobar']));
+        $this->assertStringContainsString('Invalid entry type: foobar', Artisan::output());
+    }
+
+    public function test_show_validates_type_option()
+    {
+        $entry = $this->request();
+
+        $this->assertSame(1, $this->artisan('telescope:show', ['id' => $entry->uuid, '--type' => 'foobar']));
+        $this->assertStringContainsString('Invalid entry type: foobar', Artisan::output());
     }
 }

--- a/tests/Console/ShowCommandTest.php
+++ b/tests/Console/ShowCommandTest.php
@@ -22,7 +22,7 @@ class ShowCommandTest extends FeatureTestCase
 
     public function test_show_displays_request_entry()
     {
-        $entry = $this->request([
+        $entry = $this->createRequest([
             'uri' => '/api/users', 'duration' => 145, 'controller_action' => 'UserController@index',
             'middleware' => ['web'],
         ]);
@@ -39,7 +39,7 @@ class ShowCommandTest extends FeatureTestCase
 
     public function test_show_displays_exception_entry()
     {
-        $entry = $this->exception([
+        $entry = $this->createException([
             'class' => 'InvalidArgumentException', 'message' => 'Something went wrong',
             'file' => 'app/Http/Controllers/UserController.php', 'line' => 38,
         ]);
@@ -55,7 +55,7 @@ class ShowCommandTest extends FeatureTestCase
 
     public function test_show_displays_a_failed_job_with_its_exception()
     {
-        $job = $this->entry(EntryType::JOB, [
+        $job = $this->createEntry(EntryType::JOB, [
             'name' => 'App\Jobs\SyncOrders', 'status' => 'failed', 'queue' => 'default',
             'connection' => 'redis', 'tries' => 3, 'data' => ['order_id' => 7],
             'exception' => [
@@ -77,9 +77,9 @@ class ShowCommandTest extends FeatureTestCase
     {
         $batchId = (string) Str::uuid();
 
-        $request = $this->request(['uri' => '/api/users'], ['sequence' => 100, 'batch_id' => $batchId]);
-        $this->query(['sql' => 'select * from "users"'], ['sequence' => 101, 'batch_id' => $batchId]);
-        $this->exception([], ['sequence' => 102, 'batch_id' => $batchId]);
+        $request = $this->createRequest(['uri' => '/api/users'], ['sequence' => 100, 'batch_id' => $batchId]);
+        $this->createQuery(['sql' => 'select * from "users"'], ['sequence' => 101, 'batch_id' => $batchId]);
+        $this->createException([], ['sequence' => 102, 'batch_id' => $batchId]);
 
         $this->assertSame(0, $this->artisan('telescope:show', ['id' => $request->uuid]));
 
@@ -95,8 +95,8 @@ class ShowCommandTest extends FeatureTestCase
     {
         $batchId = (string) Str::uuid();
 
-        $this->request(['method' => 'POST', 'uri' => '/orders', 'response_status' => 500], ['sequence' => 100, 'batch_id' => $batchId]);
-        $exception = $this->exception(['message' => 'Boom'], ['sequence' => 101, 'batch_id' => $batchId]);
+        $this->createRequest(['method' => 'POST', 'uri' => '/orders', 'response_status' => 500], ['sequence' => 100, 'batch_id' => $batchId]);
+        $exception = $this->createException(['message' => 'Boom'], ['sequence' => 101, 'batch_id' => $batchId]);
 
         Artisan::call('telescope:show', ['id' => $exception->uuid]);
 
@@ -107,9 +107,9 @@ class ShowCommandTest extends FeatureTestCase
     {
         $batchId = (string) Str::uuid();
 
-        $request = $this->request([], ['sequence' => 100, 'batch_id' => $batchId]);
-        $this->entry(EntryType::DUMP, ['dump' => '<pre>needle</pre>'], ['sequence' => 101, 'batch_id' => $batchId]);
-        $this->entry(EntryType::VIEW, ['name' => 'welcome', 'path' => '/v.blade.php'], ['sequence' => 102, 'batch_id' => $batchId]);
+        $request = $this->createRequest([], ['sequence' => 100, 'batch_id' => $batchId]);
+        $this->createEntry(EntryType::DUMP, ['dump' => '<pre>needle</pre>'], ['sequence' => 101, 'batch_id' => $batchId]);
+        $this->createEntry(EntryType::VIEW, ['name' => 'welcome', 'path' => '/v.blade.php'], ['sequence' => 102, 'batch_id' => $batchId]);
 
         Artisan::call('telescope:show', ['id' => $request->uuid]);
         $output = Artisan::output();
@@ -124,10 +124,10 @@ class ShowCommandTest extends FeatureTestCase
     {
         $batchId = (string) Str::uuid();
 
-        $request = $this->request([], ['sequence' => 100, 'batch_id' => $batchId]);
+        $request = $this->createRequest([], ['sequence' => 100, 'batch_id' => $batchId]);
 
         foreach (['select first', 'select second'] as $index => $sql) {
-            $this->query(['sql' => $sql, 'hash' => "h{$index}"], ['sequence' => 101 + $index, 'batch_id' => $batchId]);
+            $this->createQuery(['sql' => $sql, 'hash' => "h{$index}"], ['sequence' => 101 + $index, 'batch_id' => $batchId]);
         }
 
         Artisan::call('telescope:show', ['id' => $request->uuid]);
@@ -140,10 +140,10 @@ class ShowCommandTest extends FeatureTestCase
     {
         $batchId = (string) Str::uuid();
 
-        $request = $this->request([], ['sequence' => 100, 'batch_id' => $batchId]);
+        $request = $this->createRequest([], ['sequence' => 100, 'batch_id' => $batchId]);
 
         foreach ([[101, 150.0, true], [102, 2.0, false]] as [$sequence, $time, $slow]) {
-            $this->query([
+            $this->createQuery([
                 'sql' => 'select * from users', 'time' => $time, 'slow' => $slow, 'hash' => 'dup1',
                 'file' => '/app/Http/Controllers/UserController.php', 'line' => 3,
             ], ['sequence' => $sequence, 'batch_id' => $batchId]);
@@ -164,10 +164,10 @@ class ShowCommandTest extends FeatureTestCase
     {
         $batchId = (string) Str::uuid();
 
-        $request = $this->request([], ['sequence' => 100, 'batch_id' => $batchId]);
+        $request = $this->createRequest([], ['sequence' => 100, 'batch_id' => $batchId]);
 
         foreach (['hit', 'hit', 'hit', 'missed', 'set'] as $action) {
-            $this->entry(EntryType::CACHE, ['type' => $action, 'key' => 'user:1'], ['batch_id' => $batchId]);
+            $this->createEntry(EntryType::CACHE, ['type' => $action, 'key' => 'user:1'], ['batch_id' => $batchId]);
         }
 
         Artisan::call('telescope:show', ['id' => $request->uuid]);
@@ -179,8 +179,8 @@ class ShowCommandTest extends FeatureTestCase
     {
         $batchId = (string) Str::uuid();
 
-        $request = $this->request([], ['sequence' => 100, 'batch_id' => $batchId]);
-        $this->entry(EntryType::CACHE, ['type' => 'set', 'key' => 'user:1'], ['batch_id' => $batchId]);
+        $request = $this->createRequest([], ['sequence' => 100, 'batch_id' => $batchId]);
+        $this->createEntry(EntryType::CACHE, ['type' => 'set', 'key' => 'user:1'], ['batch_id' => $batchId]);
 
         Artisan::call('telescope:show', ['id' => $request->uuid]);
         $output = Artisan::output();
@@ -191,8 +191,8 @@ class ShowCommandTest extends FeatureTestCase
 
     public function test_show_latest_shortcut()
     {
-        $this->request(['uri' => '/old'], ['sequence' => 1]);
-        $this->exception(['message' => 'Latest'], ['sequence' => 2]);
+        $this->createRequest(['uri' => '/old'], ['sequence' => 1]);
+        $this->createException(['message' => 'Latest'], ['sequence' => 2]);
 
         $this->assertSame(0, $this->artisan('telescope:show', ['id' => 'latest']));
 
@@ -205,8 +205,8 @@ class ShowCommandTest extends FeatureTestCase
 
     public function test_show_latest_type_shortcut()
     {
-        $this->request(['uri' => '/api/test'], ['sequence' => 1]);
-        $this->exception(['message' => 'Error'], ['sequence' => 2]);
+        $this->createRequest(['uri' => '/api/test'], ['sequence' => 1]);
+        $this->createException(['message' => 'Error'], ['sequence' => 2]);
 
         Artisan::call('telescope:show', ['id' => 'latest:request']);
         $output = Artisan::output();
@@ -219,9 +219,9 @@ class ShowCommandTest extends FeatureTestCase
     {
         $batchId = (string) Str::uuid();
 
-        $request = $this->request([], ['sequence' => 100, 'batch_id' => $batchId]);
-        $this->query([], ['sequence' => 101, 'batch_id' => $batchId]);
-        $this->entry(EntryType::CACHE, ['type' => 'hit', 'key' => 'test'], ['sequence' => 102, 'batch_id' => $batchId]);
+        $request = $this->createRequest([], ['sequence' => 100, 'batch_id' => $batchId]);
+        $this->createQuery([], ['sequence' => 101, 'batch_id' => $batchId]);
+        $this->createEntry(EntryType::CACHE, ['type' => 'hit', 'key' => 'test'], ['sequence' => 102, 'batch_id' => $batchId]);
 
         Artisan::call('telescope:show', ['id' => $request->uuid, '--type' => 'query']);
         $output = Artisan::output();
@@ -234,9 +234,9 @@ class ShowCommandTest extends FeatureTestCase
     {
         $batchId = (string) Str::uuid();
 
-        $request = $this->request([], ['sequence' => 100, 'batch_id' => $batchId]);
-        $this->query([], ['sequence' => 101, 'batch_id' => $batchId]);
-        $this->entry(EntryType::CACHE, ['type' => 'hit', 'key' => 'spaced'], ['sequence' => 102, 'batch_id' => $batchId]);
+        $request = $this->createRequest([], ['sequence' => 100, 'batch_id' => $batchId]);
+        $this->createQuery([], ['sequence' => 101, 'batch_id' => $batchId]);
+        $this->createEntry(EntryType::CACHE, ['type' => 'hit', 'key' => 'spaced'], ['sequence' => 102, 'batch_id' => $batchId]);
 
         $this->assertSame(0, $this->artisan('telescope:show', ['id' => $request->uuid, '--type' => 'query, cache']));
 
@@ -250,8 +250,8 @@ class ShowCommandTest extends FeatureTestCase
     {
         $batchId = (string) Str::uuid();
 
-        $request = $this->request([], ['sequence' => 100, 'batch_id' => $batchId]);
-        $this->query([], ['sequence' => 101, 'batch_id' => $batchId]);
+        $request = $this->createRequest([], ['sequence' => 100, 'batch_id' => $batchId]);
+        $this->createQuery([], ['sequence' => 101, 'batch_id' => $batchId]);
 
         $this->assertSame(0, $this->artisan('telescope:show', ['id' => $request->uuid, '--type' => 'log']));
 
@@ -262,8 +262,8 @@ class ShowCommandTest extends FeatureTestCase
     {
         $batchId = (string) Str::uuid();
 
-        $request = $this->request([], ['sequence' => 100, 'batch_id' => $batchId]);
-        $this->query([
+        $request = $this->createRequest([], ['sequence' => 100, 'batch_id' => $batchId]);
+        $this->createQuery([
             'sql' => 'select * from users where '.str_repeat('id = 1 or ', 20).'id = 2',
         ], ['sequence' => 101, 'batch_id' => $batchId]);
 
@@ -276,7 +276,7 @@ class ShowCommandTest extends FeatureTestCase
 
     public function test_show_omits_units_for_values_the_entry_does_not_have()
     {
-        $job = $this->entry(EntryType::JOB, [
+        $job = $this->createEntry(EntryType::JOB, [
             'name' => 'App\Jobs\SyncOrders', 'status' => 'processed', 'queue' => 'default',
             'connection' => 'redis', 'tries' => null, 'timeout' => null, 'data' => [],
         ]);
@@ -288,7 +288,7 @@ class ShowCommandTest extends FeatureTestCase
 
     public function test_show_displays_event_listeners()
     {
-        $entry = $this->entry(EntryType::EVENT, [
+        $entry = $this->createEntry(EntryType::EVENT, [
             'name' => 'App\Events\OrderShipped', 'broadcast' => false, 'payload' => [],
             'listeners' => [['name' => 'App\Listeners\SendShipmentNotification@handle', 'queued' => true]],
         ]);
@@ -300,7 +300,7 @@ class ShowCommandTest extends FeatureTestCase
 
     public function test_show_displays_mail_addresses()
     {
-        $entry = $this->entry(EntryType::MAIL, [
+        $entry = $this->createEntry(EntryType::MAIL, [
             'mailable' => 'App\Mail\Welcome', 'subject' => 'Welcome', 'queued' => false,
             'to' => ['alice@example.com' => 'Alice'], 'from' => ['noreply@example.com' => null],
         ]);
@@ -314,9 +314,9 @@ class ShowCommandTest extends FeatureTestCase
     {
         $batchId = (string) Str::uuid();
 
-        $request = $this->request([], ['sequence' => 100, 'batch_id' => $batchId]);
-        $this->query([], ['sequence' => 101, 'batch_id' => $batchId]);
-        $this->entry(EntryType::CACHE, ['type' => 'hit', 'key' => 'test'], ['sequence' => 102, 'batch_id' => $batchId]);
+        $request = $this->createRequest([], ['sequence' => 100, 'batch_id' => $batchId]);
+        $this->createQuery([], ['sequence' => 101, 'batch_id' => $batchId]);
+        $this->createEntry(EntryType::CACHE, ['type' => 'hit', 'key' => 'test'], ['sequence' => 102, 'batch_id' => $batchId]);
 
         Artisan::call('telescope:show', ['id' => $request->uuid, '--json' => true, '--type' => 'query']);
         $json = json_decode(Artisan::output(), true);
@@ -340,7 +340,7 @@ class ShowCommandTest extends FeatureTestCase
 
     public function test_show_latest_type_with_no_matching_entries()
     {
-        $this->request();
+        $this->createRequest();
 
         $this->assertSame(1, $this->artisan('telescope:show', ['id' => 'latest:exception']));
         $this->assertStringContainsString('No exception entries found.', Artisan::output());
@@ -354,7 +354,7 @@ class ShowCommandTest extends FeatureTestCase
 
     public function test_show_validates_type_option()
     {
-        $entry = $this->request();
+        $entry = $this->createRequest();
 
         $this->assertSame(1, $this->artisan('telescope:show', ['id' => $entry->uuid, '--type' => 'foobar']));
         $this->assertStringContainsString('Invalid entry type: foobar', Artisan::output());


### PR DESCRIPTION
Today, Telescope's recorded data is reachable only through the browser dashboard. 
This pr add a way to query data via cli


### Usage

Find the entry you care about:

```bash
php artisan telescope:list request
php artisan telescope:list exception --limit=5
php artisan telescope:list --batch=<batch-id>
php artisan telescope:list request --tag=Auth:42
```

Then show it with everything from the same batch:

```bash
php artisan telescope:show <uuid>
php artisan telescope:show latest:request
php artisan telescope:show latest:exception --type=query,cache
```

```text
 Request: GET /api/users → 200
 ┌────────────┬──────────────────────────────────────┐
 │ Time       │ 2 seconds ago  (2026-09-07 17:15:45) │
 │ Controller │ UserController@index                 │
 │ Duration   │ 145ms                                │
 │ User       │ Taylor #1                            │
 └────────────┴──────────────────────────────────────┘

 Related Entries — batch 79a09461
 Queries — 2 total, 152ms, 1 slow, 1 duplicate groups
 ┌───┬──────────┬───────┬─────────────────────┬─────────┬──────────┐
 │ # │ UUID     │ Time  │ SQL                 │ Source  │ Flags    │
 ├───┼──────────┼───────┼─────────────────────┼─────────┼──────────┤
 │ 1 │ 6e8dcc05 │ 2ms   │ select * from users │         │ DUP      │
 │ 2 │ a29fcc04 │ 150ms │ select * from users │ X.php:3 │ SLOW DUP │
 └───┴──────────┴───────┴─────────────────────┴─────────┴──────────┘

 Cache — 1 hits, 0 misses — 100% hit rate
 ┌────────┬────────┐
 │ Action │ Key    │
 ├────────┼────────┤
 │ HIT    │ user:1 │
 └────────┴────────┘
```

- `latest` and `latest:{type}` resolve to the most recent entry, so an agent never has to copy a UUID after it runs a request.
- The Queries section flags `SLOW` queries and marks `DUP` groups that share one SQL pattern, which points straight at an N+1.
- `--type` narrows the batch context when a request produced hundreds of entries.

