### PR TITLE
[5.x] Fix SQL corruption in QueryWatcher when named bindings share a prefix

### DIFF
--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -96,7 +96,7 @@ class QueryWatcher extends Watcher
         foreach ($this->formatBindings($event) as $key => $binding) {
             $regex = is_numeric($key)
                 ? "/\?(?=(?:[^'\\\']*'[^'\\\']*')*[^'\\\']*$)/"
-                : "/:{$key}(?=(?:[^'\\\']*'[^'\\\']*')*[^'\\\']*$)/";
+                : "/:{$key}(?![a-zA-Z0-9_])(?=(?:[^'\\\']*'[^'\\\']*')*[^'\\\']*$)/";
 
             if ($binding === null) {
                 $binding = 'null';

--- a/tests/Watchers/QueryWatcherTest.php
+++ b/tests/Watchers/QueryWatcherTest.php
@@ -144,4 +144,24 @@ Data: {
 }
 SQL, $sql);
     }
+
+    public function test_query_watcher_handles_named_bindings_with_shared_prefix()
+    {
+        $this->app->get('db')->statement(<<<'SQL'
+update "telescope_entries" set "content" = :content1, "should_display_on_index" = :content10 where "type" = :type
+SQL
+            , [
+                'content1' => 'a',
+                'content10' => 'b',
+                'type' => 'query',
+            ]);
+
+        $entry = $this->loadTelescopeEntries()->first();
+
+        $this->assertSame(EntryType::QUERY, $entry->type);
+        $this->assertSame(<<<'SQL'
+update "telescope_entries" set "content" = 'a', "should_display_on_index" = 'b' where "type" = 'query'
+SQL
+            , $entry->content['sql']);
+    }
 }


### PR DESCRIPTION
When executing raw bulk queries with dynamically indexed named placeholders (e.g. bulk replacing product attributes), `QueryWatcher::replaceBindings()` matches and replaces prefixes of longer placeholders.

```php
DB::statement('
    REPLACE INTO product_attributes (product_code, column_id, column_value) VALUES 
    (:product_code1, :column_id1, :column_value1),
    ...
    (:product_code10, :column_id10, :column_value10)
', [
    'product_code1' => 'P01', 'column_id1' => 1, 'column_value1' => 'Red',
    ...
    'product_code10' => 'P01', 'column_id10' => 10, 'column_value10' => 'Cotton',
]);
```

Because `:column_value1` is a prefix of `:column_value10`, `QueryWatcher` partially replaces `:column_value10` and corrupts the logged SQL into `'Red'0`.

This PR adds `(?![a-zA-Z0-9_])` so the named-binding regex only matches complete parameter names. Regression test included.

(Follow-up to #1765)
