### PR TITLE
[5.x] Fix SQL corruption in QueryWatcher when named bindings share a prefix

### DIFF
--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -96,7 +96,7 @@ class QueryWatcher extends Watcher
         foreach ($this->formatBindings($event) as $key => $binding) {
             $regex = is_numeric($key)
                 ? "/\?(?=(?:[^'\\\']*'[^'\\\']*')*[^'\\\']*$)/"
-                : "/:{$key}(?=(?:[^'\\\']*'[^'\\\']*')*[^'\\\']*$)/";
+                : "/:{$key}(?![a-zA-Z0-9_])(?=(?:[^'\\\']*'[^'\\\']*')*[^'\\\']*$)/";
 
             if ($binding === null) {
                 $binding = 'null';

--- a/tests/Watchers/QueryWatcherTest.php
+++ b/tests/Watchers/QueryWatcherTest.php
@@ -144,4 +144,24 @@ Data: {
 }
 SQL, $sql);
     }
+
+    public function test_query_watcher_handles_named_bindings_with_shared_prefix()
+    {
+        $this->app->get('db')->statement(<<<'SQL'
+update "telescope_entries" set "content" = :content1, "should_display_on_index" = :content10 where "type" = :type
+SQL
+            , [
+                'content1' => 'a',
+                'content10' => 'b',
+                'type' => 'query',
+            ]);
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::QUERY, $entry->type);
+        $this->assertSame(<<<'SQL'
+update "telescope_entries" set "content" = 'a', "should_display_on_index" = 'b' where "type" = 'query'
+SQL
+            , $entry->content['sql']);
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When a query uses named placeholders where one is a prefix of another (e.g. `:content1` and `:content10`), `QueryWatcher::replaceBindings()` matches and replaces the prefix inside the longer placeholder. This leaves trailing characters (such as `'a'0`) and corrupts the resulting SQL.